### PR TITLE
Preserve run ordering when merging aligned sample BAMs

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -503,12 +503,24 @@ workflow {
   // mergeAlignedSampleBAMs
   //******************
 
+  // Preserve run ordering from params.runs so merge order matches the YAML configuration
+  run_id_order = params.runs.collectEntries { run, idx -> [(run.run_id): idx] }
+
   // Create input channel
   mergeAlignedSampleBAMs_input_ch = pbmm2Align.out
     .map { run_id, individual_id, sample_id, barcode_id, bamFile, pbiFile ->
-        tuple(individual_id, sample_id, bamFile, pbiFile)
+        tuple(individual_id, sample_id, run_id_order[run_id], bamFile, pbiFile)
     }
     .groupTuple(by: [0, 1]) // Group by individual_id, sample_id
+    .map { individual_id, sample_id, run_order, bamFiles, pbiFiles ->
+      def ordered = [run_order, bamFiles, pbiFiles].transpose().sort { it[0] }
+      tuple(
+        individual_id,
+        sample_id,
+        ordered.collect { it[1] },
+        ordered.collect { it[2] }
+      )
+    }
 
   // Run process
   mergeAlignedSampleBAMs(mergeAlignedSampleBAMs_input_ch)


### PR DESCRIPTION
### Motivation

- Ensure that the order used to merge aligned sample BAMs follows the `params.runs` YAML configuration so merged inputs are deterministic and predictable.
- Prevent nondeterministic ordering introduced by grouping channels which could reorder BAMs across runs.
- Keep downstream `mergeAlignedSampleBAMs` behavior consistent with user-configured run order.

### Description

- Build a `run_id_order` map from `params.runs` using `params.runs.collectEntries` to assign each `run_id` an index.
- Add the run order index into the tuples emitted from `pbmm2Align.out` and include it in the `groupTuple` grouping key.
- Reorder the grouped `bamFiles` and `pbiFiles` by the run-order index using a `.map` that transposes and sorts by the index before passing the ordered lists to `mergeAlignedSampleBAMs`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d46d6036ec8321b3798abe5ec93fdd)