### PR TITLE
Fix limaDemux emitted channel access in main workflow

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -360,7 +360,7 @@ workflow {
 
   limaDemux_round1 = limaDemux(limaDemux_round1_input_ch)
 
-  limaDemux_round1_map_ch = limaDemux_round1.out.bam
+  limaDemux_round1_map_ch = limaDemux_round1.bam
     .transpose()
     .map { run_id, bamFile ->
       def m = bamFile.name =~ /.*\.demux\.([A-Za-z0-9_]+)--([A-Za-z0-9_]+)\.bam$/
@@ -397,7 +397,7 @@ workflow {
 
   limaDemux_round2 = limaDemux(limaDemux_round2_input_ch)
 
-  limaDemux_round2_map_ch = limaDemux_round2.out.bam
+  limaDemux_round2_map_ch = limaDemux_round2.bam
     .transpose()
     .map { run_id, bamFile ->
       def m = bamFile.name =~ /(.*)\.demux\.([A-Za-z0-9_]+)--([A-Za-z0-9_]+)\.bam$/


### PR DESCRIPTION
### Motivation
- The workflow was failing with a `MissingPropertyException` when accessing `limaDemux_roundX.out.bam` because the `limaDemux` process exposes a named output via `emit: bam`, so the invocation returns `.bam` directly. 
- The change ensures the workflow references the named output correctly to avoid runtime errors during channel access.

### Description
- Replaced `limaDemux_round1.out.bam` with `limaDemux_round1.bam` in `main.nf` so the round 1 demux map channel uses the process' named output. 
- Replaced `limaDemux_round2.out.bam` with `limaDemux_round2.bam` in `main.nf` so the round 2 demux map channel uses the process' named output.
- Only `main.nf` was modified to correct the channel access that was causing the `MissingPropertyException`.

### Testing
- Confirmed the changes are present in the repository diff and updated `main.nf` lines referencing the demux map channels. 
- Attempted to run `nextflow -version` to perform runtime validation but it failed because `nextflow` is not installed in this environment, so end-to-end pipeline execution could not be run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bc0e92e31483219372e85068e39292)