### PR TITLE
Propagate barcode (`bc`) BAM tag through call extraction, outputs, and docs

### DIFF
--- a/bin/calculateBurdens.R
+++ b/bin/calculateBurdens.R
@@ -776,7 +776,7 @@ indel_cols_discard <- c(
 
 #Define columns that are identical between zm and strands to either '_keep' or '_discard' in the subsequent pivot_wider for SBSindel_call_type == "mutation" call tables. Not including call_class, call_type, SBSindel_call_type as these are removed from finalCalls after the below nest_join.
 zm_identical_cols_keep <- c(
-	"analysis_chunk", "run_id", "zm"
+	"analysis_chunk", "run_id", "zm", "bc"
 )
 
 strand_identical_cols_keep <- c(

--- a/bin/extractCalls.R
+++ b/bin/extractCalls.R
@@ -179,7 +179,7 @@ bam <- bamFile %>%
     param=ScanBamParam(
       what=setdiff(scanBamWhat(),c("mrnm","mpos","groupid","mate_status")),
       tag=c(
-        "ec","np","rq","zm","sa","sm","sx","RG",
+        "ec","np","rq","zm","bc","sa","sm","sx","RG",
         call_types_MDB %>% pluck("call_bam_scoretag")
         )
     )
@@ -197,6 +197,10 @@ invisible(gc())
 #Add movie_ids and run_ids using run metadata, while maintaining DataFrame format
 bam.df <- bam.df %>%
 	cbind(run_metadata[match(bam.df$RG, run_metadata$rg_id),c("movie_id","run_id")])
+
+#Convert bc tag from uint16[2] list to comma-separated string (forward,reverse barcode FASTA indices)
+bam.df$bc <- bam.df$bc %>%
+	map_chr(function(x){str_c(x, collapse = ",")})
 
 #Extract ccs strand
 bam.df$ccs_strand <- bam.df$qname %>% str_extract("(fwd|rev)$")
@@ -362,6 +366,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
   #Initialize empty calls tibble
   calls.out <- tibble(
     zm=integer(),
+    bc=character(),
     seqnames=factor(),
     strand=factor(),
     start_queryspace=integer(),
@@ -925,6 +930,15 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       )
     )
   
+  #Annotate barcode tag (bc) from input reads
+  calls.out <- calls.out %>%
+    left_join(
+      bam.gr.input %>%
+        distinct(zm, strand, bc),
+      by = join_by(zm, strand)
+    ) %>%
+    relocate(bc, .after = zm)
+
   #Set call_class and call_type
   calls.out <- calls.out %>%
     mutate(

--- a/bin/outputResults.R
+++ b/bin/outputResults.R
@@ -604,7 +604,7 @@ cat("## Outputting germline variant calls...")
 #Define columns that are identical between strands to either '_keep' or '_discard' in the subsequent pivot_wider.
 strand_identical_cols_keep <- c(
 	"analysis_id", "individual_id", "sample_id", "chromgroup", "filtergroup",
-	"analysis_chunk", "run_id", "zm",
+	"analysis_chunk", "run_id", "zm", "bc",
 	"call_class", "call_type", "SBSindel_call_type",
 	"seqnames", "start_refspace", "end_refspace", "ref_plus_strand", "alt_plus_strand",
 	"reftnc_plus_strand", "alttnc_plus_strand", "reftnc_pyr", "alttnc_pyr",

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -108,7 +108,7 @@ The table below summarises tags present in the aligned CCS BAM. See references f
 | `ma` | Barcode/adapter | Adapter detection status (`0` both sides detected, `1` missing left, `2` missing right). |
 | `qs` | Barcode/adapter | Query start position after barcode trimming. |
 | `qe` | Barcode/adapter | Query end position before barcode trimming. |
-| `bc` | Barcode/adapter | Integer barcode pair indices (0-based offsets within barcode FASTA). |
+| `bc` | Barcode/adapter | Comma-separated barcode pair indices (`forward,reverse`) stored from the `uint16[2]` barcode call; values are 0-based offsets within the barcode FASTA. |
 | `bq` | Barcode/adapter | Quality of the barcode call. |
 | `cx` | Barcode/adapter | Sum of subread local context flags (adapter/barcode presence, pass orientation, etc.); CCS BAMs downstream of pbmm2 set `cx=12`. |
 | `bl` | Barcode/adapter | Barcode sequence clipped from the leading end. |
@@ -181,7 +181,7 @@ The pipeline emits four artefacts per call subtype:
 
 - **`finalCalls.tsv`** — Strand-level mismatch tables and per-mutation SBS/indel tables share a common schema:
   - Shared identifiers: `analysis_id`, `individual_id`, `sample_id`, `chromgroup`, `filtergroup`, `call_class`, `call_type`, `SBSindel_call_type`, `analysis_chunk`.
-  - Molecule identifiers and coordinates in reference space: `run_id`, `zm`, `seqnames`, `start_refspace`, `end_refspace`.
+  - Molecule identifiers and coordinates in reference space: `run_id`, `zm`, `bc`, `seqnames`, `start_refspace`, `end_refspace` (`bc` is stored as comma-separated `forward,reverse` barcode indices).
   - Alleles: `ref_plus_strand`, `alt_plus_strand`
   - Strand-specific coordinates in query space (i.e., read coordinates), quality metrics, and additional sequence information: `start_queryspace`, `end_queryspace`, `qual`, `sa`, `sm`, `sx`, `ref_synthesized_strand`, `ref_template_strand`, `alt_synthesized_strand`, `alt_template_strand`. Measurements for multi-base calls, such as `qual` are stored as comma-delimited values for every base. SBS and indel mutation call tables are pivoted to one row per mutation with these strand-specific columns suffixed with `_refstrand_plus_read` and `_refstrand_minus_read`. Non-mutation (i.e., single-strand) call types remain one row per call with a `refstrand` column annotating to which reference strand the call's read aligned.
   - Trinucleotide context (SBS and MDB tables only):
@@ -208,7 +208,7 @@ The pipeline produces two files:
 
 - `germlineVariantCalls.tsv` — Final germline calls that passed all non-germline filters, with one row per mutation. Columns are grouped as follows:
   - Shared identifiers: `analysis_id`, `individual_id`, `sample_id`, `chromgroup`, `filtergroup`, `call_class`, `call_type`, `SBSindel_call_type`, `analysis_chunk`.
-  - Molecule identifiers and coordinates in reference space: `run_id`, `zm`, `seqnames`, `start_refspace`, `end_refspace`.
+  - Molecule identifiers and coordinates in reference space: `run_id`, `zm`, `bc`, `seqnames`, `start_refspace`, `end_refspace` (`bc` is stored as comma-separated `forward,reverse` barcode indices).
   - Alleles and trinucleotide context: `ref_plus_strand`, `alt_plus_strand`, `reftnc_plus_strand`, `alttnc_plus_strand`, `reftnc_pyr`, `alttnc_pyr`.
   - Strand-specific coordinates in query space (i.e., read coordinates), quality metrics, and additional sequence information, with `_refstrand_plus_read` / `_refstrand_minus_read` suffixes: `start_queryspace`, `end_queryspace`, `qual`, `sa`, `sm`, `sx`, `ref_synthesized_strand`, `ref_template_strand`, `alt_synthesized_strand`, `alt_template_strand`, `reftnc_synthesized_strand`, `reftnc_template_strand`, `alttnc_synthesized_strand`, `alttnc_template_strand`.
   - Indel width: `indel_width` for indel calls.
@@ -327,7 +327,7 @@ Unified table of all call types across all chromgroups and filtergroups, with on
 | Column | Description |
 | --- | --- |
 | `analysis_id`, `individual_id`, `sample_id`, `chromgroup`, `filtergroup`, `call_class`, `call_type`, `SBSindel_call_type` | Call metadata. |
-| `analysis_chunk`, `run_id`, `zm` | Chunk identifier, sequencing run ID, and ZMW hole number. |
+| `analysis_chunk`, `run_id`, `zm`, `bc` | Chunk identifier, sequencing run ID, ZMW hole number, and barcode pair indices from the last round of demultplexing, encoded as a comma-separated `forward,reverse` index pair. |
 | `seqnames`, `start_refspace`, `end_refspace` | Reference contig and reference space 1-based coordinates. |
 | `ref_plus_strand`, `alt_plus_strand` | Reference genome forward strand reference and alternate allele sequences. |
 | `refstrand` | Reference genome strand that the read aligned to which supplied the call (`+` or `-`). |


### PR DESCRIPTION
### Motivation

- Ensure the demultiplexed barcode pair indices from the CCS BAM (`bc` tag) are carried through read parsing, call extraction, and final outputs so molecule-level calls record barcode information.

### Description

- Add `bc` to the BAM `scanBam` tag list and convert the `uint16[2]` barcode array to a comma-separated `forward,reverse` string during BAM read ingestion (`bin/extractCalls.R`).
- Include `bc` in the `calls` tibble schema and annotate calls with `bc` by joining per-read barcode info during call extraction (`extract_calls` in `bin/extractCalls.R`), and relocate it after `zm`.
- Add `bc` to lists of strand/zm-identical columns used when pivoting and producing final call tables in multiple scripts (`bin/calculateBurdens.R`, `bin/outputResults.R`).
- Update documentation to describe the `bc` BAM tag format and include `bc` in column lists and schemas for `finalCalls` and `germlineVariantCalls` in `docs/outputs.md`.

### Testing

- No automated tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c93a0f72408321934ac4fc529a4cfb)