### PR TITLE
Use channel variables instead of `.out` accessor for mergeDemuxBams outputs

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -387,7 +387,7 @@ workflow {
     .filter { it.round2_enabled }
     .map { cfg -> tuple(cfg.run_id, cfg.individual_id, cfg.sample_id, cfg.barcode_ids, cfg.barcode_ids_round2, cfg.barcode_ids_round2_parsed.mode, cfg.barcode_ids_round2_parsed.ids[0], cfg.barcode_ids_round2_parsed.ids.size()==2 ? cfg.barcode_ids_round2_parsed.ids[1] : cfg.barcode_ids_round2_parsed.ids[0]) }
 
-  limaDemux_round2_input_ch = mergeDemuxBams_round1.out
+  limaDemux_round2_input_ch = mergeDemuxBams_round1
     .join(limaDemux_round2_samples_ch, by: [0,1,2,3])
     .join(makeBarcodesFasta.out, by: 0)
     .filter { run_id, individual_id, sample_id, barcode_ids, mergedBam, mergedPbi, barcode_ids_round2, mode2, id21, id22, barcodesFasta, demux_round -> demux_round == 'round2' }
@@ -407,7 +407,7 @@ workflow {
       tuple(run_id, m[0][1], m[0][2], m[0][3], bamFile)
     }
 
-  mergeDemuxBams_round2_input_ch = mergeDemuxBams_round1.out
+  mergeDemuxBams_round2_input_ch = mergeDemuxBams_round1
     .join(limaDemux_round2_samples_ch, by: [0,1,2,3])
     .map { run_id, individual_id, sample_id, barcode_ids, mergedBam, mergedPbi, barcode_ids_round2, mode2, id21, id22 ->
       tuple(run_id, mergedBam.baseName, individual_id, sample_id, barcode_ids, mode2, id21, id22)
@@ -428,11 +428,11 @@ workflow {
   //******************
 
   // Create input channel
-  pbmm2_round1_final_ch = mergeDemuxBams_round1.out
+  pbmm2_round1_final_ch = mergeDemuxBams_round1
     .filter { run_id, individual_id, sample_id, barcode_ids, bamFile, pbiFile -> !round2_run_ids.contains(run_id) }
     .map { run_id, individual_id, sample_id, barcode_ids, bamFile, pbiFile -> tuple(run_id, individual_id, sample_id, barcode_ids, bamFile) }
 
-  pbmm2_round2_final_ch = mergeDemuxBams_round2.out
+  pbmm2_round2_final_ch = mergeDemuxBams_round2
     .map { run_id, individual_id, sample_id, barcode_ids, bamFile, pbiFile -> tuple(run_id, individual_id, sample_id, barcode_ids, bamFile) }
 
   pbmm2Align_input_ch = pbmm2_round1_final_ch


### PR DESCRIPTION
### Motivation
- Fix incorrect usage of the `.out` accessor on `mergeDemuxBams` results so downstream channel operations receive the channel itself rather than an invalid property.
- Ensure downstream steps (`limaDemux` and `pbmm2Align`) join and filter on the correct channels to avoid runtime failures in the demux/merge/align pipeline.

### Description
- Replaced `mergeDemuxBams_round1.out` with `mergeDemuxBams_round1` when constructing `limaDemux_round2_input_ch` and `pbmm2_round1_final_ch` so the channel is passed directly.
- Replaced `mergeDemuxBams_round2.out` with `mergeDemuxBams_round2` when constructing `pbmm2_round2_final_ch` and `mergeDemuxBams_round2_input_ch` so the channel is passed directly.
- No other logic changes were made; joins, filters, and mappings remain unchanged and operate on the corrected channels.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69be9c9be5948321ae63b889554683f1)