### PR TITLE
Enforce global presence of `barcode_ids_round2` and centralize run/sample barcode validation

### DIFF
--- a/config_templates/README.md
+++ b/config_templates/README.md
@@ -40,7 +40,7 @@ Below, the `parameter[].subparameter` notation indicates that `parameter` is a l
 | `runs[].samples[]` | list | yes | Sample-to-barcode mapping entries for each run. |
 | `runs[].samples[].sample_id` | string | yes | Sample identifier. Must match an entry in samples[].sample_id`. |
 | `runs[].samples[].barcode_ids` | string | yes | Either one barcode_id (single-end barcode; lima runs with `--same`) or two barcode_ids separated by `-` (lima runs with `--different --keep-tag-idx-order`). The two values must differ when two are supplied. |
-| `runs[].samples[].barcode_ids_round2` | string | optional | Optional second-round demultiplexing barcode_ids using the same format/rules as `barcode_ids`. This field must be defined for all samples within a run if it is defined for any sample in that run. |
+| `runs[].samples[].barcode_ids_round2` | string | optional | Optional second-round demultiplexing barcode_ids using the same format/rules as `barcode_ids`. This field must be defined for every sample in every run if it is defined for any sample. |
 
 Barcode uniqueness rules within a run:
 - If only one round is configured (`barcode_ids_round2` not set), `barcode_ids` must be unique across samples.

--- a/main.nf
+++ b/main.nf
@@ -161,14 +161,8 @@ workflow {
 
   sample_to_individual = params.samples.collectEntries { [ (it.sample_id): it.individual_id ] }
 
-  run_sample_configs = params.runs.collectMany { run ->
-    def hasAnyRound2 = run.samples.any { sample -> sample.barcode_ids_round2 }
-    def hasAllRound2 = run.samples.every { sample -> sample.barcode_ids_round2 }
-    if (hasAnyRound2 && !hasAllRound2) {
-      error "run '${run.run_id}' has barcode_ids_round2 configured for only a subset of samples. Define barcode_ids_round2 for all samples in a run or for none."
-    }
-
-    def runConfigs = run.samples.collect { sample ->
+  provisional_run_sample_configs = params.runs.collectMany { run ->
+    run.samples.collect { sample ->
       def sampleContext = "run '${run.run_id}', sample '${sample.sample_id}'"
       def round1 = parseBarcodeIds(sample.barcode_ids, 'barcode_ids', sampleContext)
       round1.ids.each { barcodeId ->
@@ -178,7 +172,7 @@ workflow {
       }
 
       def round2 = null
-      if (hasAllRound2) {
+      if (sample.barcode_ids_round2) {
         round2 = parseBarcodeIds(sample.barcode_ids_round2, 'barcode_ids_round2', sampleContext)
         round2.ids.each { barcodeId ->
           if (!barcode_seq_by_id.containsKey(barcodeId)) {
@@ -194,43 +188,52 @@ workflow {
         barcode_ids: round1.raw,
         barcode_ids_parsed: round1,
         barcode_ids_round2: round2?.raw,
-        barcode_ids_round2_parsed: round2,
-        round2_enabled: hasAllRound2
+        barcode_ids_round2_parsed: round2
       ]
     }
-
-    if (hasAllRound2) {
-      runConfigs.groupBy { cfg ->
-        "${cfg.barcode_ids_parsed.canonical}|${cfg.barcode_ids_round2_parsed.canonical}"
-      }.each { key, cfgs ->
-        if (cfgs.size() > 1) {
-          error "run '${run.run_id}' has duplicate barcode_ids + barcode_ids_round2 configuration '${key}' across samples: ${cfgs.collect{it.sample_id}.join(', ')}. When using two demultiplexing rounds, each sample in a run must have a unique combination across both rounds."
-        }
-      }
-    } else {
-      runConfigs.groupBy { cfg ->
-        cfg.barcode_ids_parsed.canonical
-      }.each { key, cfgs ->
-        if (cfgs.size() > 1) {
-          error "run '${run.run_id}' has duplicate barcode_ids configuration '${key}' across samples: ${cfgs.collect{it.sample_id}.join(', ')}"
-        }
-      }
-    }
-
-    def round1Modes = runConfigs.collect { it.barcode_ids_parsed.mode }.unique()
-    if (round1Modes.size() > 1) {
-      error "run '${run.run_id}' mixes barcode_ids demultiplexing modes across samples (${round1Modes.join(', ')}). Use a single mode ('same' or 'different') per run for round1 demultiplexing."
-    }
-
-    if (hasAllRound2) {
-      def round2Modes = runConfigs.collect { it.barcode_ids_round2_parsed.mode }.unique()
-      if (round2Modes.size() > 1) {
-        error "run '${run.run_id}' mixes barcode_ids_round2 demultiplexing modes across samples (${round2Modes.join(', ')}). Use a single mode ('same' or 'different') per run for round2 demultiplexing."
-      }
-    }
-
-    runConfigs
   }
+
+  def hasAnyRound2 = provisional_run_sample_configs.any { it.barcode_ids_round2_parsed }
+  def hasAllRound2 = provisional_run_sample_configs.every { it.barcode_ids_round2_parsed }
+  if (hasAnyRound2 && !hasAllRound2) {
+    error "barcode_ids_round2 is configured for only a subset of samples. Define barcode_ids_round2 for all samples in every run_id or for none."
+  }
+
+  run_sample_configs = provisional_run_sample_configs
+    .groupBy { it.run_id }
+    .collectMany { runId, runConfigs ->
+      if (hasAllRound2) {
+        runConfigs.groupBy { cfg ->
+          "${cfg.barcode_ids_parsed.canonical}|${cfg.barcode_ids_round2_parsed.canonical}"
+        }.each { key, cfgs ->
+          if (cfgs.size() > 1) {
+            error "run '${runId}' has duplicate barcode_ids + barcode_ids_round2 configuration '${key}' across samples: ${cfgs.collect{it.sample_id}.join(', ')}. When using two demultiplexing rounds, each sample in a run must have a unique combination across both rounds."
+          }
+        }
+      } else {
+        runConfigs.groupBy { cfg ->
+          cfg.barcode_ids_parsed.canonical
+        }.each { key, cfgs ->
+          if (cfgs.size() > 1) {
+            error "run '${runId}' has duplicate barcode_ids configuration '${key}' across samples: ${cfgs.collect{it.sample_id}.join(', ')}"
+          }
+        }
+      }
+
+      def round1Modes = runConfigs.collect { it.barcode_ids_parsed.mode }.unique()
+      if (round1Modes.size() > 1) {
+        error "run '${runId}' mixes barcode_ids demultiplexing modes across samples (${round1Modes.join(', ')}). Use a single mode ('same' or 'different') per run for round1 demultiplexing."
+      }
+
+      if (hasAllRound2) {
+        def round2Modes = runConfigs.collect { it.barcode_ids_round2_parsed.mode }.unique()
+        if (round2Modes.size() > 1) {
+          error "run '${runId}' mixes barcode_ids_round2 demultiplexing modes across samples (${round2Modes.join(', ')}). Use a single mode ('same' or 'different') per run for round2 demultiplexing."
+        }
+      }
+
+      runConfigs.collect { cfg -> cfg + [round2_enabled: hasAllRound2] }
+    }
 
   // Create a channel of runs
   runs_ch = Channel.fromList(params.runs)


### PR DESCRIPTION
### Motivation

- Ensure consistent demultiplexing configuration by requiring `barcode_ids_round2` to be present for every sample across all runs if it is used at all. 
- Centralize parsing and validation of barcode fields to simplify logic and avoid per-run partial checks. 

### Description

- Update documentation in `config_templates/README.md` to state that `barcode_ids_round2` must be defined for every sample in every run if it is defined anywhere. 
- Refactor `main.nf` to first collect provisional per-sample configurations (`provisional_run_sample_configs`) and parse `barcode_ids_round2` per-sample, then compute global `hasAnyRound2`/`hasAllRound2` flags and error if only a subset of samples use round 2. 
- Move per-run grouping and uniqueness checks into a second pass that groups `provisional_run_sample_configs` by `run_id`, validate duplicate `(barcode_ids, barcode_ids_round2)` combinations per run when two-round demultiplexing is enabled, and set `round2_enabled` uniformly using the global `hasAllRound2`. 
- Small message and variable-name cleanups to use `runId` in error messages and to streamline control flow. 

### Testing

- Ran the repository linting and existing automated test suite; no tests were changed and all checks completed successfully. 
- Verified that sample-level barcode parsing still runs when `barcode_ids_round2` is present on any sample and that the global consistency check correctly errors when only a subset of samples specify round 2.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c9e3975fa8832184ed82df95672172)