### PR TITLE
Canonicalize barcode pair keys and centralize canonicalization logic

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -55,6 +55,10 @@ def configHash(params_input, keys) {
   digest.digest().encodeHex().toString()
 }
 
+def canonicalBarcodePair(barcodeA, barcodeB) {
+  return barcodeA == barcodeB ? barcodeA : [barcodeA, barcodeB].toSorted().join('-')
+}
+
 def parseBarcodeIds(rawBarcodeIds, fieldName, contextLabel) {
   if (!rawBarcodeIds) {
     error "${contextLabel}: ${fieldName} must be defined."
@@ -79,7 +83,7 @@ def parseBarcodeIds(rawBarcodeIds, fieldName, contextLabel) {
     raw: rawBarcodeIds,
     ids: barcodeIds,
     mode: barcodeIds.size() == 1 ? 'same' : 'different',
-    canonical: barcodeIds.size() == 1 ? barcodeIds[0] : barcodeIds.toSorted().join('-')
+    canonical: barcodeIds.size() == 1 ? canonicalBarcodePair(barcodeIds[0], barcodeIds[0]) : canonicalBarcodePair(barcodeIds[0], barcodeIds[1])
   ]
 }
 
@@ -377,7 +381,7 @@ workflow {
       if (!m) {
           error "Can't match BAM file name to run_id and barcode_id: ${bamFile.name}"
       }
-      def barcode_pair_key = [m[0][1], m[0][2]].sort().join('-')
+      def barcode_pair_key = canonicalBarcodePair(m[0][1], m[0][2])
       tuple(run_id, barcode_pair_key, bamFile)
     }
 
@@ -413,7 +417,7 @@ workflow {
       if (!m) {
           error "Can't match BAM file name to run_id and barcode_id: ${bamFile.name}"
       }
-      def barcode_pair_key = [m[0][1], m[0][2]].sort().join('-')
+      def barcode_pair_key = canonicalBarcodePair(m[0][1], m[0][2])
       tuple(run_id, individual_id, sample_id, barcode_ids, barcode_ids_round2, barcode_pair_key_round2, barcode_pair_key, bamFile)
     }
     .filter { run_id, individual_id, sample_id, barcode_ids, barcode_ids_round2, barcode_pair_key_round2, barcode_pair_key, bamFile ->


### PR DESCRIPTION
### Motivation
- Ensure a single, consistent canonical representation for barcode pairs across the workflow and centralize the logic to avoid duplicated ad-hoc sorting/joining and to handle single-barcode cases uniformly.

### Description
- Add `canonicalBarcodePair(barcodeA, barcodeB)` and update `parseBarcodeIds` and places that derived `barcode_pair_key` to call this function instead of ad-hoc sorting/joining in `main.nf`.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cb2b77ce408321aab82485ac9277f6)