### PR TITLE
Fix lima demux channel joins for two-round barcode runs

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -349,11 +349,18 @@ workflow {
     .map { cfg -> tuple(cfg.run_id, cfg.barcode_ids_parsed.mode) }
     .unique()
 
+  round1_barcodes_fasta_ch = makeBarcodesFasta.out
+    .filter { run_id, barcodesFasta, demux_round -> demux_round == 'round1' }
+    .map { run_id, barcodesFasta, demux_round -> tuple(run_id, barcodesFasta) }
+
+  round2_barcodes_fasta_ch = makeBarcodesFasta.out
+    .filter { run_id, barcodesFasta, demux_round -> demux_round == 'round2' }
+    .map { run_id, barcodesFasta, demux_round -> tuple(run_id, barcodesFasta) }
+
   // Create input channel
   limaDemux_round1_input_ch = filterAdapter.out
-      .join(makeBarcodesFasta.out, by: 0)
-      .filter { run_id, bamFile, pbiFile, barcodesFasta, demux_round -> demux_round == 'round1' }
-      .map { run_id, bamFile, pbiFile, barcodesFasta, demux_round ->
+      .join(round1_barcodes_fasta_ch, by: 0)
+      .map { run_id, bamFile, pbiFile, barcodesFasta ->
         tuple(run_id, bamFile, pbiFile, barcodesFasta)
       }
       .join(limaDemux_round1_mode_ch, by: 0)
@@ -392,9 +399,8 @@ workflow {
 
   limaDemux_round2_input_ch = mergeDemuxBams_round1
     .join(limaDemux_round2_samples_ch, by: [0,1,2,3])
-    .join(makeBarcodesFasta.out, by: 0)
-    .filter { run_id, individual_id, sample_id, barcode_ids, mergedBam, mergedPbi, barcode_ids_round2, mode2, barcode_pair_key_round2, barcodesFasta, demux_round -> demux_round == 'round2' }
-    .map { run_id, individual_id, sample_id, barcode_ids, mergedBam, mergedPbi, barcode_ids_round2, mode2, barcode_pair_key_round2, barcodesFasta, demux_round ->
+    .join(round2_barcodes_fasta_ch, by: 0)
+    .map { run_id, individual_id, sample_id, barcode_ids, mergedBam, mergedPbi, barcode_ids_round2, mode2, barcode_pair_key_round2, barcodesFasta ->
       tuple(run_id, individual_id, sample_id, barcode_ids, barcode_ids_round2, barcode_pair_key_round2, mergedBam, mergedPbi, barcodesFasta, mode2, params.lima_round2_supplemental_settings)
     }
 


### PR DESCRIPTION
### Motivation
- The pipeline can configure two demultiplexing rounds, and `makeBarcodesFasta.out` emits both `round1` and `round2` tuples per `run_id`, which caused downstream `join` logic to lose matching tuples and leave `limaDemuxRound1` without inputs. 
- The change prevents key-collision/consumption behavior in joins with duplicate keys that can drop valid demux inputs. 

### Description
- Updated `main.nf` to split `makeBarcodesFasta.out` into two explicit channels: `round1_barcodes_fasta_ch` and `round2_barcodes_fasta_ch`, each filtered by `demux_round` and mapped to `(run_id, barcodesFasta)` tuples. 
- Rewired `limaDemux_round1_input_ch` to join only `round1_barcodes_fasta_ch` and produce the expected tuple shape for `limaDemuxRound1`. 
- Rewired `limaDemux_round2_input_ch` to join only `round2_barcodes_fasta_ch` and produce the expected tuple shape for `limaDemuxRound2`.
- Change affects only demultiplexing channel wiring in `main.nf` (no process internals altered). 

### Testing
- Performed static inspection of the codebase with `rg` to locate demux-related logic and validated the modified code regions using `sed` and `nl` to print relevant `main.nf` excerpts, and these showed the new channels and updated joins as intended. 
- Applied the patch using the repo tooling which reported a successful update to `main.nf` and displayed the resulting diff for review. 
- No full Nextflow runtime test was executed in this environment due to missing cluster/data access, so runtime validation should be performed by re-running the pipeline (for example with `nextflow run ... -resume`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cae7a267888321bb5ef459152aaedf)