### PR TITLE
Introduce dedicated Nextflow workflows for limaDemux rounds

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -358,7 +358,7 @@ workflow {
         tuple(run_id, bamFile, pbiFile, barcodesFasta, mode, params.lima_supplemental_settings)
       }
 
-  limaDemux_round1 = limaDemux(limaDemux_round1_input_ch)
+  limaDemux_round1 = limaDemuxRound1(limaDemux_round1_input_ch)
 
   limaDemux_round1_map_ch = limaDemux_round1.bam
     .transpose()
@@ -395,7 +395,7 @@ workflow {
       tuple(run_id, mergedBam, mergedPbi, barcodesFasta, mode2, params.lima_round2_supplemental_settings)
     }
 
-  limaDemux_round2 = limaDemux(limaDemux_round2_input_ch)
+  limaDemux_round2 = limaDemuxRound2(limaDemux_round2_input_ch)
 
   limaDemux_round2_map_ch = limaDemux_round2.bam
     .transpose()
@@ -800,6 +800,32 @@ process filterAdapter {
     conda activate ${params.conda_pbbioconda_env}
     pbindex ${run_id}.ccs.filtered.bam
     """
+}
+
+workflow limaDemuxRound1 {
+    take:
+      limaDemux_input_ch
+
+    main:
+      demux = limaDemux(limaDemux_input_ch)
+
+    emit:
+      bam = demux.bam
+      lima_summary = demux.lima_summary
+      lima_counts = demux.lima_counts
+}
+
+workflow limaDemuxRound2 {
+    take:
+      limaDemux_input_ch
+
+    main:
+      demux = limaDemux(limaDemux_input_ch)
+
+    emit:
+      bam = demux.bam
+      lima_summary = demux.lima_summary
+      lima_counts = demux.lima_counts
 }
 
 /*


### PR DESCRIPTION
### Motivation
- Encapsulate the two demultiplexing rounds into separate Nextflow workflows to improve readability and isolation of inputs/outputs.
- Allow the existing `limaDemux` process to be invoked in a structured way for round1 and round2 demuxing steps.

### Description
- Replaced direct invocations `limaDemux(...)` with calls to new workflows `limaDemuxRound1(...)` and `limaDemuxRound2(...)` at the two demux call sites. 
- Added two workflows `limaDemuxRound1` and `limaDemuxRound2` that `take` an input channel (named `limaDemux_input_ch` inside the workflow), call the `limaDemux` process, and `emit` the `bam`, `lima_summary`, and `lima_counts` outputs.
- Placed the new workflows before the `limaDemux` process definition so the file structure clearly groups the wrapper workflows with the process they invoke.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bea9a2ab188321bed894c900d266be)