### PR TITLE
Simplify mergeDemuxBams by always using pbmerge

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -896,11 +896,7 @@ process mergeDemuxBams {
     """
     source ${params.conda_base_script}
     conda activate ${params.conda_pbbioconda_env}
-    if [[ ${demuxBams.size()} -eq 1 ]]; then
-      cp ${demuxBams[0]} ${run_id}.${individual_id}.${sample_id}.${barcode_ids}.ccs.filtered.bam
-    else
-      pbmerge -o ${run_id}.${individual_id}.${sample_id}.${barcode_ids}.ccs.filtered.bam ${demuxBams.join(' ')}
-    fi
+    pbmerge -o ${run_id}.${individual_id}.${sample_id}.${barcode_ids}.ccs.filtered.bam ${demuxBams.join(' ')}
     pbindex ${run_id}.${individual_id}.${sample_id}.${barcode_ids}.ccs.filtered.bam
     """
 }


### PR DESCRIPTION
### Motivation
- Reduce complexity in the `mergeDemuxBams` process by removing a special-case branch for single-input merges because `pbmerge` accepts a single input file and works for both one and multiple inputs.

### Description
- Replaced the `if [[ ${demuxBams.size()} -eq 1 ]] ... cp ... else pbmerge ... fi` block with a single call to `pbmerge -o ${run_id}.${individual_id}.${sample_id}.${barcode_ids}.ccs.filtered.bam ${demuxBams.join(' ')}` in `main.nf`.
- Left the process outputs and the subsequent `pbindex` invocation unchanged.

### Testing
- No automated tests were run for this minimal Nextflow script change and it should be validated during workflow execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c2ce2236688321806694f136d48b49)