### PR TITLE
Wrap mergeDemuxBams in round-specific workflows and consume emitted channels

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -381,7 +381,7 @@ workflow {
     }
     .groupTuple(by: [0,1,2,3])
 
-  mergeDemuxBams_round1 = mergeDemuxBams(mergeDemuxBams_round1_input_ch)
+  mergeDemuxBams_round1 = mergeDemuxBamsRound1(mergeDemuxBams_round1_input_ch).out
 
   limaDemux_round2_samples_ch = Channel.fromList(run_sample_configs)
     .filter { it.round2_enabled }
@@ -421,7 +421,7 @@ workflow {
     }
     .groupTuple(by: [0,1,2,3])
 
-  mergeDemuxBams_round2 = mergeDemuxBams(mergeDemuxBams_round2_input_ch)
+  mergeDemuxBams_round2 = mergeDemuxBamsRound2(mergeDemuxBams_round2_input_ch).out
 
   //******************
   // pbmm2Align
@@ -802,32 +802,6 @@ process filterAdapter {
     """
 }
 
-workflow limaDemuxRound1 {
-    take:
-      limaDemux_input_ch
-
-    main:
-      demux = limaDemux(limaDemux_input_ch)
-
-    emit:
-      bam = demux.bam
-      lima_summary = demux.lima_summary
-      lima_counts = demux.lima_counts
-}
-
-workflow limaDemuxRound2 {
-    take:
-      limaDemux_input_ch
-
-    main:
-      demux = limaDemux(limaDemux_input_ch)
-
-    emit:
-      bam = demux.bam
-      lima_summary = demux.lima_summary
-      lima_counts = demux.lima_counts
-}
-
 /*
   limaDemux: Demultiplexes the filtered BAM using lima.
 */
@@ -868,6 +842,32 @@ process limaDemux {
     """
 }
 
+workflow limaDemuxRound1 {
+    take:
+      limaDemux_input_ch
+
+    main:
+      demux = limaDemux(limaDemux_input_ch)
+
+    emit:
+      bam = demux.bam
+      lima_summary = demux.lima_summary
+      lima_counts = demux.lima_counts
+}
+
+workflow limaDemuxRound2 {
+    take:
+      limaDemux_input_ch
+
+    main:
+      demux = limaDemux(limaDemux_input_ch)
+
+    emit:
+      bam = demux.bam
+      lima_summary = demux.lima_summary
+      lima_counts = demux.lima_counts
+}
+
 
 /*
   mergeDemuxBams: Merges one or more demultiplexed BAMs for a sample into a single BAM.
@@ -903,6 +903,28 @@ process mergeDemuxBams {
     fi
     pbindex ${run_id}.${individual_id}.${sample_id}.${barcode_ids}.ccs.filtered.bam
     """
+}
+
+workflow mergeDemuxBamsRound1 {
+    take:
+      mergeDemuxBams_input_ch
+
+    main:
+      out = mergeDemuxBams(mergeDemuxBams_input_ch)
+
+    emit:
+      out
+}
+
+workflow mergeDemuxBamsRound2 {
+    take:
+      mergeDemuxBams_input_ch
+
+    main:
+      out = mergeDemuxBams(mergeDemuxBams_input_ch)
+
+    emit:
+      out
 }
 
 


### PR DESCRIPTION
### Motivation
- Ensure the merged-demux BAM outputs are provided as emitted channels for downstream joins by wrapping the `mergeDemuxBams` process in round-specific workflows. 
- Clarify and separate round1/round2 merging behavior so demux/align stages can join on consistent channel shapes. 

### Description
- Replace direct process invocation with workflow wrappers and consume the emitted channel using `.out` by changing assignments to `mergeDemuxBamsRound1(...).out` and `mergeDemuxBamsRound2(...).out`.
- Add `workflow mergeDemuxBamsRound1` and `workflow mergeDemuxBamsRound2` that call `mergeDemuxBams` and emit its output channel as `out`.
- Reinsert (moved) `limaDemuxRound1` and `limaDemuxRound2` workflow blocks without changing their internal logic to keep workflow declarations grouped and consistent.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bf3b6000748321864c71316df5bd6a)