### PR TITLE
Document outputResultsSample retries and qs2 coverage toggle

### DIFF
--- a/config_templates/README.md
+++ b/config_templates/README.md
@@ -85,7 +85,9 @@ Below, the `parameter[].subparameter` notation indicates that `parameter` is a l
 | `mem_extractCallsChunk`, `time_extractCallsChunk`, `maxRetries_extractCallsChunk` | string/integer | optional | Baseline memory, time limit, and retry count for `extractCallsChunk` processes. Each retry will increase the memory and time limit by one half of the baseline. |
 | `mem_filterCallsChunk`, `time_filterCallsChunk`, `maxRetries_filterCallsChunk` | string/integer | optional | Analogous settings for `filterCallsChunk` processes. |
 | `mem_calculateBurdensChromgroupFiltergroup`, `time_calculateBurdensChromgroupFiltergroup`, `maxRetries_calculateBurdensChromgroupFiltergroup` | string/integer | optional | Analogous settings for `calculateBurdensChromgroupFiltergroup` processes. |
+| `mem_outputResultsSample`, `time_outputResultsSample`, `maxRetries_outputResultsSample` | string/integer | optional | Baseline memory, time limit, and retry count for `outputResultsSample` processes. Each retry increases the memory request by one half of the baseline value and extends the time limit by one additional baseline duration. |
 | `remove_intermediate_files` | boolean, `true` or `false` | optional | When true, enables the `removeIntermediateFiles` workflow segment to delete intermediate per-sample directories once outputs are finalised. |
+| `save_coverage_in_final_qs2` | boolean, `true` or `false` | optional | When set to `false`, omits genome-wide coverage GRanges objects from the `.qs2` serialized output to reduce file size and memory usage when loading the object. |
 
 ## Reference genome resources
 

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -279,7 +279,7 @@ The pipeline produces several files per per below, and each table contains metad
 - `total.tsv` — Total SBS mutation error probability across all trinucleotide channels.
 
 ### Serialized object (.qs2)
-For each sample, a `.qs2` file is stored in `[analysis_output_dir]/[analysis_id].[individual_id].[sample_id]/outputResults/${analysis_id}.${individual_id}.${sample_id}.qs2`. It contains all the final data structures required for downstream analyses in R in a more convenient bundle than the many separate files described above. It is saved with the <a href="https://github.com/qsbase/qs2" target="_blank" rel="noopener noreferrer">qs2 R package</a> format and can be loaded with `qs2::qs_read`. Each component of the object is listed below with its schema.
+For each sample, a `.qs2` file is stored in `[analysis_output_dir]/[analysis_id].[individual_id].[sample_id]/outputResults/${analysis_id}.${individual_id}.${sample_id}.qs2`. It contains all the final data structures required for downstream analyses in R in a more convenient bundle than the many separate files described above. It is saved with the <a href="https://github.com/qsbase/qs2" target="_blank" rel="noopener noreferrer">qs2 R package</a> format and can be loaded with `qs2::qs_read`. When the YAML parameter `save_coverage_in_final_qs2` is set to `false`, coverage GRanges are excluded from the serialized object to reduce its size and in-memory footprint. Each component of the object is listed below with its schema.
 
 #### yaml.config
 Top-level configuration loaded from the analysis YAML, stored as nested lists per the structure and parameters documented in [`config_templates/`](../config_templates).
@@ -354,7 +354,7 @@ Table containing genome coverage by interrogated base pairs (i.e., duplex covera
 
 | Column | Description |
 | --- | --- |
-| `bam.gr.filtertrack.coverage` | List-column of GRanges coverage objects for interrogated base pairs (i.e., duplex coverage counting once coverage by both strands of a molecule). |
+| `bam.gr.filtertrack.coverage` | List-column of GRanges coverage objects for interrogated base pairs (i.e., duplex coverage counting once coverage by both strands of a molecule). Omitted when `save_coverage_in_final_qs2` is `false` in the YAML configuration. |
 | `bam.gr.filtertrack.reftnc_pyr`, `bam.gr.filtertrack.reftnc_both_strands` | Same format as `.bam.gr.filtertrack.reftnc_pyr.tsv` and `bam.gr.filtertrack.reftnc_both_strands.tsv` described above. |
 
 #### genome.reftnc and genome_chromgroup.reftnc


### PR DESCRIPTION
## Summary
- document the new outputResultsSample memory/time retry parameters in the YAML configuration guide
- explain the save_coverage_in_final_qs2 toggle in the configuration and describe its effect on serialized outputs

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68e6d1f2c47c8321b6fe1c6866b60117