### PR TITLE
Skip configs with null round2 barcodes when building round2 barcode FASTA

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -296,7 +296,7 @@ workflow {
   }.mix(
     Channel.fromList(round2_run_ids).map { run_id ->
       def barcodeIdsInRun = run_sample_configs
-        .findAll { it.run_id == run_id }
+        .findAll { cfg -> cfg.run_id == run_id && cfg.barcode_ids_round2_parsed != null }
         .collectMany { cfg -> cfg.barcode_ids_round2_parsed.ids }
         .toSet()
         .toList()


### PR DESCRIPTION
### Motivation
- Ensure only sample configs that actually have parsed round‑2 barcodes are included when building the round‑2 barcode FASTA to avoid null accesses and incorrect/empty FASTA entries.

### Description
- Updated the `findAll` predicate used to collect round‑2 barcode IDs to `findAll { cfg -> cfg.run_id == run_id && cfg.barcode_ids_round2_parsed != null }`, so only configs with `barcode_ids_round2_parsed` present are processed.

### Testing
- Ran the pipeline input-channel generation with a small test config via `nextflow` (test profile) to verify the round‑2 FASTA generation path and observed the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d3d9211fe4832188645f716eee0b09)