### PR TITLE
Make barcode column a factor and relocate it after strand in extract_calls

### DIFF
--- a/bin/extractCalls.R
+++ b/bin/extractCalls.R
@@ -367,9 +367,9 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
   #Initialize empty calls tibble
   calls.out <- tibble(
     zm=integer(),
-    bc=character(),
     seqnames=factor(),
     strand=factor(),
+    bc=factor(),
     start_queryspace=integer(),
     end_queryspace=integer(),
     start_refspace=integer(),
@@ -940,7 +940,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
         distinct(zm, strand, bc),
       by = join_by(zm, strand)
     ) %>%
-    relocate(bc, .after = zm)
+    relocate(bc, .after = strand)
 
   #Set call_class and call_type
   calls.out <- calls.out %>%


### PR DESCRIPTION
### Motivation
- Ensure `bc` (barcode) column has a consistent factor type and is positioned after `strand` in the `calls.out` tibble to match other factor columns and downstream expectations.

### Description
- Change the `calls.out` tibble to declare `bc` as a `factor` and update the `relocate(bc, ...)` call to place `bc` after `strand` instead of after `zm`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cc736d39d08321897b20ffd321280e)