### PR TITLE
Treat `bc` as strand-specific field; move `bc` column in calls and update output schema/docs

### DIFF
--- a/bin/calculateBurdens.R
+++ b/bin/calculateBurdens.R
@@ -776,7 +776,7 @@ indel_cols_discard <- c(
 
 #Define columns that are identical between zm and strands to either '_keep' or '_discard' in the subsequent pivot_wider for SBSindel_call_type == "mutation" call tables. Not including call_class, call_type, SBSindel_call_type as these are removed from finalCalls after the below nest_join.
 zm_identical_cols_keep <- c(
-	"analysis_chunk", "run_id", "zm", "bc"
+	"analysis_chunk", "run_id", "zm"
 )
 
 strand_identical_cols_keep <- c(
@@ -786,7 +786,7 @@ strand_identical_cols_keep <- c(
 )
 
 strand_identical_cols_discard <- c(
-	"strand",
+	"bc", "strand",
 	"call_class.opposite_strand", "call_type.opposite_strand",
 	"alt_plus_strand.opposite_strand"
 )

--- a/bin/extractCalls.R
+++ b/bin/extractCalls.R
@@ -367,9 +367,9 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
   #Initialize empty calls tibble
   calls.out <- tibble(
     zm=integer(),
+    bc=factor(),
     seqnames=factor(),
     strand=factor(),
-    bc=factor(),
     start_queryspace=integer(),
     end_queryspace=integer(),
     start_refspace=integer(),
@@ -940,7 +940,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
         distinct(zm, strand, bc),
       by = join_by(zm, strand)
     ) %>%
-    relocate(bc, .after = strand)
+    relocate(bc, .after = zm)
 
   #Set call_class and call_type
   calls.out <- calls.out %>%

--- a/bin/outputResults.R
+++ b/bin/outputResults.R
@@ -604,15 +604,15 @@ cat("## Outputting germline variant calls...")
 #Define columns that are identical between strands to either '_keep' or '_discard' in the subsequent pivot_wider.
 strand_identical_cols_keep <- c(
 	"analysis_id", "individual_id", "sample_id", "chromgroup", "filtergroup",
-	"analysis_chunk", "run_id", "zm", "bc",
 	"call_class", "call_type", "SBSindel_call_type",
+	"analysis_chunk", "run_id", "zm",
 	"seqnames", "start_refspace", "end_refspace", "ref_plus_strand", "alt_plus_strand",
 	"reftnc_plus_strand", "alttnc_plus_strand", "reftnc_pyr", "alttnc_pyr",
 	"indel_width"
 )
 
 strand_identical_cols_discard <- c(
-	"refstrand",
+	"bc", "refstrand",
 	"call_class.opposite_strand", "call_type.opposite_strand",
 	"alt_plus_strand.opposite_strand",
 	"deletion.bothstrands.startendmatch", "MDB_score"

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -183,9 +183,9 @@ The pipeline emits four artefacts per call subtype:
 
 - **`finalCalls.tsv`** — Strand-level mismatch tables and per-mutation SBS/indel tables share a common schema:
   - Shared identifiers: `analysis_id`, `individual_id`, `sample_id`, `chromgroup`, `filtergroup`, `call_class`, `call_type`, `SBSindel_call_type`, `analysis_chunk`.
-  - Molecule identifiers and coordinates in reference space: `run_id`, `zm`, `bc`, `seqnames`, `start_refspace`, `end_refspace` (`bc` is stored as comma-separated `forward,reverse` barcode indices).
+  - Molecule identifiers and coordinates in reference space: `run_id`, `zm`, `seqnames`, `start_refspace`, `end_refspace`.
   - Alleles: `ref_plus_strand`, `alt_plus_strand`
-  - Strand-specific coordinates in query space (i.e., read coordinates), quality metrics, and additional sequence information: `start_queryspace`, `end_queryspace`, `qual`, `sa`, `sm`, `sx`, `ref_synthesized_strand`, `ref_template_strand`, `alt_synthesized_strand`, `alt_template_strand`. Measurements for multi-base calls, such as `qual` are stored as comma-delimited values for every base. SBS and indel mutation call tables are pivoted to one row per mutation with these strand-specific columns suffixed with `_refstrand_plus_read` and `_refstrand_minus_read`. Non-mutation (i.e., single-strand) call types remain one row per call with a `refstrand` column annotating to which reference strand the call's read aligned.
+  - Strand-specific coordinates in query space (i.e., read coordinates), quality metrics, and additional sequence information: `bc` (comma-separated `forward,reverse` barcode indices), `start_queryspace`, `end_queryspace`, `qual`, `sa`, `sm`, `sx`, `ref_synthesized_strand`, `ref_template_strand`, `alt_synthesized_strand`, `alt_template_strand`. Measurements for multi-base calls, such as `qual` are stored as comma-delimited values for every base. SBS and indel mutation call tables are pivoted to one row per mutation with these strand-specific columns suffixed with `_refstrand_plus_read` and `_refstrand_minus_read`. Non-mutation (i.e., single-strand) call types remain one row per call with a `refstrand` column annotating to which reference strand the call's read aligned.
   - Trinucleotide context (SBS and MDB tables only):
     - `reftnc_plus_strand` and `alttnc_plus_strand` — reference and call trinucleotide sequence at the call position on the reference genome plus strand.
     - `reftnc_pyr` and `alttnc_pyr`— reference and call trinucleotide sequences collapsed to central pyrimidine trinucleotide sequences.
@@ -210,7 +210,7 @@ The pipeline produces two files:
 
 - `germlineVariantCalls.tsv` — Final germline calls that passed all non-germline filters, with one row per mutation. Columns are grouped as follows:
   - Shared identifiers: `analysis_id`, `individual_id`, `sample_id`, `chromgroup`, `filtergroup`, `call_class`, `call_type`, `SBSindel_call_type`, `analysis_chunk`.
-  - Molecule identifiers and coordinates in reference space: `run_id`, `zm`, `bc`, `seqnames`, `start_refspace`, `end_refspace` (`bc` is stored as comma-separated `forward,reverse` barcode indices).
+  - Molecule identifiers and coordinates in reference space: `run_id`, `zm`, `seqnames`, `start_refspace`, `end_refspace`.
   - Alleles and trinucleotide context: `ref_plus_strand`, `alt_plus_strand`, `reftnc_plus_strand`, `alttnc_plus_strand`, `reftnc_pyr`, `alttnc_pyr`.
   - Strand-specific coordinates in query space (i.e., read coordinates), quality metrics, and additional sequence information, with `_refstrand_plus_read` / `_refstrand_minus_read` suffixes: `start_queryspace`, `end_queryspace`, `qual`, `sa`, `sm`, `sx`, `ref_synthesized_strand`, `ref_template_strand`, `alt_synthesized_strand`, `alt_template_strand`, `reftnc_synthesized_strand`, `reftnc_template_strand`, `alttnc_synthesized_strand`, `alttnc_template_strand`.
   - Indel width: `indel_width` for indel calls.
@@ -329,10 +329,10 @@ Unified table of all call types across all chromgroups and filtergroups, with on
 | Column | Description |
 | --- | --- |
 | `analysis_id`, `individual_id`, `sample_id`, `chromgroup`, `filtergroup`, `call_class`, `call_type`, `SBSindel_call_type` | Call metadata. |
-| `analysis_chunk`, `run_id`, `zm`, `bc` | Chunk identifier, sequencing run ID, ZMW hole number, and barcode pair indices from the last round of demultplexing, encoded as a comma-separated `forward,reverse` index pair. |
-| `seqnames`, `start_refspace`, `end_refspace` | Reference contig and reference space 1-based coordinates. |
+| `analysis_chunk`, `run_id`, `zm` | Chunk identifier, sequencing run ID, and ZMW hole number. |
+| `bc`, `seqnames`, `refstrand` | Barcode pair indices from the last round of demultplexing (encoded as a comma-separated `forward,reverse` index pair), reference contig, and reference genome strand that the read aligned to which supplied the call (`+` or `-`). |
+| `start_refspace`, `end_refspace` | Reference space 1-based coordinates. |
 | `ref_plus_strand`, `alt_plus_strand` | Reference genome forward strand reference and alternate allele sequences. |
-| `refstrand` | Reference genome strand that the read aligned to which supplied the call (`+` or `-`). |
 | `start_queryspace`, `end_queryspace` | Query-space 1-based coordinates. |
 | `qual`, `qual.opposite_strand` | Base qualities of the call and on the opposite strand per reference space alignment coordinates (Phred values; list of values for each call, as some calls span multiple bases). |
 | `sa`, `sa.opposite_strand` | Subread coverage of the call and on the opposite strand per reference space alignment coordinates (list of values for each call, as some calls span multiple bases). |


### PR DESCRIPTION
### Motivation

- Ensure the barcode (`bc`) is treated as a strand-specific/read-level field rather than as a field identical between strands, to reflect how barcodes are derived from individual reads. 

### Description

- Move the `bc` column in the callers pipeline so it is emitted adjacent to `zm` in the `calls` tibble and relocated with `relocate(bc, .after = zm)` in `bin/extractCalls.R`.
- Update the lists of columns kept/discarded during pivoting in `bin/calculateBurdens.R` and `bin/outputResults.R` to remove `bc` from the set of strand-identical columns and add it to strand-discard/strand-specific lists as appropriate.
- Update the `docs/outputs.md` documentation to reflect the new schema for `finalCalls` and germline outputs (move `bc` into the strand-specific/query-space section and update column descriptions accordingly).
- Minor EOF newline normalizations in `bin/calculateBurdens.R` and `bin/outputResults.R`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d5a638cf6c832192ba8978c1df44bd)