### PR TITLE
Enforce per-sample round2 demux rules and clarify templates/README

### DIFF
--- a/config_templates/README.md
+++ b/config_templates/README.md
@@ -40,12 +40,13 @@ Below, the `parameter[].subparameter` notation indicates that `parameter` is a l
 | `runs[].samples[]` | list | yes | Sample-to-barcode mapping entries for each run. |
 | `runs[].samples[].sample_id` | string | yes | Sample identifier. Must match an entry in samples[].sample_id`. |
 | `runs[].samples[].barcode_ids` | string | yes | Either one barcode_id (single-end barcode; lima runs with `--same`) or two barcode_ids separated by `-` (lima runs with `--different --keep-tag-idx-order`). The two values must differ when two are supplied. |
-| `runs[].samples[].barcode_ids_round2` | string | optional | Optional second-round demultiplexing barcode_ids using the same format/rules as `barcode_ids`. This field must be defined for every sample in every run if it is defined for any sample. |
+| `runs[].samples[].barcode_ids_round2` | string | optional | Optional second-round demultiplexing barcode_ids using the same format/rules as `barcode_ids`. This can be configured per sample (for example, some samples can be round1-only), but if round2 demultiplexing is performed for a sample, `barcode_ids_round2` must be configured for that sample across all runs that contain it. |
 
 Barcode uniqueness rules within a run:
-- If only one round is configured (`barcode_ids_round2` not set), `barcode_ids` must be unique across samples.
-- If two rounds are configured, the **combination** of `(barcode_ids, barcode_ids_round2)` must be unique across samples, but either field alone may repeat across samples.
-- This allows designs where round 1 is shared and round 2 differs per sample, or round 1 differs per sample and round 2 is shared.
+- Among round1-only samples (no `barcode_ids_round2`), `barcode_ids` must be unique.
+- Among round1+round2 samples, the **combination** of `(barcode_ids, barcode_ids_round2)` must be unique; either field alone may repeat.
+- Round1 barcode_ids used by round1-only samples cannot be reused by round1+round2 samples in the same run.
+- This allows mixed-run designs (some samples round1-only, others round1+round2) while preserving unambiguous sample assignment.
 
 ### Sample metadata
 | Key | Type | Required | Description |

--- a/config_templates/hidef-seq_3.0.template.hg38.yaml
+++ b/config_templates/hidef-seq_3.0.template.hg38.yaml
@@ -25,10 +25,10 @@ runs: # can specify multiple run_id entries
     samples:
       - sample_id: 
         barcode_ids: 
-        barcode_ids_round2: # optional second demultiplexing round
+        barcode_ids_round2: # optional second demultiplexing round; if performed for a sample, barcode_ids_round2 must be configured for that sample across all runs that contain it
       - sample_id: 
         barcode_ids: 
-        barcode_ids_round2: # optional second demultiplexing round
+        barcode_ids_round2: # optional second demultiplexing round; if performed for a sample, barcode_ids_round2 must be configured for that sample across all runs that contain it
 
 samples:
   - sample_id:

--- a/config_templates/hidef-seq_3.0.template.yaml
+++ b/config_templates/hidef-seq_3.0.template.yaml
@@ -25,10 +25,10 @@ runs: # can specify multiple run_id entries
     samples:
       - sample_id: 
         barcode_ids: 
-        barcode_ids_round2: # optional second demultiplexing round
+        barcode_ids_round2: # optional second demultiplexing round; if performed for a sample, barcode_ids_round2 must be configured for that sample across all runs that contain it
       - sample_id: 
         barcode_ids: 
-        barcode_ids_round2: # optional second demultiplexing round
+        barcode_ids_round2: # optional second demultiplexing round; if performed for a sample, barcode_ids_round2 must be configured for that sample across all runs that contain it
 
 samples:
   - sample_id:

--- a/main.nf
+++ b/main.nf
@@ -197,30 +197,44 @@ workflow {
     }
   }
 
-  def hasAnyRound2 = provisional_run_sample_configs.any { it.barcode_ids_round2_parsed }
-  def hasAllRound2 = provisional_run_sample_configs.every { it.barcode_ids_round2_parsed }
-  if (hasAnyRound2 && !hasAllRound2) {
-    error "barcode_ids_round2 is configured for only a subset of samples. Define barcode_ids_round2 for all samples in every run_id or for none."
-  }
+  provisional_run_sample_configs
+    .groupBy { it.sample_id }
+    .each { sampleId, sampleConfigs ->
+      def round2Usage = sampleConfigs.collect { it.barcode_ids_round2_parsed != null }.unique()
+      if (round2Usage.size() > 1) {
+        def runIds = sampleConfigs.collect { it.run_id }.unique().sort().join(', ')
+        error "sample '${sampleId}' has inconsistent barcode_ids_round2 usage across runs (${runIds}). Configure this sample with either barcode_ids only in all runs or with both barcode_ids and barcode_ids_round2 in all runs."
+      }
+    }
 
   run_sample_configs = provisional_run_sample_configs
     .groupBy { it.run_id }
     .collectMany { runId, runConfigs ->
-      if (hasAllRound2) {
-        runConfigs.groupBy { cfg ->
+      def round1OnlyConfigs = runConfigs.findAll { !it.barcode_ids_round2_parsed }
+      def round2Configs = runConfigs.findAll { it.barcode_ids_round2_parsed }
+
+      round1OnlyConfigs.groupBy { cfg ->
+        cfg.barcode_ids_parsed.canonical
+      }.each { key, cfgs ->
+        if (cfgs.size() > 1) {
+          error "run '${runId}' has duplicate barcode_ids configuration '${key}' across round1-only samples: ${cfgs.collect{it.sample_id}.join(', ')}"
+        }
+      }
+
+      if (round2Configs) {
+        round2Configs.groupBy { cfg ->
           "${cfg.barcode_ids_parsed.canonical}|${cfg.barcode_ids_round2_parsed.canonical}"
         }.each { key, cfgs ->
           if (cfgs.size() > 1) {
-            error "run '${runId}' has duplicate barcode_ids + barcode_ids_round2 configuration '${key}' across samples: ${cfgs.collect{it.sample_id}.join(', ')}. When using two demultiplexing rounds, each sample in a run must have a unique combination across both rounds."
+            error "run '${runId}' has duplicate barcode_ids + barcode_ids_round2 configuration '${key}' across samples: ${cfgs.collect{it.sample_id}.join(', ')}. For samples using two demultiplexing rounds, each sample in a run must have a unique combination across both rounds."
           }
         }
-      } else {
-        runConfigs.groupBy { cfg ->
-          cfg.barcode_ids_parsed.canonical
-        }.each { key, cfgs ->
-          if (cfgs.size() > 1) {
-            error "run '${runId}' has duplicate barcode_ids configuration '${key}' across samples: ${cfgs.collect{it.sample_id}.join(', ')}"
-          }
+
+        def overlappingRound1Keys = round1OnlyConfigs.collect { it.barcode_ids_parsed.canonical }.intersect(
+          round2Configs.collect { it.barcode_ids_parsed.canonical }
+        )
+        if (overlappingRound1Keys) {
+          error "run '${runId}' reuses round1 barcode_ids across round1-only and round2 samples (${overlappingRound1Keys.join(', ')}). Round1 barcode_ids must be unique for round1-only samples relative to all other samples in the same run."
         }
       }
 
@@ -229,14 +243,14 @@ workflow {
         error "run '${runId}' mixes barcode_ids demultiplexing modes across samples (${round1Modes.join(', ')}). Use a single mode ('same' or 'different') per run for round1 demultiplexing."
       }
 
-      if (hasAllRound2) {
-        def round2Modes = runConfigs.collect { it.barcode_ids_round2_parsed.mode }.unique()
+      if (round2Configs) {
+        def round2Modes = round2Configs.collect { it.barcode_ids_round2_parsed.mode }.unique()
         if (round2Modes.size() > 1) {
           error "run '${runId}' mixes barcode_ids_round2 demultiplexing modes across samples (${round2Modes.join(', ')}). Use a single mode ('same' or 'different') per run for round2 demultiplexing."
         }
       }
 
-      runConfigs.collect { cfg -> cfg + [round2_enabled: hasAllRound2] }
+      runConfigs.collect { cfg -> cfg + [round2_enabled: cfg.barcode_ids_round2_parsed != null] }
     }
 
   // Create a channel of runs
@@ -259,6 +273,11 @@ workflow {
     .findAll { it.round2_enabled }
     .collect { it.run_id }
     .unique()
+
+  round2_sample_keys = run_sample_configs
+    .findAll { it.round2_enabled }
+    .collect { cfg -> "${cfg.run_id}|${cfg.individual_id}|${cfg.sample_id}|${cfg.barcode_ids}" }
+    .toSet()
 
   // Create input channel
   makeBarcodesFasta_input_ch = runs_ch.map { run ->
@@ -438,7 +457,9 @@ workflow {
 
   // Create input channel
   pbmm2_round1_final_ch = mergeDemuxBams_round1
-    .filter { run_id, individual_id, sample_id, barcode_ids, bamFile, pbiFile -> !round2_run_ids.contains(run_id) }
+    .filter { run_id, individual_id, sample_id, barcode_ids, bamFile, pbiFile ->
+      !round2_sample_keys.contains("${run_id}|${individual_id}|${sample_id}|${barcode_ids}")
+    }
     .map { run_id, individual_id, sample_id, barcode_ids, bamFile, pbiFile -> tuple(run_id, individual_id, sample_id, barcode_ids, bamFile) }
 
   pbmm2_round2_final_ch = mergeDemuxBams_round2


### PR DESCRIPTION
### Motivation
- Ensure `barcode_ids_round2` usage is consistent per sample across runs and allow mixed designs where some samples use two demultiplexing rounds and others use only one. 
- Prevent ambiguous barcode reuse within a run by enforcing uniqueness rules between round1-only and round1+round2 samples. 
- Clarify the configuration semantics in the README and YAML templates so users understand per-sample round2 requirements.

### Description
- Update README (`config_templates/README.md`) to document that `barcode_ids_round2` can be configured per sample but, if used for a sample, it must be present for that sample across all runs and to list uniqueness rules for mixed designs. 
- Update YAML templates (`config_templates/hidef-seq_3.0.template*.yaml`) to include the clarified `barcode_ids_round2` comment for per-sample configuration. 
- Revise `main.nf` to validate `barcode_ids_round2` usage per sample across runs and to error on inconsistent usage across runs. 
- Add per-run validations to ensure round1-only samples do not duplicate `barcode_ids`, ensure round2 samples have unique `(barcode_ids, barcode_ids_round2)` combinations, and disallow reuse of round1 `barcode_ids` between round1-only and round1+round2 samples in the same run. 
- Change `round2_enabled` to be set per-config (per-sample-in-run) and introduce `round2_sample_keys` to drive downstream filtering so downstream processes exclude or include demux results on a per-sample basis rather than based only on run-level flags. 
- Minor wording tweaks to validation error messages for clarity.

### Testing
- Ran the repository's automated CI checks (linters and unit tests) against these changes and they completed successfully. 
- Performed Nextflow parameter/config validation with the updated `main.nf` logic to exercise the new barcode consistency checks and it succeeded for valid configurations and produced expected errors for invalid/mixed configurations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d3c84119b88321bb04abda28a19b1e)