### PR TITLE
Add two-round demultiplexing uniqueness checks and propagate combined barcode IDs to outputs/docs

### DIFF
--- a/config_templates/README.md
+++ b/config_templates/README.md
@@ -42,6 +42,11 @@ Below, the `parameter[].subparameter` notation indicates that `parameter` is a l
 | `runs[].samples[].barcode_ids` | string | yes | Either one barcode_id (single-end barcode; lima runs with `--same`) or two barcode_ids separated by `-` (lima runs with `--different --keep-tag-idx-order`). The two values must differ when two are supplied. |
 | `runs[].samples[].barcode_ids_round2` | string | optional | Optional second-round demultiplexing barcode_ids using the same format/rules as `barcode_ids`. This field must be defined for all samples within a run if it is defined for any sample in that run. |
 
+Barcode uniqueness rules within a run:
+- If only one round is configured (`barcode_ids_round2` not set), `barcode_ids` must be unique across samples.
+- If two rounds are configured, the **combination** of `(barcode_ids, barcode_ids_round2)` must be unique across samples, but either field alone may repeat across samples.
+- This allows designs where round 1 is shared and round 2 differs per sample, or round 1 differs per sample and round 2 is shared.
+
 ### Sample metadata
 | Key | Type | Required | Description |
 | --- | --- | --- | --- |

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -65,7 +65,7 @@ Each sample root directory contains a `logs/` subfolder: `[analysis_output_dir]/
 - Core sample scope: `processName.${analysis_id}.${individual_id}.${sample_id}.command.log` (for example `mergeAlignedSampleBAMs.A123.I456.S789.command.log`).
 - Chunked tasks append the chunk identifier: `...chunk${chunkID}.command.log` (for example `splitBAM.A123.I456.S789.chunk04.command.log`).
 - Chromgroup/filtergroup-aware tasks insert those fields before any chunk suffix: `...${chromgroup}.${filtergroup}[.chunk${chunkID}].command.log`.
-- Per-barcode alignments append the run and barcode identifiers (for example `pbmm2Align.A123.Run123.I456.S789.bc2009.command.log` and `verifyBAMID.A123.Run123.I456.S789.bc2009.command.log`).
+- Per-barcode alignments append the run and barcode identifiers (for example `pbmm2Align.A123.Run123.I456.S789.bc2009.command.log` for one demultiplexing round, or `pbmm2Align.A123.Run123.I456.S789.bc2009.bc2010-bc2011.command.log` when two rounds are configured; analogous naming applies to `verifyBAMID` logs).
 
 ## Top-level files
 Location: `[analysis_output_dir]/[analysis_id].[individual_id].[sample_id]/`
@@ -138,6 +138,8 @@ During `processReads`, the pipeline adds to the sharedLogs directory:
 Location: `[analysis_output_dir]/[analysis_id].[individual_id].[sample_id]/verifyBAMID/` (written when all `verifybamid_*` parameters are set)
 
 One VerifyBamID2 run is emitted per `run_id`/`sample_id`/`barcode_id` alignment produced by `pbmm2Align`. Two outputs are produced for each run, with the input BAM file name from `pbmm2Align` as the prefix:
+
+`barcode_id` is the sample barcode token from demultiplexing: `${barcode_ids}` when one demultiplexing round is configured, or `${barcode_ids}.${barcode_ids_round2}` when two rounds are configured.
 
 | File | Description |
 | --- | --- |

--- a/main.nf
+++ b/main.nf
@@ -199,20 +199,20 @@ workflow {
       ]
     }
 
-    runConfigs.groupBy { cfg ->
-      cfg.barcode_ids_parsed.canonical
-    }.each { key, cfgs ->
-      if (cfgs.size() > 1) {
-        error "run '${run.run_id}' has duplicate barcode_ids configuration '${key}' across samples: ${cfgs.collect{it.sample_id}.join(', ')}"
-      }
-    }
-
     if (hasAllRound2) {
       runConfigs.groupBy { cfg ->
-        cfg.barcode_ids_round2_parsed.canonical
+        "${cfg.barcode_ids_parsed.canonical}|${cfg.barcode_ids_round2_parsed.canonical}"
       }.each { key, cfgs ->
         if (cfgs.size() > 1) {
-          error "run '${run.run_id}' has duplicate barcode_ids_round2 configuration '${key}' across samples: ${cfgs.collect{it.sample_id}.join(', ')}"
+          error "run '${run.run_id}' has duplicate barcode_ids + barcode_ids_round2 configuration '${key}' across samples: ${cfgs.collect{it.sample_id}.join(', ')}. When using two demultiplexing rounds, each sample in a run must have a unique combination across both rounds."
+        }
+      }
+    } else {
+      runConfigs.groupBy { cfg ->
+        cfg.barcode_ids_parsed.canonical
+      }.each { key, cfgs ->
+        if (cfgs.size() > 1) {
+          error "run '${run.run_id}' has duplicate barcode_ids configuration '${key}' across samples: ${cfgs.collect{it.sample_id}.join(', ')}"
         }
       }
     }
@@ -410,14 +410,14 @@ workflow {
   mergeDemuxBams_round2_input_ch = mergeDemuxBams_round1
     .join(limaDemux_round2_samples_ch, by: [0,1,2,3])
     .map { run_id, individual_id, sample_id, barcode_ids, mergedBam, mergedPbi, barcode_ids_round2, mode2, id21, id22 ->
-      tuple(run_id, mergedBam.baseName, individual_id, sample_id, barcode_ids, mode2, id21, id22)
+      tuple(run_id, mergedBam.baseName, individual_id, sample_id, barcode_ids, barcode_ids_round2, mode2, id21, id22)
     }
     .combine(limaDemux_round2_map_ch, by: [0,1])
-    .filter { run_id, output_prefix, individual_id, sample_id, barcode_ids, mode2, id21, id22, d_run_id, d_output_prefix, leftId, rightId, bamFile ->
+    .filter { run_id, output_prefix, individual_id, sample_id, barcode_ids, barcode_ids_round2, mode2, id21, id22, d_run_id, d_output_prefix, leftId, rightId, bamFile ->
       ([leftId,rightId] as Set) == ([id21,id22] as Set)
     }
-    .map { run_id, output_prefix, individual_id, sample_id, barcode_ids, mode2, id21, id22, d_run_id, d_output_prefix, leftId, rightId, bamFile ->
-      tuple(run_id, individual_id, sample_id, barcode_ids, bamFile)
+    .map { run_id, output_prefix, individual_id, sample_id, barcode_ids, barcode_ids_round2, mode2, id21, id22, d_run_id, d_output_prefix, leftId, rightId, bamFile ->
+      tuple(run_id, individual_id, sample_id, "${barcode_ids}.${barcode_ids_round2}", bamFile)
     }
     .groupTuple(by: [0,1,2,3])
 


### PR DESCRIPTION
### Motivation

- Add explicit support for workflows that use two rounds of demultiplexing and ensure barcode identity is unambiguous across samples within a run. 
- Prevent accidental duplicate demultiplexing assignments by enforcing uniqueness of the combined `(barcode_ids, barcode_ids_round2)` when two rounds are configured. 
- Ensure filenames and log naming reflect the two-round barcode combination so downstream processes and outputs remain traceable.

### Description

- Documented barcode uniqueness rules in `config_templates/README.md` to explain single- and two-round demultiplexing constraints. 
- Updated `docs/outputs.md` to show per-barcode alignment and `verifyBAMID` filenames include the combined barcode token (`${barcode_ids}.${barcode_ids_round2}`) when two rounds are configured. 
- Modified `main.nf` validation to group by a combined canonical key `"${cfg.barcode_ids_parsed.canonical}|${cfg.barcode_ids_round2_parsed.canonical}"` when `barcode_ids_round2` is present and emit a clear error if duplicate combinations appear. 
- Propagated `barcode_ids_round2` through the demultiplex/merge channels and changed merging logic to emit the combined barcode identifier string for downstream steps (including `mergeDemuxBams_round2`, `pbmm2Align`, and `verifyBAMID`).

### Testing

- Ran a Nextflow dry-run with `nextflow run . -n` to validate the workflow graph and channel mappings, which completed without errors. 
- Performed documentation/markdown lint checks on the updated docs, which passed. 
- Executed a small local demultiplexing integration smoke-test with synthetic inputs to verify merged BAM naming and pipeline branching for single- and two-round configurations, and the smoke-test succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c9477bb0908321899beee7260ed340)