### PR TITLE
Use `combine` to pair round2 barcodes FASTA with merged BAMs

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -403,7 +403,7 @@ workflow {
 
   limaDemux_round2_input_ch = mergeDemuxBams_round1
     .join(limaDemux_round2_samples_ch, by: [0,1,2,3])
-    .join(round2_barcodes_fasta_ch, by: 0)
+    .combine(round2_barcodes_fasta_ch, by: 0)
     .map { run_id, individual_id, sample_id, barcode_ids, mergedBam, mergedPbi, barcode_ids_round2, mode2, barcode_pair_key_round2, barcodesFasta ->
       tuple(run_id, individual_id, sample_id, barcode_ids, barcode_ids_round2, barcode_pair_key_round2, mergedBam, mergedPbi, barcodesFasta, mode2, params.lima_round2_supplemental_settings)
     }


### PR DESCRIPTION
### Motivation
- Replace a `join` that could miss or mis-pair entries with `combine` so `round2_barcodes_fasta_ch` is correctly associated with `limaDemux_round2` inputs regardless of channel cardinality.

### Description
- Change `.join(round2_barcodes_fasta_ch, by: 0)` to `.combine(round2_barcodes_fasta_ch, by: 0)` in `main.nf` to correctly combine the round2 barcode FASTA channel with the merged BAM channel used to build `limaDemux_round2_input_ch`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d303226ca8832188389ac462b48b9b)