### PR TITLE
Fix limaDemux command log naming to avoid duplicate run ID

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -835,7 +835,7 @@ process limaDemux {
     afterScript{
       generateAfterScript(
         "${sharedLogsDir}",
-        "${task.process}.${params.analysis_id}.${run_id}.${bamFile.baseName}.command.log"
+        "${task.process}.${params.analysis_id}.${bamFile.baseName}.command.log"
       )
     }
 


### PR DESCRIPTION
### Motivation
- `limaDemux` log filenames included both `${run_id}` and `${bamFile.baseName}`, and because `bamFile.baseName` already contains the run identifier this produced duplicated `run_id` segments in `.command.log` names.

### Description
- Update `limaDemux` `afterScript` in `main.nf` to use `"${task.process}.${params.analysis_id}.${bamFile.baseName}.command.log"` instead of including the extra `${run_id}` segment, removing redundant run ID duplication while preserving unique, informative log names.

### Testing
- Applied the patch to `main.nf` and verified the change was applied successfully, inspected the updated lines (`nl -ba main.nf | sed -n '828,845p'`) and confirmed the single-line filename template change.}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cc9309d5a88321b56cb51cf7d3ba6a)