### PR TITLE
Fix params.runs indexing in mergeAlignedSampleBAMs setup

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -504,7 +504,7 @@ workflow {
   //******************
 
   // Preserve run ordering from params.runs so merge order matches the YAML configuration
-  run_id_order = params.runs.collectEntries { run, idx -> [(run.run_id): idx] }
+  run_id_order = params.runs.withIndex().collectEntries { run, idx -> [(run.run_id): idx] }
 
   // Create input channel
   mergeAlignedSampleBAMs_input_ch = pbmm2Align.out


### PR DESCRIPTION
### Motivation
- Prevent a Groovy `MissingMethodException` caused by passing a two-argument closure to `collectEntries` when `params.runs` yields single `ConfigMap` items, while keeping deterministic run ordering for sample BAM merging.

### Description
- Change `run_id_order = params.runs.collectEntries { run, idx -> [(run.run_id): idx] }` to `run_id_order = params.runs.withIndex().collectEntries { run, idx -> [(run.run_id): idx] }` in `main.nf` so the indexing is produced explicitly and safely.

### Testing
- Attempted automated validation by running `nextflow -version` but `nextflow` is not installed in this environment, so the patch was verified by code inspection and a local `git` commit; no pipeline execution tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d4743856ec83219bbcbc18230a85e2)