### PR TITLE
Adjust strandwise spectrum legend spacing

### DIFF
--- a/bin/sharedFunctions.R
+++ b/bin/sharedFunctions.R
@@ -2081,10 +2081,10 @@ plot_spectrum_tsw <- function(spec, lwr, upr, name, max_y, colors, boxes) {
                  ytop = samp_max_y, col = COLORS[j], border = "white")
         }
         # Plot legend
-        legend("topright", bty = "n", inset = c(0.016, 0.03),
+        legend("topright", bty = "n", inset = c(0.008, 0.03),
                legend = c("Central pyrimidine", "Central purine"),
                cex = 2.1, fill = NA, border = NA)
-        legend("topright", bty = "n", inset = c(0.115, 0.03), pch=15, pt.cex=3.75,
+        legend("topright", bty = "n", inset = c(0.135, 0.03), pch=15, pt.cex=3.75,
                col=STRANDCOL, legend = c("", ""), cex = 2.1)
         # Plot spectrum bars
         bars <- barplot(rbind(spec[i, 1:(NCAT/2)],


### PR DESCRIPTION
### Motivation
- Prevent overlap between the "Central pyrimidine" / "Central purine" labels and the colored legend boxes in the strandwise/template-strand spectrum plot by making a very small positional adjustment to the legend elements.

### Description
- In `bin/sharedFunctions.R` inside `plot_spectrum_tsw`, adjusted the legend `inset` x-values to nudge the text and colored square markers slightly apart by changing the text legend `inset` from `c(0.016, 0.03)` to `c(0.008, 0.03)` and the marker legend `inset` from `c(0.115, 0.03)` to `c(0.135, 0.03)`.

### Testing
- No automated tests were run because this is a small visual layout tweak to plotting code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8e48aac408321826fef13c33168f9)