### PR TITLE
[codex] Forge BSgenome from configured FASTA

### DIFF
--- a/bin/calculateBurdens.R
+++ b/bin/calculateBurdens.R
@@ -23,6 +23,11 @@ suppressPackageStartupMessages(library(qs2))
 suppressPackageStartupMessages(library(tidyverse))
 
 ######################
+### Load custom shared functions
+######################
+source(Sys.which("sharedFunctions.R"))
+
+######################
 ### Load configuration
 ######################
 cat("## Loading configuration...\n")
@@ -58,9 +63,10 @@ chromgroup_toanalyze <- opt$chromgroup_toanalyze
 filtergroup_toanalyze <- opt$filtergroup_toanalyze
 filterCallsFiles <- opt$files %>% str_split_1(",") %>% str_trim
 outputFile <- opt$output
+BSgenome_name <- get_bsgenome_name(yaml.config)
 
 #Load the BSgenome reference
-suppressPackageStartupMessages(library(yaml.config$BSgenome$BSgenome_name,character.only=TRUE,lib.loc=yaml.config$cache_dir))
+suppressPackageStartupMessages(library(BSgenome_name,character.only=TRUE,lib.loc=yaml.config$cache_dir))
 
 #Load miscellaneous configuration parameters
  #chromosomes to analyze
@@ -111,11 +117,6 @@ cat("    chromgroup:",chromgroup_toanalyze,"\n")
 cat("    filtergroup:",filtergroup_toanalyze,"\n")
 
 cat("DONE\n")
-
-######################
-### Load custom shared functions
-######################
-source(Sys.which("sharedFunctions.R"))
 
 ######################
 ### Define custom functions
@@ -171,7 +172,7 @@ indel_labels.sigfit <- c(
 #Function to sum two RleLists, including handling of chromosomes only present in one of the RleLists.
 sum_RleList <- function(a, b) {
 	seqs_union <- union(names(a), names(b))
-	
+
 	seqs_union %>%
 		map(function(nm){
 			seq_in_a <- nm %in% names(a)
@@ -199,43 +200,43 @@ sum_bam.gr.filtertracks <- function(bam.gr.filtertrack1, bam.gr.filtertrack2=NUL
 					map_lgl(function(x){
 						x_plus <- x %>% filter(strand == "+")
 						x_minus <- x %>% filter(strand == "-")
-						
+
 						return(identical(ranges(x_plus), ranges(x_minus)) & identical(mcols(x_plus), mcols(x_minus)))
 					})
 			) %>%
 			pull(plus_minus_identical) %>%
 			all
 	}
-	
+
 	#Helper function to calculate coverage from both strands and then divide by two to get duplex coverage
 	calc_duplex_coverage <- function(gr){
 		cov <- gr %>% coverage
-		
+
 		#Confirm all values are even integers
 		if((cov %% 2L != 0L) %>% any %>% any){
 			stop("Non-even strand coverage in bam.gr.filtertrack!")
 		}
-		
+
 		return(cov %/% 2L)
 	}
-	
+
 	if(is.null(bam.gr.filtertrack2)){
 		if(! bam.gr.filtertrack1 %>% is_plus_minus_identical){
 			stop("Mismatched plus and minus strand ranges in bam.gr.filtertrack!")
 		}
-		
+
 		bam.gr.filtertrack1 %>%
 			mutate(
 				bam.gr.filtertrack.coverage = bam.gr.filtertrack %>%
 					map(function(x){x %>% calc_duplex_coverage})
 			) %>%
 			select(-bam.gr.filtertrack)
-		
+
 	}else{
 		if(! bam.gr.filtertrack2 %>% is_plus_minus_identical){
 			stop("Mismatched plus and minus strand ranges in bam.gr.filtertrack!")
 		}
-		
+
 		bam.gr.filtertrack1 %>%
 			left_join(
 				bam.gr.filtertrack2 %>%
@@ -260,24 +261,24 @@ sum_bam.gr.filtertracks <- function(bam.gr.filtertrack1, bam.gr.filtertrack2=NUL
 
 #Function to extract coverage for a GRanges object with only 1 bp ranges from a SimpleRleList coverage object. Coverage = 0 for seqnames in the GRanges that are not in the coverage object.
 gr_1bp_cov <- function(gr, cov){
-	
+
 	stopifnot(all(width(gr) == 1))
-	
+
 	n <- length(gr)
 	result <- rep.int(0, n) #pre-fill zeros
 	chr <- gr %>% seqnames %>% as.character
 	pos <- gr %>% start
-	
+
 	# indices per chromosome (keeps order in 'gr')
 	idx_by_chr <- split(seq_len(n), chr)
-	
+
 	for (ch in names(idx_by_chr)) {
 		idx <- idx_by_chr[[ch]]
 		if (ch %in% names(cov)){
 			result[idx] <- cov[[ch]][pos[idx]]
 		}
 	}
-	
+
 	return(result)
 }
 
@@ -293,15 +294,15 @@ molecule_stats <- list()
 
 #Loop over all filterCallsFiles
 for(i in seq_along(filterCallsFiles)){
-	
+
 	#Extract analysis chunk number for logging in case filterCallsFiles are not supplied in order
 	analysis_chunk_num <- filterCallsFiles[i] %>% str_extract("(?<=chunk)\\d+")
-		
+
 	cat(" ", analysis_chunk_num, sep="")
-	
+
 	#Load filterCallsFile
 	filterCallsFile <- qs_read(filterCallsFiles[i])
-	
+
 	#Load basic configuration only from first chunk, since identical in all chunks.
 	if(i == 1){
 		#Basic configuration parameters
@@ -309,7 +310,7 @@ for(i in seq_along(filterCallsFiles)){
 		genome_chromgroup.gr <- filterCallsFile %>% pluck("config","genome_chromgroup.gr")
 		region_read_filters_config <- filterCallsFile %>% pluck("config","region_read_filters_config")
 		region_genome_filters_config <- filterCallsFile %>% pluck("config","region_genome_filters_config")
-		
+
 		#germline-related filters that are excluded when calculating sensitivity
 		germline_filters <- c(
 			"germline_vcf.passfilter",
@@ -327,7 +328,7 @@ for(i in seq_along(filterCallsFiles)){
 				basename %>%
 				str_c("region_genome_filter_",.,".passfilter")
 		)
-		
+
 		#region_genome_filter_stats
 		region_genome_filter_stats <- filterCallsFile %>% pluck("region_genome_filter_stats")
 	}
@@ -338,7 +339,7 @@ for(i in seq_along(filterCallsFiles)){
 		filter(
 			if_all(contains("passfilter"), ~ .x == TRUE)
 		)
-	
+
 	#Load germline variant calls that pass all filters ignoring the germline filters, since we will later also need the calls filtered by germline filters to calculate sensitivity
 	germlineVariantCalls[[i]] <- filterCallsFile %>%
 		pluck("calls") %>%
@@ -348,23 +349,23 @@ for(i in seq_along(filterCallsFiles)){
 			if_all(contains("passfilter") & !all_of(germline_filters), ~ .x == TRUE), #All non-germline filters == TRUE
 			germline_vcf.passfilter == FALSE #Detected in at least one germline VCF
 		)
-	
+
 	#Filtered duplex read coverage of the genome, with and without germline_filters
 	if(i == 1){
 		bam.gr.filtertrack.bytype <- sum_bam.gr.filtertracks(
 			filterCallsFile %>% pluck("bam.gr.filtertrack.bytype")
 		)
-		
+
 		bam.gr.filtertrack.except_germline_filters.bytype <- sum_bam.gr.filtertracks(
 			filterCallsFile %>% pluck("bam.gr.filtertrack.except_germline_filters.bytype")
 		)
-		
+
 	}else{
 		bam.gr.filtertrack.bytype <- sum_bam.gr.filtertracks(
 			bam.gr.filtertrack.bytype,
 			filterCallsFile %>% pluck("bam.gr.filtertrack.bytype")
 		)
-		
+
 		bam.gr.filtertrack.except_germline_filters.bytype <- sum_bam.gr.filtertracks(
 			bam.gr.filtertrack.except_germline_filters.bytype,
 			filterCallsFile %>% pluck("bam.gr.filtertrack.except_germline_filters.bytype")
@@ -373,7 +374,7 @@ for(i in seq_along(filterCallsFiles)){
 
 	#molecule_stats
 	molecule_stats[[i]] <- filterCallsFile %>% pluck("molecule_stats")
-	
+
 	#Remove temporary objects
 	rm(filterCallsFile)
 	invisible(gc())
@@ -428,33 +429,33 @@ bam.gr.filtertrack.bytype %>%
 	pwalk(
 		function(...){
 			x <- list(...)
-			
+
 			output_file <- str_c(x$row_id,".bed")
 			if(file.exists(output_file)){file.remove(output_file)}
 			file.create(output_file)
-			
+
 			x$bam.gr.filtertrack.coverage %>%
 				iwalk(
 					function(rle, seqname){
 						lens <- rle %>% runLength
 						vals <- rle %>% runValue
 						n <- lens %>% length
-						
+
 						offset <- 0L
-						
+
 						for(lo in seq.int(1L, n, by = chunk_runs)){
 							hi <- min(lo + chunk_runs - 1L, n)
 							len_slice <- lens[lo:hi]
 							val_slice <- vals[lo:hi]
-							
+
 							nz <- which(val_slice != 0L)
 							if(length(nz) == 0){
 								offset <- offset + sum(len_slice)
 								next
 							}
-							
+
 							ends_chunk <- offset + cumsum(len_slice)
-							
+
 							starts_chunk_sub <- ends_chunk[nz]
 							gt1 <- nz > 1L
 							if(any(gt1)){starts_chunk_sub[gt1] <- ends_chunk[nz[gt1] - 1L]}
@@ -467,9 +468,9 @@ bam.gr.filtertrack.bytype %>%
 								value = val_slice[nz]
 							) %>%
 								data.table::fwrite(output_file, sep="\t", col.names = FALSE, append = TRUE, showProgress = FALSE)
-							
+
 							offset <- ends_chunk[length(ends_chunk)]
-							
+
 							invisible(gc())
 						}
 					}
@@ -489,18 +490,18 @@ paste(
 	"| cut -f2- |",
 	yaml.config$bedtools_bin,"merge -i stdin > all.bed"
 ) %>%
-	system2(command="/bin/bash", args="-s", input=.) %>% 
+	system2(command="/bin/bash", args="-s", input=.) %>%
 	invisible
 
 #Expand to per-base coverage runs and annotate with genome trinucleotide sequences
-genome_trinuc_file <- str_c(yaml.config$cache_dir,"/",yaml.config$BSgenome$BSgenome_name, ".bed.gz")
+genome_trinuc_file <- str_c(yaml.config$cache_dir,"/",BSgenome_name, ".bed.gz")
 
 paste(
 	yaml.config$bedtools_bin, "makewindows -w 1 -b all.bed |",
 	yaml.config$bedtools_bin, "intersect -sorted -loj -wa -wb -a stdin -b",genome_trinuc_file, "-g", yaml.config$genome_fai,
 	"| cut -f 1-3,7 > all.trinuc.bed"
 ) %>%
-	system2(command="/bin/bash", args="-s", input=.) %>% 
+	system2(command="/bin/bash", args="-s", input=.) %>%
 	invisible
 
 file.remove("all.bed") %>% invisible
@@ -511,7 +512,7 @@ bam.gr.filtertrack.bytype %>%
 	pwalk(
 		function(...){
 			x <- list(...)
-			
+
 			cov_output_file <- str_c(
 				yaml.config$analysis_id,
 				individual_id,
@@ -525,7 +526,7 @@ bam.gr.filtertrack.bytype %>%
 				"bed.gz",
 				sep="."
 			)
-			
+
 			paste(
 				yaml.config$bedtools_bin, "intersect -sorted -wa -wb",
 				"-a", str_c(x$row_id,".bed"), "-b all.trinuc.bed",
@@ -544,9 +545,9 @@ bam.gr.filtertrack.bytype %>%
 				"&&",
 				yaml.config$tabix_bin, "-@2 -s1 -b2 -e3", cov_output_file
 			) %>%
-				system2(command="/bin/bash", args="-s", input=.) %>% 
+				system2(command="/bin/bash", args="-s", input=.) %>%
 				invisible
-			
+
 			file.remove(str_c(x$row_id,".bed")) %>% invisible
 		}
 	)
@@ -572,7 +573,7 @@ if(
 		"bed.gz",
 		sep="."
 	)
-	
+
 	file.remove(cov_output_file, str_c(cov_output_file,".tbi")) %>% invisible
 }
 
@@ -596,7 +597,7 @@ bam.gr.filtertrack.bytype <- bam.gr.filtertrack.bytype %>%
 		name = "bam.gr.filtertrack.reftnc_plus_strand"
 	) %>%
 	select(-row_id) %>%
-	
+
 	mutate(
 		bam.gr.filtertrack.reftnc_minus_strand = bam.gr.filtertrack.reftnc_plus_strand %>%
 			map(function(x){
@@ -626,7 +627,7 @@ bam.gr.filtertrack.bytype <- bam.gr.filtertrack.bytype %>%
 					rename(reftnc_pyr = reftnc) %>%
 					mutate(fraction = count / sum(count))
 			}),
-		
+
 		bam.gr.filtertrack.reftnc_both_strands = map2(
 			bam.gr.filtertrack.reftnc_plus_strand,
 			bam.gr.filtertrack.reftnc_minus_strand,
@@ -644,7 +645,7 @@ bam.gr.filtertrack.bytype <- bam.gr.filtertrack.bytype %>%
 #Calculate trinucleotide distributions of the whole genome and of the genome in the analyzed chromgroup
  #Function to extract trinucleotide distribution for selected chromosomes
 get_genome_reftnc <- function(BSgenome_name, chroms){
-	
+
 	reftnc_plus_strand <- BSgenome_name %>%
 		get %>%
 		getSeq(chroms) %>%
@@ -652,7 +653,7 @@ get_genome_reftnc <- function(BSgenome_name, chroms){
 		trinucleotideFrequency(simplify.as = "collapsed") %>%
 		enframe(name = "reftnc", value = "count") %>%
 		mutate(reftnc = reftnc %>% factor(levels = trinucleotides_64))
-	
+
 	reftnc_minus_strand <- reftnc_plus_strand %>%
 		mutate(
 			reftnc = reftnc %>%
@@ -667,7 +668,7 @@ get_genome_reftnc <- function(BSgenome_name, chroms){
 		rename(reftnc_pyr = reftnc) %>%
 		filter(!is.na(reftnc_pyr)) %>%
 		mutate(fraction = count / sum(count))
-	
+
 	reftnc_both_strands <- bind_rows(
 		reftnc_plus_strand,
 		reftnc_minus_strand
@@ -677,7 +678,7 @@ get_genome_reftnc <- function(BSgenome_name, chroms){
 		arrange(reftnc) %>%
 		filter(!is.na(reftnc)) %>%
 		mutate(fraction = count / sum(count))
-	
+
 	return(
 		list(
 			reftnc_pyr = reftnc_pyr,
@@ -688,13 +689,13 @@ get_genome_reftnc <- function(BSgenome_name, chroms){
 
 	#Whole genome
 genome.reftnc <- get_genome_reftnc(
-	BSgenome_name = yaml.config$BSgenome$BSgenome_name,
-	chroms = yaml.config$BSgenome$BSgenome_name %>% get %>% seqnames
+	BSgenome_name = BSgenome_name,
+	chroms = BSgenome_name %>% get %>% seqnames
 	)
 
  #genome in the analyzed chromgroup
 genome_chromgroup.reftnc <- get_genome_reftnc(
-	BSgenome_name = yaml.config$BSgenome$BSgenome_name,
+	BSgenome_name = BSgenome_name,
 	chroms = chroms_toanalyze
 )
 
@@ -719,7 +720,7 @@ bam.gr.filtertrack.bytype <- bam.gr.filtertrack.bytype %>%
 						)
 				}
 			),
-		
+
 		bam.gr.filtertrack.reftnc_both_strands = bam.gr.filtertrack.reftnc_both_strands %>%
 			map(
 				function(x){
@@ -736,14 +737,14 @@ bam.gr.filtertrack.bytype <- bam.gr.filtertrack.bytype %>%
 						)
 				}
 			),
-		
+
 		across(
 			starts_with("bam.gr.filtertrack.reftnc"),
 			function(x){
 				x %>%
 					map(
 						function(y){
-							y %>% 
+							y %>%
 								mutate(
 									fraction_ratio_to_genome = fraction / fraction.genome,
 									fraction_ratio_to_genome_chromgroup = fraction / fraction.genome_chromgroup
@@ -800,10 +801,10 @@ strand_redundant_cols_discard <- c(
 
 #Nest_join finalCalls for each call_class x call_type x SBSindel_call_type combination, and add SBS/mismatch-ss if not in call_types_toanalyze for downstream SBS mutation error rate calculation, and collapse to distinct calls ignoring strand for call_class = "SBS" and "indel" with SBSindel_call_type = "mutation" so that each of these events is only counted once, while all other SBS and indel SBSindel_call_types and all MDB SBSindel_call_types will be counted once for each strand on which they occur. Also extract unique calls for SBSindel_call_type = "mutation". Then convert to a table formatted for tsv output. Before the nest join, remove "germline_vcf_types_detected", "germline_vcf_files_detected", and "passfilter" columns as these are empty, empty, and TRUE, respectively for all finalCalls. Used for burden, spectra, and vcf output.
 finalCalls.bytype <- call_types_toanalyze %>%
-	
+
 	#remove columns that are not needed here
 	select(-analyzein_chromgroups, -starts_with("MDB")) %>%
-	
+
 	#Add row for SBS/mismatch-ss
 	bind_rows(
 		tibble(
@@ -814,7 +815,7 @@ finalCalls.bytype <- call_types_toanalyze %>%
 		)
 	) %>%
 	distinct %>%
-	
+
 	#Nest join finalCalls
 	nest_join(
 		finalCalls %>%
@@ -830,7 +831,7 @@ finalCalls.bytype <- call_types_toanalyze %>%
 		by = join_by(call_class, call_type, SBSindel_call_type),
 		name = "finalCalls"
 	) %>%
-	
+
 	#Discard columns that are not needed for each call_class
 	mutate(
 		finalCalls = map2(
@@ -846,17 +847,17 @@ finalCalls.bytype <- call_types_toanalyze %>%
 			}
 		)
 	) %>%
-	
+
 	#Make tables for tsv and vcf output
 	mutate(
-		
+
 		#Calls for tsv output
 		finalCalls_for_tsv = if_else(
 			call_class %in% c("SBS","indel") & SBSindel_call_type == "mutation",
 			finalCalls %>% map(
 				function(x){
 					x %>%
-						
+
 						#Change strand levels so that new column names after pivot_wider have suffixes ref_strand_(plus/minus)_read instead of +/-.
 						mutate(
 							strand = strand %>%
@@ -865,7 +866,7 @@ finalCalls.bytype <- call_types_toanalyze %>%
 									refstrand_minus_read = "-"
 								)
 						) %>%
-						
+
 						#Collapse to one row per mutation
             pivot_wider(
               id_cols = any_of(c(zm_identical_cols_keep, strand_identical_cols_keep)),
@@ -878,7 +879,7 @@ finalCalls.bytype <- call_types_toanalyze %>%
 			),
 			finalCalls
 		),
-		
+
 		#Unique calls for tsv output
 		finalCalls_unique_for_tsv = if_else(
 			SBSindel_call_type == "mutation",
@@ -889,26 +890,26 @@ finalCalls.bytype <- call_types_toanalyze %>%
 			),
 			NA
 		),
-		
+
 		#Calls for vcf output
 		finalCalls_for_vcf = finalCalls_for_tsv %>% map(
 			function(x){
-				x %>% 
+				x %>%
 					normalize_indels_for_vcf(
-						BSgenome_name = yaml.config$BSgenome$BSgenome_name
+						BSgenome_name = BSgenome_name
 					)
 			}
 		),
-		
+
 		#Unique calls for vcf output
 		finalCalls_unique_for_vcf = if_else(
 			SBSindel_call_type == "mutation",
 			finalCalls_unique_for_tsv %>%
 				map(
 					function(x){
-						x %>% 
+						x %>%
 							normalize_indels_for_vcf(
-								BSgenome_name = yaml.config$BSgenome$BSgenome_name
+								BSgenome_name = BSgenome_name
 							)
 					}
 				),
@@ -925,7 +926,7 @@ finalCalls <- finalCalls %>%
 #Calculate trinucleotide counts and fractions for call_class = "SBS" and "MDB". For all call types (including SBS/mismatch-ss even if not in call_types_toanalyze, for downstream SBS mutation error calculation), calculate reftnc_pyr. For call_class "SBS" with SBSindel_call_type = "mutation", also calculate reftnc_pyr for unique calls, and for all other call types, calculate reftnc_template_strand.
 finalCalls.reftnc_spectra <- finalCalls.bytype %>%
 	mutate(
-		
+
 		finalCalls.reftnc_pyr = pmap(
 			list(call_class, finalCalls_for_tsv),
 			function(x,z){
@@ -941,7 +942,7 @@ finalCalls.reftnc_spectra <- finalCalls.bytype %>%
 				}
 			}
 		),
-		
+
 		finalCalls_unique.reftnc_pyr = pmap(
 			list(call_class, SBSindel_call_type, finalCalls_unique_for_tsv),
 			function(x,y,z){
@@ -957,7 +958,7 @@ finalCalls.reftnc_spectra <- finalCalls.bytype %>%
 				}
 			}
 		),
-		
+
 		finalCalls.reftnc_template_strand = pmap(
 			list(call_class, SBSindel_call_type, finalCalls_for_tsv),
 			function(x,y,z){
@@ -1004,7 +1005,7 @@ finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>%
 				}
 			}
 		),
-		
+
 		finalCalls_unique.reftnc_pyr_spectrum = pmap(
 			list(call_class, SBSindel_call_type, finalCalls_unique_for_tsv),
 			function(x,y,z){
@@ -1024,7 +1025,7 @@ finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>%
 				}
 			}
 		),
-		
+
 		finalCalls.reftnc_template_strand_spectrum = pmap(
 			list(call_class, SBSindel_call_type, finalCalls_for_tsv),
 			function(x,y,z){
@@ -1047,7 +1048,7 @@ finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>%
 	)
 
 #Extract indel spectra (only for mutations)
-BSgenome_for_indel.spectrum <- yaml.config$BSgenome$BSgenome_name %>%
+BSgenome_for_indel.spectrum <- BSgenome_name %>%
 	get %>%
 	getSeq
 
@@ -1070,7 +1071,7 @@ finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>%
 				}
 			}
 		),
-		
+
 		finalCalls_unique.refindel_spectrum = pmap(
 			list(call_class, SBSindel_call_type, finalCalls_unique_for_vcf),
 			function(x,y,z){
@@ -1096,16 +1097,16 @@ invisible(gc())
 #Calculate trinucleotide distributions and spectra of SBS and MDB calls corrected for genome and genome_chromgroup distributions. Note, when genome correction factors are 0, setting corrected count to 0 rather than NA. When the sum of counts is 0, setting the fraction to 0 instead of NA.
  #Helper function to annotate corrected counts and fractions
 annotate_corrected_counts_fractions <- function(df, cols, ref_col, annotation_type){
-	
+
 	expr_map <- list(
 		reftnc_pyr = expr(reftnc_pyr == reftnc_pyr),
 		reftnc_template_strand = expr(reftnc_template_strand == reftnc),
 		reftnc_pyr_channel = expr(reftnc_pyr_channel == reftnc_pyr),
 		reftnc_template_strand_channel = expr(reftnc_template_strand_channel == reftnc)
 	)
-	
+
 	join_by_expr <- expr_map %>% pluck(annotation_type)
-	
+
 	df %>%
 		mutate(
 			across(
@@ -1115,7 +1116,7 @@ annotate_corrected_counts_fractions <- function(df, cols, ref_col, annotation_ty
 						s, !!sym(ref_col),
 						function(x,y){
 							if (is.null(x)){return(x)}
-							
+
 							if(annotation_type == "reftnc_pyr_channel"){
 								x <- x %>%
 									mutate(
@@ -1131,7 +1132,7 @@ annotate_corrected_counts_fractions <- function(df, cols, ref_col, annotation_ty
 											factor(levels = trinucleotides_64)
 									)
 							}
-							
+
 							x %>% left_join(
 								y,
 								by = join_by(!!join_by_expr),
@@ -1191,19 +1192,19 @@ cat("## Calculating call burdens...")
 
 #Calculate number of interrogated base pairs (SBSindel_call_type = mutation) or bases (mismatch-ss, mismatch-ds, mismatch-os, match), for each call_type to analyze. Note, for mismatch-ds, each mismatch-ds is counted as 2 mismatches so burdens use interrogated bases rather than base pairs.
 finalCalls.burdens <- bam.gr.filtertrack.bytype %>%
-	
-	#Exclude SBS/mismatch-ss row if it was only added to bam.gr.filtertrack.bytype for downstream calculation of SBS mutation error probability. 
+
+	#Exclude SBS/mismatch-ss row if it was only added to bam.gr.filtertrack.bytype for downstream calculation of SBS mutation error probability.
 	semi_join(
 		call_types_toanalyze,
 		by = join_by(call_type, call_class, SBSindel_call_type, filtergroup)
 	) %>%
-	
+
 	mutate(
 		cov_sum = bam.gr.filtertrack.coverage %>%
 			map_dbl(function(x){
 					x %>% map_dbl(sum) %>% sum
 			}),
-		
+
 		interrogated_bases_or_bp = if_else(
 			SBSindel_call_type == "mutation",
 			cov_sum,
@@ -1226,7 +1227,7 @@ finalCalls.burdens <- finalCalls.burdens %>%
 					reftnc_corrected_reference = NA,
 					sensitivity_corrected = FALSE
 				),
-		
+
 			#Unique calls (only mutations)
 			finalCalls.bytype %>%
 				filter(!map_lgl(finalCalls_unique_for_tsv,is.null)) %>%
@@ -1254,7 +1255,7 @@ finalCalls.burdens <- finalCalls.burdens %>%
 #		unique_col_annotation: Label to give the unique_calls column in the resulting tibble
 get_burden_data <- function(x, y, reftnc_cols, ratio_col_suffix, unique_col_annotation){
 	df <- left_join(x, y, by = join_by(!!reftnc_cols))
-	
+
 	return(
 		tibble(
 			interrogated_bases_or_bp = df %>% pull(count.y) %>% sum,
@@ -1280,7 +1281,7 @@ finalCalls.reftnc_spectra.genome_correction.SBSmutations <- finalCalls.reftnc_sp
 finalCalls.burdens <- finalCalls.burdens %>%
 	bind_rows(
 		bind_rows(
-			
+
 			#Not unique calls, whole-genome corrected
 			finalCalls.reftnc_spectra.genome_correction.SBSmutations %>%
 				mutate(
@@ -1290,7 +1291,7 @@ finalCalls.burdens <- finalCalls.burdens %>%
 						function(x,y){get_burden_data(x,y,expr(reftnc_pyr==reftnc_pyr),"genome",FALSE)}
 					)
 				),
-				
+
 			#Unique calls, whole-genome corrected
 			finalCalls.reftnc_spectra.genome_correction.SBSmutations %>%
 				mutate(
@@ -1300,7 +1301,7 @@ finalCalls.burdens <- finalCalls.burdens %>%
 						function(x,y){get_burden_data(x,y,expr(reftnc_pyr==reftnc_pyr),"genome",TRUE)}
 					)
 				),
-				
+
 			#Not unique calls, genome chromgroup corrected
 			finalCalls.reftnc_spectra.genome_correction.SBSmutations %>%
 				mutate(
@@ -1310,7 +1311,7 @@ finalCalls.burdens <- finalCalls.burdens %>%
 							function(x,y){get_burden_data(x,y,expr(reftnc_pyr==reftnc_pyr),"genome_chromgroup",FALSE)}
 					)
 				),
-				
+
 			#Unique calls, genome chromgroup corrected
 			finalCalls.reftnc_spectra.genome_correction.SBSmutations %>%
 				mutate(
@@ -1338,7 +1339,7 @@ finalCalls.reftnc_spectra.genome_correction.SBSnonmutations <- finalCalls.reftnc
 finalCalls.burdens <- finalCalls.burdens %>%
 	bind_rows(
 		bind_rows(
-			
+
 			#Not unique calls, whole-genome corrected
 			finalCalls.reftnc_spectra.genome_correction.SBSnonmutations %>%
 				mutate(
@@ -1348,7 +1349,7 @@ finalCalls.burdens <- finalCalls.burdens %>%
 						function(x,y){get_burden_data(x,y,expr(reftnc_template_strand==reftnc),"genome",FALSE)}
 					)
 				),
-			
+
 			#Not unique calls, genome chromgroup corrected
 			finalCalls.reftnc_spectra.genome_correction.SBSnonmutations %>%
 				mutate(
@@ -1370,10 +1371,10 @@ invisible(gc())
 finalCalls.burdens <- finalCalls.burdens %>%
 	mutate(
 		ci = num_calls %>% map( function(x){cipoisson(x)} ),
-		
+
 		num_calls_lci = map_dbl(ci,1),
 		num_calls_uci = map_dbl(ci,2),
-		
+
 		burden_calls = num_calls / interrogated_bases_or_bp,
 		burden_calls_lci = num_calls_lci / interrogated_bases_or_bp,
 		burden_calls_uci = num_calls_uci / interrogated_bases_or_bp
@@ -1383,16 +1384,16 @@ finalCalls.burdens <- finalCalls.burdens %>%
 #Create sigfit-format finalCalls spectra tables
  #Helper function
 tibble_to_sigfit <- function(finalCalls_col, rowname_col, mode = c("pyr","template","indel"), value_col = NULL){
-				
+
 	map2(finalCalls_col, rowname_col, function(x,y){
 		if(is.null(x)){return(NULL)}
-		
+
 		result <- switch(
 			mode,
 			"pyr" = x %>%
 				select(channel, all_of(value_col)) %>%
 				pivot_wider(names_from = channel, values_from = all_of(value_col)),
-			
+
 			"template" = x %>%
 				mutate(
 					channel = if_else(
@@ -1408,7 +1409,7 @@ tibble_to_sigfit <- function(finalCalls_col, rowname_col, mode = c("pyr","templa
 				) %>%
 				select(channel, all_of(value_col)) %>%
 				pivot_wider(names_from = channel, values_from = all_of(value_col)),
-			
+
 			"indel" = x %>% indelspectrum.to.sigfit
 		) %>%
 			mutate(rowname = y) %>%
@@ -1425,7 +1426,7 @@ finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>%
 			call_class, call_type, SBSindel_call_type,
 			sep="."
 		),
-		
+
 		#reftnc_pyr spectra for all and unique calls
 		 #Not corrected
 		across(
@@ -1445,7 +1446,7 @@ finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>%
 			function(x){tibble_to_sigfit(x, .data[["rowname_col"]], mode = "pyr", value_col = "count_corrected_to_genome_chromgroup")},
 			.names = "{.col}.corrected_to_genome_chromgroup.sigfit"
 		),
-		
+
 		#reftnc_template_strand spectra for all calls
 		 #Not corrected
 		across(
@@ -1465,7 +1466,7 @@ finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>%
 			function(x){tibble_to_sigfit(x, .data[["rowname_col"]], mode = "template", value_col = "count_corrected_to_genome_chromgroup")},
 			.names = "{.col}.corrected_to_genome_chromgroup.sigfit"
 		),
-		
+
 		# indel spectra (all + unique)
 		across(
 			c(finalCalls.refindel_spectrum, finalCalls_unique.refindel_spectrum),
@@ -1499,9 +1500,9 @@ sensitivity <- call_types_toanalyze %>%
 
 #Create set of high-quality germline variants for sensitivity analysis if use_chromgroup is defined and is the current chromgroup
 if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_chromgroup == chromgroup_toanalyze){
-	
+
 	cat("## Calculating SBS and indel sensitivity...")
-	
+
 	#Count number of germline VCFs for the analyzed individual
 	num_germline_vcf_files <- yaml.config$individuals %>%
 		modify_tree(leaf = as.character) %>%
@@ -1512,16 +1513,16 @@ if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_
 		unnest_wider(germline_vcf_files) %>%
 		filter(individual_id == !!individual_id) %>%
 		nrow
-	
+
 	#Load sensitivity_vcf
 	sensitivity_vcf <- load_vcf(
 		vcf_file = sensitivity_parameters$sensitivity_vcf,
 		genome_fasta = yaml.config$genome_fasta,
-		BSgenome_name = yaml.config$BSgenome$BSgenome_name,
+		BSgenome_name = BSgenome_name,
 		bcftools_bin = yaml.config$bcftools_bin
 	) %>%
 		as_tibble
-	
+
 	#Load germline VCF variants and filter to retain high-confidence variants
 	high_confidence_germline_vcf_variants <- qs_read(
 		str_c(
@@ -1538,13 +1539,13 @@ if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_
 		)
 	) %>%
 		as_tibble %>%
-		
+
 		#Separate genotypes of each allele
 		separate_wider_delim(GT, regex("[^[:digit:].]"), names=c("GT1","GT2"), cols_remove = FALSE) %>%
-		
+
 		#Group by germline_vcf_file so that filters are calculated separately for each germline VCF.
-		group_by(germline_vcf_file) %>% 
-		
+		group_by(germline_vcf_file) %>%
+
 		#Filter per sensitivity_threshold settings
 		filter(
 			(Depth >= quantile(Depth, sensitivity_parameters$SBS_min_Depth_quantile) & call_class == "SBS") |
@@ -1561,29 +1562,29 @@ if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_
 				(sensitivity_parameters$genotype == "homozygous" & (GT1 == "1" & GT2 == "1"))
 		) %>%
 		ungroup %>%
-		
+
 		#Keep variants detected in all germline vcfs
 		count(seqnames, start, end, ref_plus_strand, alt_plus_strand, call_class, call_type, SBSindel_call_type) %>%
 		filter(n == !!num_germline_vcf_files) %>%
 		select(-n) %>%
-		
+
 		#Keep variants in chromgroup, and exclude variants in sex chromosomes and mitochondrial chromosome
 		filter(
 			seqnames %in% chroms_toanalyze,
 			! seqnames %in% sex_chromosomes,
 			! seqnames %in% mitochondrial_chromosome
 		) %>%
-		
+
 		#Keep variants in sensitivity_vcf
 		semi_join(
 			sensitivity_vcf,
 			by = names(.)
 		)
-	
+
 	rm(num_germline_vcf_files, sensitivity_vcf)
 	invisible(gc())
-	
-	#Annotate for each variant in high_confidence_germline_vcf_variants how many times it was detected in germlineVariantCalls, counting 1 for each zm in which it was detected. 
+
+	#Annotate for each variant in high_confidence_germline_vcf_variants how many times it was detected in germlineVariantCalls, counting 1 for each zm in which it was detected.
 	high_confidence_germline_vcf_variants <- high_confidence_germline_vcf_variants %>%
 		left_join(
 			germlineVariantCalls %>%
@@ -1597,7 +1598,7 @@ if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_
 			by = names(high_confidence_germline_vcf_variants)
 		) %>%
 		mutate(num_zm_detected = num_zm_detected %>% replace_na(0))
-	
+
 	#Annotate duplex coverage of high_confidence_germline_vcf_variants for each non-germline filter tracker. For insertions and deletions, annotate the minimum coverage at the left and right bases immediately flanking the insertion site/deleted bases.
 	#For high_confidence_germline_vcf_variants, change insertion and deletion ranges to span immediately flanking bases
 	high_confidence_germline_vcf_variants <- high_confidence_germline_vcf_variants %>%
@@ -1605,7 +1606,7 @@ if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_
 			start = if_else(call_class == "indel", start - 1, start),
 			end = if_else(call_class == "indel", end + 1, end)
 		)
-	
+
 	#Get coverage for start and end positions so that coverage is calculated for those bases specifically, and then set coverage to the minimum between these.
 	bam.gr.filtertrack.except_germline_filters.bytype <- bam.gr.filtertrack.except_germline_filters.bytype %>%
 		nest_join(high_confidence_germline_vcf_variants, by = "call_type") %>%
@@ -1614,12 +1615,12 @@ if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_
 				high_confidence_germline_vcf_variants,
 				bam.gr.filtertrack.coverage,
 				function(x,y){
-					
+
 					gr <- x %>%
 						makeGRangesFromDataFrame(
-							seqinfo = yaml.config$BSgenome$BSgenome_name %>% get %>% seqinfo
+							seqinfo = BSgenome_name %>% get %>% seqinfo
 						)
-					
+
 					x %>%
 						mutate(
 							duplex_coverage = pmin(
@@ -1634,18 +1635,18 @@ if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_
 				}
 			)
 		)
-	
-	#Join high_confidence_germline_vcf_variants.annotated to sensitivity tibble 
+
+	#Join high_confidence_germline_vcf_variants.annotated to sensitivity tibble
 	sensitivity <- sensitivity %>%
 		left_join(
 			bam.gr.filtertrack.except_germline_filters.bytype %>%
 				select(-bam.gr.filtertrack.coverage),
 			by = join_by(call_type, call_class, SBSindel_call_type, filtergroup)
 		)
-	
+
 	rm(high_confidence_germline_vcf_variants, bam.gr.filtertrack.except_germline_filters.bytype)
 	invisible(gc())
-	
+
 	#Sum number of high confidence germline VCF variant detections and coverage, and remove high_confidence_germline_vcf_variants that is no longer needed
 	sensitivity <- sensitivity %>%
 		mutate(
@@ -1653,43 +1654,43 @@ if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_
 				map_int( function(x){x$num_zm_detected %>% sum} ),
 			high_confidence_germline_vcf_variants_sum_duplex_coverage = high_confidence_germline_vcf_variants %>%
 				map_int( function(x){x$duplex_coverage %>% sum} )
-		) %>% 
+		) %>%
 		select(-high_confidence_germline_vcf_variants)
-	
+
 	#Calculate sensitivity.
-	#Calculate sensitivity only if number of high-confidence germline variant detections is above the configured minimum required, otherwise keep as default of 1. 
+	#Calculate sensitivity only if number of high-confidence germline variant detections is above the configured minimum required, otherwise keep as default of 1.
 	#If sensitivity_parameters$genotype = 'homozygous' (i.e. used only homozygous variants for sensitivity calculation): calculate sensitivity as sum(num_zm_detected) / sum(duplex_coverage)
 	#If sensitivity_parameters$genotype = 'heterozygous', calculate sensitivity as 2 * sum(num_zm_detected) / sum(duplex_coverage).
-	#Cap sensitivity to a max of 1, since it is possible to exceed 1 due to the above 'heterozygous' correction and edge cases. 
-	sensitivity <- sensitivity %>% 
+	#Cap sensitivity to a max of 1, since it is possible to exceed 1 due to the above 'heterozygous' correction and edge cases.
+	sensitivity <- sensitivity %>%
 		mutate(
-			
+
 			#Check based on thresholds if sensitivity should be calculated
 			calculate_sensitivity = (call_class == "SBS" &
 															 	high_confidence_germline_vcf_variants_sum_zm_detected >= sensitivity_parameters$SBS_min_variant_detections &
 															 	high_confidence_germline_vcf_variants_sum_duplex_coverage > 0) |
-				
+
 				(call_class == "indel" &
 				 	high_confidence_germline_vcf_variants_sum_zm_detected >= sensitivity_parameters$indel_min_variant_detections &
 				 	high_confidence_germline_vcf_variants_sum_duplex_coverage > 0),
-			
+
 			sensitivity = case_when(
 				calculate_sensitivity & sensitivity_parameters$genotype == "homozygous" ~
 					high_confidence_germline_vcf_variants_sum_zm_detected / high_confidence_germline_vcf_variants_sum_duplex_coverage,
-				
+
 				calculate_sensitivity & sensitivity_parameters$genotype == "heterozygous" ~
 					2 * (high_confidence_germline_vcf_variants_sum_zm_detected / high_confidence_germline_vcf_variants_sum_duplex_coverage),
-				
+
 				.default = sensitivity
 			),
-			
+
 			sensitivity = pmin(1, sensitivity),
-			
+
 			sensitivity_source = if_else(calculate_sensitivity, "calculated", sensitivity_source)
-			
+
 		) %>%
 		select(-calculate_sensitivity)
-	
+
 	#Change sensitivity to sqrt(sensitivity) for SBSindel_call_type = 'mismatch-ss' and 'mismatch-ds'. Do not do this transformation for SBSindel_call_type = 'mutation' since this involves detection in both strands. Although 'mismatch-ds' is detected in both strands, these are counted for burdens as two events for simplicity in output of mismatch-ds calls. SBSindel_call_type = 'mismatch-os' and 'match' are also not changed since these are for type MDB that is set in the yaml.config.
 	sensitivity <- sensitivity %>%
 		mutate(
@@ -1699,9 +1700,9 @@ if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_
 				sensitivity
 			)
 		)
-	
+
 	cat("DONE\n")
-	
+
 }else if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_chromgroup != chromgroup_toanalyze){
 	cat("## All non-MDB sensitivities set to NA since the currently analyzed chromgroup is not equal to sensitivity_parameters$use_chromgroup.\n")
 	sensitivity <- sensitivity %>%
@@ -1733,7 +1734,7 @@ estimatedSBSMutationErrorProbability_by_channel <- left_join(
 		filter(call_class=="SBS", SBSindel_call_type=="mismatch-ss") %>%
 		pluck("bam.gr.filtertrack.reftnc_both_strands",1) %>%
 		select(reftnc, count),
-	
+
 	by = "reftnc",
 	suffix = c(".calls",".interrogated_bases")
 ) %>%
@@ -1783,15 +1784,15 @@ estimatedSBSMutationErrorProbability$by_channel_pyr <- estimatedSBSMutationError
 	arrange(channel_pyr)
 
 estimatedSBSMutationErrorProbability$total <- estimatedSBSMutationErrorProbability$by_channel_pyr %>%
-	pull(error_prob) %>% 
+	pull(error_prob) %>%
 	sum
 
 estimatedSBSMutationErrorProbability$total_corrected_to_genome <- estimatedSBSMutationErrorProbability$by_channel_pyr %>%
-	pull(error_prob_corrected_to_genome) %>% 
+	pull(error_prob_corrected_to_genome) %>%
 	sum
 
 estimatedSBSMutationErrorProbability$total_corrected_to_genome_chromgroup <- estimatedSBSMutationErrorProbability$by_channel_pyr %>%
-	pull(error_prob_corrected_to_genome_chromgroup) %>% 
+	pull(error_prob_corrected_to_genome_chromgroup) %>%
 	sum
 
 rm(estimatedSBSMutationErrorProbability_by_channel)

--- a/bin/calculateBurdens.R
+++ b/bin/calculateBurdens.R
@@ -515,7 +515,7 @@ paste(
 	invisible
 
 #Expand to per-base coverage runs and annotate with genome trinucleotide sequences
-genome_trinuc_file <- str_c(yaml.config$cache_dir,"/",BSgenome_name, ".bed.gz")
+genome_trinuc_file <- str_c(yaml.config$cache_dir,"/",basename(yaml.config$genome_fasta), ".bed.gz")
 
 paste(
 	yaml.config$bedtools_bin, "makewindows -w 1 -b all.bed |",

--- a/bin/calculateBurdens.R
+++ b/bin/calculateBurdens.R
@@ -172,7 +172,7 @@ indel_labels.sigfit <- c(
 #Function to sum two RleLists, including handling of chromosomes only present in one of the RleLists.
 sum_RleList <- function(a, b) {
 	seqs_union <- union(names(a), names(b))
-
+	
 	seqs_union %>%
 		map(function(nm){
 			seq_in_a <- nm %in% names(a)
@@ -200,43 +200,43 @@ sum_bam.gr.filtertracks <- function(bam.gr.filtertrack1, bam.gr.filtertrack2=NUL
 					map_lgl(function(x){
 						x_plus <- x %>% filter(strand == "+")
 						x_minus <- x %>% filter(strand == "-")
-
+						
 						return(identical(ranges(x_plus), ranges(x_minus)) & identical(mcols(x_plus), mcols(x_minus)))
 					})
 			) %>%
 			pull(plus_minus_identical) %>%
 			all
 	}
-
+	
 	#Helper function to calculate coverage from both strands and then divide by two to get duplex coverage
 	calc_duplex_coverage <- function(gr){
 		cov <- gr %>% coverage
-
+		
 		#Confirm all values are even integers
 		if((cov %% 2L != 0L) %>% any %>% any){
 			stop("Non-even strand coverage in bam.gr.filtertrack!")
 		}
-
+		
 		return(cov %/% 2L)
 	}
-
+	
 	if(is.null(bam.gr.filtertrack2)){
 		if(! bam.gr.filtertrack1 %>% is_plus_minus_identical){
 			stop("Mismatched plus and minus strand ranges in bam.gr.filtertrack!")
 		}
-
+		
 		bam.gr.filtertrack1 %>%
 			mutate(
 				bam.gr.filtertrack.coverage = bam.gr.filtertrack %>%
 					map(function(x){x %>% calc_duplex_coverage})
 			) %>%
 			select(-bam.gr.filtertrack)
-
+		
 	}else{
 		if(! bam.gr.filtertrack2 %>% is_plus_minus_identical){
 			stop("Mismatched plus and minus strand ranges in bam.gr.filtertrack!")
 		}
-
+		
 		bam.gr.filtertrack1 %>%
 			left_join(
 				bam.gr.filtertrack2 %>%
@@ -261,24 +261,24 @@ sum_bam.gr.filtertracks <- function(bam.gr.filtertrack1, bam.gr.filtertrack2=NUL
 
 #Function to extract coverage for a GRanges object with only 1 bp ranges from a SimpleRleList coverage object. Coverage = 0 for seqnames in the GRanges that are not in the coverage object.
 gr_1bp_cov <- function(gr, cov){
-
+	
 	stopifnot(all(width(gr) == 1))
-
+	
 	n <- length(gr)
 	result <- rep.int(0, n) #pre-fill zeros
 	chr <- gr %>% seqnames %>% as.character
 	pos <- gr %>% start
-
+	
 	# indices per chromosome (keeps order in 'gr')
 	idx_by_chr <- split(seq_len(n), chr)
-
+	
 	for (ch in names(idx_by_chr)) {
 		idx <- idx_by_chr[[ch]]
 		if (ch %in% names(cov)){
 			result[idx] <- cov[[ch]][pos[idx]]
 		}
 	}
-
+	
 	return(result)
 }
 
@@ -294,15 +294,15 @@ molecule_stats <- list()
 
 #Loop over all filterCallsFiles
 for(i in seq_along(filterCallsFiles)){
-
+	
 	#Extract analysis chunk number for logging in case filterCallsFiles are not supplied in order
 	analysis_chunk_num <- filterCallsFiles[i] %>% str_extract("(?<=chunk)\\d+")
-
+		
 	cat(" ", analysis_chunk_num, sep="")
-
+	
 	#Load filterCallsFile
 	filterCallsFile <- qs_read(filterCallsFiles[i])
-
+	
 	#Load basic configuration only from first chunk, since identical in all chunks.
 	if(i == 1){
 		#Basic configuration parameters
@@ -310,7 +310,7 @@ for(i in seq_along(filterCallsFiles)){
 		genome_chromgroup.gr <- filterCallsFile %>% pluck("config","genome_chromgroup.gr")
 		region_read_filters_config <- filterCallsFile %>% pluck("config","region_read_filters_config")
 		region_genome_filters_config <- filterCallsFile %>% pluck("config","region_genome_filters_config")
-
+		
 		#germline-related filters that are excluded when calculating sensitivity
 		germline_filters <- c(
 			"germline_vcf.passfilter",
@@ -328,7 +328,7 @@ for(i in seq_along(filterCallsFiles)){
 				basename %>%
 				str_c("region_genome_filter_",.,".passfilter")
 		)
-
+		
 		#region_genome_filter_stats
 		region_genome_filter_stats <- filterCallsFile %>% pluck("region_genome_filter_stats")
 	}
@@ -339,7 +339,7 @@ for(i in seq_along(filterCallsFiles)){
 		filter(
 			if_all(contains("passfilter"), ~ .x == TRUE)
 		)
-
+	
 	#Load germline variant calls that pass all filters ignoring the germline filters, since we will later also need the calls filtered by germline filters to calculate sensitivity
 	germlineVariantCalls[[i]] <- filterCallsFile %>%
 		pluck("calls") %>%
@@ -349,23 +349,23 @@ for(i in seq_along(filterCallsFiles)){
 			if_all(contains("passfilter") & !all_of(germline_filters), ~ .x == TRUE), #All non-germline filters == TRUE
 			germline_vcf.passfilter == FALSE #Detected in at least one germline VCF
 		)
-
+	
 	#Filtered duplex read coverage of the genome, with and without germline_filters
 	if(i == 1){
 		bam.gr.filtertrack.bytype <- sum_bam.gr.filtertracks(
 			filterCallsFile %>% pluck("bam.gr.filtertrack.bytype")
 		)
-
+		
 		bam.gr.filtertrack.except_germline_filters.bytype <- sum_bam.gr.filtertracks(
 			filterCallsFile %>% pluck("bam.gr.filtertrack.except_germline_filters.bytype")
 		)
-
+		
 	}else{
 		bam.gr.filtertrack.bytype <- sum_bam.gr.filtertracks(
 			bam.gr.filtertrack.bytype,
 			filterCallsFile %>% pluck("bam.gr.filtertrack.bytype")
 		)
-
+		
 		bam.gr.filtertrack.except_germline_filters.bytype <- sum_bam.gr.filtertracks(
 			bam.gr.filtertrack.except_germline_filters.bytype,
 			filterCallsFile %>% pluck("bam.gr.filtertrack.except_germline_filters.bytype")
@@ -374,7 +374,7 @@ for(i in seq_along(filterCallsFiles)){
 
 	#molecule_stats
 	molecule_stats[[i]] <- filterCallsFile %>% pluck("molecule_stats")
-
+	
 	#Remove temporary objects
 	rm(filterCallsFile)
 	invisible(gc())
@@ -429,33 +429,33 @@ bam.gr.filtertrack.bytype %>%
 	pwalk(
 		function(...){
 			x <- list(...)
-
+			
 			output_file <- str_c(x$row_id,".bed")
 			if(file.exists(output_file)){file.remove(output_file)}
 			file.create(output_file)
-
+			
 			x$bam.gr.filtertrack.coverage %>%
 				iwalk(
 					function(rle, seqname){
 						lens <- rle %>% runLength
 						vals <- rle %>% runValue
 						n <- lens %>% length
-
+						
 						offset <- 0L
-
+						
 						for(lo in seq.int(1L, n, by = chunk_runs)){
 							hi <- min(lo + chunk_runs - 1L, n)
 							len_slice <- lens[lo:hi]
 							val_slice <- vals[lo:hi]
-
+							
 							nz <- which(val_slice != 0L)
 							if(length(nz) == 0){
 								offset <- offset + sum(len_slice)
 								next
 							}
-
+							
 							ends_chunk <- offset + cumsum(len_slice)
-
+							
 							starts_chunk_sub <- ends_chunk[nz]
 							gt1 <- nz > 1L
 							if(any(gt1)){starts_chunk_sub[gt1] <- ends_chunk[nz[gt1] - 1L]}
@@ -468,9 +468,9 @@ bam.gr.filtertrack.bytype %>%
 								value = val_slice[nz]
 							) %>%
 								data.table::fwrite(output_file, sep="\t", col.names = FALSE, append = TRUE, showProgress = FALSE)
-
+							
 							offset <- ends_chunk[length(ends_chunk)]
-
+							
 							invisible(gc())
 						}
 					}
@@ -490,7 +490,7 @@ paste(
 	"| cut -f2- |",
 	yaml.config$bedtools_bin,"merge -i stdin > all.bed"
 ) %>%
-	system2(command="/bin/bash", args="-s", input=.) %>%
+	system2(command="/bin/bash", args="-s", input=.) %>% 
 	invisible
 
 #Expand to per-base coverage runs and annotate with genome trinucleotide sequences
@@ -501,7 +501,7 @@ paste(
 	yaml.config$bedtools_bin, "intersect -sorted -loj -wa -wb -a stdin -b",genome_trinuc_file, "-g", yaml.config$genome_fai,
 	"| cut -f 1-3,7 > all.trinuc.bed"
 ) %>%
-	system2(command="/bin/bash", args="-s", input=.) %>%
+	system2(command="/bin/bash", args="-s", input=.) %>% 
 	invisible
 
 file.remove("all.bed") %>% invisible
@@ -512,7 +512,7 @@ bam.gr.filtertrack.bytype %>%
 	pwalk(
 		function(...){
 			x <- list(...)
-
+			
 			cov_output_file <- str_c(
 				yaml.config$analysis_id,
 				individual_id,
@@ -526,7 +526,7 @@ bam.gr.filtertrack.bytype %>%
 				"bed.gz",
 				sep="."
 			)
-
+			
 			paste(
 				yaml.config$bedtools_bin, "intersect -sorted -wa -wb",
 				"-a", str_c(x$row_id,".bed"), "-b all.trinuc.bed",
@@ -545,9 +545,9 @@ bam.gr.filtertrack.bytype %>%
 				"&&",
 				yaml.config$tabix_bin, "-@2 -s1 -b2 -e3", cov_output_file
 			) %>%
-				system2(command="/bin/bash", args="-s", input=.) %>%
+				system2(command="/bin/bash", args="-s", input=.) %>% 
 				invisible
-
+			
 			file.remove(str_c(x$row_id,".bed")) %>% invisible
 		}
 	)
@@ -573,7 +573,7 @@ if(
 		"bed.gz",
 		sep="."
 	)
-
+	
 	file.remove(cov_output_file, str_c(cov_output_file,".tbi")) %>% invisible
 }
 
@@ -597,7 +597,7 @@ bam.gr.filtertrack.bytype <- bam.gr.filtertrack.bytype %>%
 		name = "bam.gr.filtertrack.reftnc_plus_strand"
 	) %>%
 	select(-row_id) %>%
-
+	
 	mutate(
 		bam.gr.filtertrack.reftnc_minus_strand = bam.gr.filtertrack.reftnc_plus_strand %>%
 			map(function(x){
@@ -627,7 +627,7 @@ bam.gr.filtertrack.bytype <- bam.gr.filtertrack.bytype %>%
 					rename(reftnc_pyr = reftnc) %>%
 					mutate(fraction = count / sum(count))
 			}),
-
+		
 		bam.gr.filtertrack.reftnc_both_strands = map2(
 			bam.gr.filtertrack.reftnc_plus_strand,
 			bam.gr.filtertrack.reftnc_minus_strand,
@@ -645,7 +645,7 @@ bam.gr.filtertrack.bytype <- bam.gr.filtertrack.bytype %>%
 #Calculate trinucleotide distributions of the whole genome and of the genome in the analyzed chromgroup
  #Function to extract trinucleotide distribution for selected chromosomes
 get_genome_reftnc <- function(BSgenome_name, chroms){
-
+	
 	reftnc_plus_strand <- BSgenome_name %>%
 		get %>%
 		getSeq(chroms) %>%
@@ -653,7 +653,7 @@ get_genome_reftnc <- function(BSgenome_name, chroms){
 		trinucleotideFrequency(simplify.as = "collapsed") %>%
 		enframe(name = "reftnc", value = "count") %>%
 		mutate(reftnc = reftnc %>% factor(levels = trinucleotides_64))
-
+	
 	reftnc_minus_strand <- reftnc_plus_strand %>%
 		mutate(
 			reftnc = reftnc %>%
@@ -668,7 +668,7 @@ get_genome_reftnc <- function(BSgenome_name, chroms){
 		rename(reftnc_pyr = reftnc) %>%
 		filter(!is.na(reftnc_pyr)) %>%
 		mutate(fraction = count / sum(count))
-
+	
 	reftnc_both_strands <- bind_rows(
 		reftnc_plus_strand,
 		reftnc_minus_strand
@@ -678,7 +678,7 @@ get_genome_reftnc <- function(BSgenome_name, chroms){
 		arrange(reftnc) %>%
 		filter(!is.na(reftnc)) %>%
 		mutate(fraction = count / sum(count))
-
+	
 	return(
 		list(
 			reftnc_pyr = reftnc_pyr,
@@ -720,7 +720,7 @@ bam.gr.filtertrack.bytype <- bam.gr.filtertrack.bytype %>%
 						)
 				}
 			),
-
+		
 		bam.gr.filtertrack.reftnc_both_strands = bam.gr.filtertrack.reftnc_both_strands %>%
 			map(
 				function(x){
@@ -737,14 +737,14 @@ bam.gr.filtertrack.bytype <- bam.gr.filtertrack.bytype %>%
 						)
 				}
 			),
-
+		
 		across(
 			starts_with("bam.gr.filtertrack.reftnc"),
 			function(x){
 				x %>%
 					map(
 						function(y){
-							y %>%
+							y %>% 
 								mutate(
 									fraction_ratio_to_genome = fraction / fraction.genome,
 									fraction_ratio_to_genome_chromgroup = fraction / fraction.genome_chromgroup
@@ -801,10 +801,10 @@ strand_redundant_cols_discard <- c(
 
 #Nest_join finalCalls for each call_class x call_type x SBSindel_call_type combination, and add SBS/mismatch-ss if not in call_types_toanalyze for downstream SBS mutation error rate calculation, and collapse to distinct calls ignoring strand for call_class = "SBS" and "indel" with SBSindel_call_type = "mutation" so that each of these events is only counted once, while all other SBS and indel SBSindel_call_types and all MDB SBSindel_call_types will be counted once for each strand on which they occur. Also extract unique calls for SBSindel_call_type = "mutation". Then convert to a table formatted for tsv output. Before the nest join, remove "germline_vcf_types_detected", "germline_vcf_files_detected", and "passfilter" columns as these are empty, empty, and TRUE, respectively for all finalCalls. Used for burden, spectra, and vcf output.
 finalCalls.bytype <- call_types_toanalyze %>%
-
+	
 	#remove columns that are not needed here
 	select(-analyzein_chromgroups, -starts_with("MDB")) %>%
-
+	
 	#Add row for SBS/mismatch-ss
 	bind_rows(
 		tibble(
@@ -815,7 +815,7 @@ finalCalls.bytype <- call_types_toanalyze %>%
 		)
 	) %>%
 	distinct %>%
-
+	
 	#Nest join finalCalls
 	nest_join(
 		finalCalls %>%
@@ -831,7 +831,7 @@ finalCalls.bytype <- call_types_toanalyze %>%
 		by = join_by(call_class, call_type, SBSindel_call_type),
 		name = "finalCalls"
 	) %>%
-
+	
 	#Discard columns that are not needed for each call_class
 	mutate(
 		finalCalls = map2(
@@ -847,17 +847,17 @@ finalCalls.bytype <- call_types_toanalyze %>%
 			}
 		)
 	) %>%
-
+	
 	#Make tables for tsv and vcf output
 	mutate(
-
+		
 		#Calls for tsv output
 		finalCalls_for_tsv = if_else(
 			call_class %in% c("SBS","indel") & SBSindel_call_type == "mutation",
 			finalCalls %>% map(
 				function(x){
 					x %>%
-
+						
 						#Change strand levels so that new column names after pivot_wider have suffixes ref_strand_(plus/minus)_read instead of +/-.
 						mutate(
 							strand = strand %>%
@@ -866,7 +866,7 @@ finalCalls.bytype <- call_types_toanalyze %>%
 									refstrand_minus_read = "-"
 								)
 						) %>%
-
+						
 						#Collapse to one row per mutation
             pivot_wider(
               id_cols = any_of(c(zm_identical_cols_keep, strand_identical_cols_keep)),
@@ -879,7 +879,7 @@ finalCalls.bytype <- call_types_toanalyze %>%
 			),
 			finalCalls
 		),
-
+		
 		#Unique calls for tsv output
 		finalCalls_unique_for_tsv = if_else(
 			SBSindel_call_type == "mutation",
@@ -890,24 +890,24 @@ finalCalls.bytype <- call_types_toanalyze %>%
 			),
 			NA
 		),
-
+		
 		#Calls for vcf output
 		finalCalls_for_vcf = finalCalls_for_tsv %>% map(
 			function(x){
-				x %>%
+				x %>% 
 					normalize_indels_for_vcf(
 						BSgenome_name = BSgenome_name
 					)
 			}
 		),
-
+		
 		#Unique calls for vcf output
 		finalCalls_unique_for_vcf = if_else(
 			SBSindel_call_type == "mutation",
 			finalCalls_unique_for_tsv %>%
 				map(
 					function(x){
-						x %>%
+						x %>% 
 							normalize_indels_for_vcf(
 								BSgenome_name = BSgenome_name
 							)
@@ -926,7 +926,7 @@ finalCalls <- finalCalls %>%
 #Calculate trinucleotide counts and fractions for call_class = "SBS" and "MDB". For all call types (including SBS/mismatch-ss even if not in call_types_toanalyze, for downstream SBS mutation error calculation), calculate reftnc_pyr. For call_class "SBS" with SBSindel_call_type = "mutation", also calculate reftnc_pyr for unique calls, and for all other call types, calculate reftnc_template_strand.
 finalCalls.reftnc_spectra <- finalCalls.bytype %>%
 	mutate(
-
+		
 		finalCalls.reftnc_pyr = pmap(
 			list(call_class, finalCalls_for_tsv),
 			function(x,z){
@@ -942,7 +942,7 @@ finalCalls.reftnc_spectra <- finalCalls.bytype %>%
 				}
 			}
 		),
-
+		
 		finalCalls_unique.reftnc_pyr = pmap(
 			list(call_class, SBSindel_call_type, finalCalls_unique_for_tsv),
 			function(x,y,z){
@@ -958,7 +958,7 @@ finalCalls.reftnc_spectra <- finalCalls.bytype %>%
 				}
 			}
 		),
-
+		
 		finalCalls.reftnc_template_strand = pmap(
 			list(call_class, SBSindel_call_type, finalCalls_for_tsv),
 			function(x,y,z){
@@ -1005,7 +1005,7 @@ finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>%
 				}
 			}
 		),
-
+		
 		finalCalls_unique.reftnc_pyr_spectrum = pmap(
 			list(call_class, SBSindel_call_type, finalCalls_unique_for_tsv),
 			function(x,y,z){
@@ -1025,7 +1025,7 @@ finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>%
 				}
 			}
 		),
-
+		
 		finalCalls.reftnc_template_strand_spectrum = pmap(
 			list(call_class, SBSindel_call_type, finalCalls_for_tsv),
 			function(x,y,z){
@@ -1071,7 +1071,7 @@ finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>%
 				}
 			}
 		),
-
+		
 		finalCalls_unique.refindel_spectrum = pmap(
 			list(call_class, SBSindel_call_type, finalCalls_unique_for_vcf),
 			function(x,y,z){
@@ -1097,16 +1097,16 @@ invisible(gc())
 #Calculate trinucleotide distributions and spectra of SBS and MDB calls corrected for genome and genome_chromgroup distributions. Note, when genome correction factors are 0, setting corrected count to 0 rather than NA. When the sum of counts is 0, setting the fraction to 0 instead of NA.
  #Helper function to annotate corrected counts and fractions
 annotate_corrected_counts_fractions <- function(df, cols, ref_col, annotation_type){
-
+	
 	expr_map <- list(
 		reftnc_pyr = expr(reftnc_pyr == reftnc_pyr),
 		reftnc_template_strand = expr(reftnc_template_strand == reftnc),
 		reftnc_pyr_channel = expr(reftnc_pyr_channel == reftnc_pyr),
 		reftnc_template_strand_channel = expr(reftnc_template_strand_channel == reftnc)
 	)
-
+	
 	join_by_expr <- expr_map %>% pluck(annotation_type)
-
+	
 	df %>%
 		mutate(
 			across(
@@ -1116,7 +1116,7 @@ annotate_corrected_counts_fractions <- function(df, cols, ref_col, annotation_ty
 						s, !!sym(ref_col),
 						function(x,y){
 							if (is.null(x)){return(x)}
-
+							
 							if(annotation_type == "reftnc_pyr_channel"){
 								x <- x %>%
 									mutate(
@@ -1132,7 +1132,7 @@ annotate_corrected_counts_fractions <- function(df, cols, ref_col, annotation_ty
 											factor(levels = trinucleotides_64)
 									)
 							}
-
+							
 							x %>% left_join(
 								y,
 								by = join_by(!!join_by_expr),
@@ -1192,19 +1192,19 @@ cat("## Calculating call burdens...")
 
 #Calculate number of interrogated base pairs (SBSindel_call_type = mutation) or bases (mismatch-ss, mismatch-ds, mismatch-os, match), for each call_type to analyze. Note, for mismatch-ds, each mismatch-ds is counted as 2 mismatches so burdens use interrogated bases rather than base pairs.
 finalCalls.burdens <- bam.gr.filtertrack.bytype %>%
-
-	#Exclude SBS/mismatch-ss row if it was only added to bam.gr.filtertrack.bytype for downstream calculation of SBS mutation error probability.
+	
+	#Exclude SBS/mismatch-ss row if it was only added to bam.gr.filtertrack.bytype for downstream calculation of SBS mutation error probability. 
 	semi_join(
 		call_types_toanalyze,
 		by = join_by(call_type, call_class, SBSindel_call_type, filtergroup)
 	) %>%
-
+	
 	mutate(
 		cov_sum = bam.gr.filtertrack.coverage %>%
 			map_dbl(function(x){
 					x %>% map_dbl(sum) %>% sum
 			}),
-
+		
 		interrogated_bases_or_bp = if_else(
 			SBSindel_call_type == "mutation",
 			cov_sum,
@@ -1227,7 +1227,7 @@ finalCalls.burdens <- finalCalls.burdens %>%
 					reftnc_corrected_reference = NA,
 					sensitivity_corrected = FALSE
 				),
-
+		
 			#Unique calls (only mutations)
 			finalCalls.bytype %>%
 				filter(!map_lgl(finalCalls_unique_for_tsv,is.null)) %>%
@@ -1255,7 +1255,7 @@ finalCalls.burdens <- finalCalls.burdens %>%
 #		unique_col_annotation: Label to give the unique_calls column in the resulting tibble
 get_burden_data <- function(x, y, reftnc_cols, ratio_col_suffix, unique_col_annotation){
 	df <- left_join(x, y, by = join_by(!!reftnc_cols))
-
+	
 	return(
 		tibble(
 			interrogated_bases_or_bp = df %>% pull(count.y) %>% sum,
@@ -1281,7 +1281,7 @@ finalCalls.reftnc_spectra.genome_correction.SBSmutations <- finalCalls.reftnc_sp
 finalCalls.burdens <- finalCalls.burdens %>%
 	bind_rows(
 		bind_rows(
-
+			
 			#Not unique calls, whole-genome corrected
 			finalCalls.reftnc_spectra.genome_correction.SBSmutations %>%
 				mutate(
@@ -1291,7 +1291,7 @@ finalCalls.burdens <- finalCalls.burdens %>%
 						function(x,y){get_burden_data(x,y,expr(reftnc_pyr==reftnc_pyr),"genome",FALSE)}
 					)
 				),
-
+				
 			#Unique calls, whole-genome corrected
 			finalCalls.reftnc_spectra.genome_correction.SBSmutations %>%
 				mutate(
@@ -1301,7 +1301,7 @@ finalCalls.burdens <- finalCalls.burdens %>%
 						function(x,y){get_burden_data(x,y,expr(reftnc_pyr==reftnc_pyr),"genome",TRUE)}
 					)
 				),
-
+				
 			#Not unique calls, genome chromgroup corrected
 			finalCalls.reftnc_spectra.genome_correction.SBSmutations %>%
 				mutate(
@@ -1311,7 +1311,7 @@ finalCalls.burdens <- finalCalls.burdens %>%
 							function(x,y){get_burden_data(x,y,expr(reftnc_pyr==reftnc_pyr),"genome_chromgroup",FALSE)}
 					)
 				),
-
+				
 			#Unique calls, genome chromgroup corrected
 			finalCalls.reftnc_spectra.genome_correction.SBSmutations %>%
 				mutate(
@@ -1339,7 +1339,7 @@ finalCalls.reftnc_spectra.genome_correction.SBSnonmutations <- finalCalls.reftnc
 finalCalls.burdens <- finalCalls.burdens %>%
 	bind_rows(
 		bind_rows(
-
+			
 			#Not unique calls, whole-genome corrected
 			finalCalls.reftnc_spectra.genome_correction.SBSnonmutations %>%
 				mutate(
@@ -1349,7 +1349,7 @@ finalCalls.burdens <- finalCalls.burdens %>%
 						function(x,y){get_burden_data(x,y,expr(reftnc_template_strand==reftnc),"genome",FALSE)}
 					)
 				),
-
+			
 			#Not unique calls, genome chromgroup corrected
 			finalCalls.reftnc_spectra.genome_correction.SBSnonmutations %>%
 				mutate(
@@ -1371,10 +1371,10 @@ invisible(gc())
 finalCalls.burdens <- finalCalls.burdens %>%
 	mutate(
 		ci = num_calls %>% map( function(x){cipoisson(x)} ),
-
+		
 		num_calls_lci = map_dbl(ci,1),
 		num_calls_uci = map_dbl(ci,2),
-
+		
 		burden_calls = num_calls / interrogated_bases_or_bp,
 		burden_calls_lci = num_calls_lci / interrogated_bases_or_bp,
 		burden_calls_uci = num_calls_uci / interrogated_bases_or_bp
@@ -1384,16 +1384,16 @@ finalCalls.burdens <- finalCalls.burdens %>%
 #Create sigfit-format finalCalls spectra tables
  #Helper function
 tibble_to_sigfit <- function(finalCalls_col, rowname_col, mode = c("pyr","template","indel"), value_col = NULL){
-
+				
 	map2(finalCalls_col, rowname_col, function(x,y){
 		if(is.null(x)){return(NULL)}
-
+		
 		result <- switch(
 			mode,
 			"pyr" = x %>%
 				select(channel, all_of(value_col)) %>%
 				pivot_wider(names_from = channel, values_from = all_of(value_col)),
-
+			
 			"template" = x %>%
 				mutate(
 					channel = if_else(
@@ -1409,7 +1409,7 @@ tibble_to_sigfit <- function(finalCalls_col, rowname_col, mode = c("pyr","templa
 				) %>%
 				select(channel, all_of(value_col)) %>%
 				pivot_wider(names_from = channel, values_from = all_of(value_col)),
-
+			
 			"indel" = x %>% indelspectrum.to.sigfit
 		) %>%
 			mutate(rowname = y) %>%
@@ -1426,7 +1426,7 @@ finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>%
 			call_class, call_type, SBSindel_call_type,
 			sep="."
 		),
-
+		
 		#reftnc_pyr spectra for all and unique calls
 		 #Not corrected
 		across(
@@ -1446,7 +1446,7 @@ finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>%
 			function(x){tibble_to_sigfit(x, .data[["rowname_col"]], mode = "pyr", value_col = "count_corrected_to_genome_chromgroup")},
 			.names = "{.col}.corrected_to_genome_chromgroup.sigfit"
 		),
-
+		
 		#reftnc_template_strand spectra for all calls
 		 #Not corrected
 		across(
@@ -1466,7 +1466,7 @@ finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>%
 			function(x){tibble_to_sigfit(x, .data[["rowname_col"]], mode = "template", value_col = "count_corrected_to_genome_chromgroup")},
 			.names = "{.col}.corrected_to_genome_chromgroup.sigfit"
 		),
-
+		
 		# indel spectra (all + unique)
 		across(
 			c(finalCalls.refindel_spectrum, finalCalls_unique.refindel_spectrum),
@@ -1500,9 +1500,9 @@ sensitivity <- call_types_toanalyze %>%
 
 #Create set of high-quality germline variants for sensitivity analysis if use_chromgroup is defined and is the current chromgroup
 if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_chromgroup == chromgroup_toanalyze){
-
+	
 	cat("## Calculating SBS and indel sensitivity...")
-
+	
 	#Count number of germline VCFs for the analyzed individual
 	num_germline_vcf_files <- yaml.config$individuals %>%
 		modify_tree(leaf = as.character) %>%
@@ -1513,7 +1513,7 @@ if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_
 		unnest_wider(germline_vcf_files) %>%
 		filter(individual_id == !!individual_id) %>%
 		nrow
-
+	
 	#Load sensitivity_vcf
 	sensitivity_vcf <- load_vcf(
 		vcf_file = sensitivity_parameters$sensitivity_vcf,
@@ -1522,7 +1522,7 @@ if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_
 		bcftools_bin = yaml.config$bcftools_bin
 	) %>%
 		as_tibble
-
+	
 	#Load germline VCF variants and filter to retain high-confidence variants
 	high_confidence_germline_vcf_variants <- qs_read(
 		str_c(
@@ -1539,13 +1539,13 @@ if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_
 		)
 	) %>%
 		as_tibble %>%
-
+		
 		#Separate genotypes of each allele
 		separate_wider_delim(GT, regex("[^[:digit:].]"), names=c("GT1","GT2"), cols_remove = FALSE) %>%
-
+		
 		#Group by germline_vcf_file so that filters are calculated separately for each germline VCF.
-		group_by(germline_vcf_file) %>%
-
+		group_by(germline_vcf_file) %>% 
+		
 		#Filter per sensitivity_threshold settings
 		filter(
 			(Depth >= quantile(Depth, sensitivity_parameters$SBS_min_Depth_quantile) & call_class == "SBS") |
@@ -1562,29 +1562,29 @@ if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_
 				(sensitivity_parameters$genotype == "homozygous" & (GT1 == "1" & GT2 == "1"))
 		) %>%
 		ungroup %>%
-
+		
 		#Keep variants detected in all germline vcfs
 		count(seqnames, start, end, ref_plus_strand, alt_plus_strand, call_class, call_type, SBSindel_call_type) %>%
 		filter(n == !!num_germline_vcf_files) %>%
 		select(-n) %>%
-
+		
 		#Keep variants in chromgroup, and exclude variants in sex chromosomes and mitochondrial chromosome
 		filter(
 			seqnames %in% chroms_toanalyze,
 			! seqnames %in% sex_chromosomes,
 			! seqnames %in% mitochondrial_chromosome
 		) %>%
-
+		
 		#Keep variants in sensitivity_vcf
 		semi_join(
 			sensitivity_vcf,
 			by = names(.)
 		)
-
+	
 	rm(num_germline_vcf_files, sensitivity_vcf)
 	invisible(gc())
-
-	#Annotate for each variant in high_confidence_germline_vcf_variants how many times it was detected in germlineVariantCalls, counting 1 for each zm in which it was detected.
+	
+	#Annotate for each variant in high_confidence_germline_vcf_variants how many times it was detected in germlineVariantCalls, counting 1 for each zm in which it was detected. 
 	high_confidence_germline_vcf_variants <- high_confidence_germline_vcf_variants %>%
 		left_join(
 			germlineVariantCalls %>%
@@ -1598,7 +1598,7 @@ if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_
 			by = names(high_confidence_germline_vcf_variants)
 		) %>%
 		mutate(num_zm_detected = num_zm_detected %>% replace_na(0))
-
+	
 	#Annotate duplex coverage of high_confidence_germline_vcf_variants for each non-germline filter tracker. For insertions and deletions, annotate the minimum coverage at the left and right bases immediately flanking the insertion site/deleted bases.
 	#For high_confidence_germline_vcf_variants, change insertion and deletion ranges to span immediately flanking bases
 	high_confidence_germline_vcf_variants <- high_confidence_germline_vcf_variants %>%
@@ -1606,7 +1606,7 @@ if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_
 			start = if_else(call_class == "indel", start - 1, start),
 			end = if_else(call_class == "indel", end + 1, end)
 		)
-
+	
 	#Get coverage for start and end positions so that coverage is calculated for those bases specifically, and then set coverage to the minimum between these.
 	bam.gr.filtertrack.except_germline_filters.bytype <- bam.gr.filtertrack.except_germline_filters.bytype %>%
 		nest_join(high_confidence_germline_vcf_variants, by = "call_type") %>%
@@ -1615,12 +1615,12 @@ if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_
 				high_confidence_germline_vcf_variants,
 				bam.gr.filtertrack.coverage,
 				function(x,y){
-
+					
 					gr <- x %>%
 						makeGRangesFromDataFrame(
 							seqinfo = BSgenome_name %>% get %>% seqinfo
 						)
-
+					
 					x %>%
 						mutate(
 							duplex_coverage = pmin(
@@ -1635,18 +1635,18 @@ if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_
 				}
 			)
 		)
-
-	#Join high_confidence_germline_vcf_variants.annotated to sensitivity tibble
+	
+	#Join high_confidence_germline_vcf_variants.annotated to sensitivity tibble 
 	sensitivity <- sensitivity %>%
 		left_join(
 			bam.gr.filtertrack.except_germline_filters.bytype %>%
 				select(-bam.gr.filtertrack.coverage),
 			by = join_by(call_type, call_class, SBSindel_call_type, filtergroup)
 		)
-
+	
 	rm(high_confidence_germline_vcf_variants, bam.gr.filtertrack.except_germline_filters.bytype)
 	invisible(gc())
-
+	
 	#Sum number of high confidence germline VCF variant detections and coverage, and remove high_confidence_germline_vcf_variants that is no longer needed
 	sensitivity <- sensitivity %>%
 		mutate(
@@ -1654,43 +1654,43 @@ if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_
 				map_int( function(x){x$num_zm_detected %>% sum} ),
 			high_confidence_germline_vcf_variants_sum_duplex_coverage = high_confidence_germline_vcf_variants %>%
 				map_int( function(x){x$duplex_coverage %>% sum} )
-		) %>%
+		) %>% 
 		select(-high_confidence_germline_vcf_variants)
-
+	
 	#Calculate sensitivity.
-	#Calculate sensitivity only if number of high-confidence germline variant detections is above the configured minimum required, otherwise keep as default of 1.
+	#Calculate sensitivity only if number of high-confidence germline variant detections is above the configured minimum required, otherwise keep as default of 1. 
 	#If sensitivity_parameters$genotype = 'homozygous' (i.e. used only homozygous variants for sensitivity calculation): calculate sensitivity as sum(num_zm_detected) / sum(duplex_coverage)
 	#If sensitivity_parameters$genotype = 'heterozygous', calculate sensitivity as 2 * sum(num_zm_detected) / sum(duplex_coverage).
-	#Cap sensitivity to a max of 1, since it is possible to exceed 1 due to the above 'heterozygous' correction and edge cases.
-	sensitivity <- sensitivity %>%
+	#Cap sensitivity to a max of 1, since it is possible to exceed 1 due to the above 'heterozygous' correction and edge cases. 
+	sensitivity <- sensitivity %>% 
 		mutate(
-
+			
 			#Check based on thresholds if sensitivity should be calculated
 			calculate_sensitivity = (call_class == "SBS" &
 															 	high_confidence_germline_vcf_variants_sum_zm_detected >= sensitivity_parameters$SBS_min_variant_detections &
 															 	high_confidence_germline_vcf_variants_sum_duplex_coverage > 0) |
-
+				
 				(call_class == "indel" &
 				 	high_confidence_germline_vcf_variants_sum_zm_detected >= sensitivity_parameters$indel_min_variant_detections &
 				 	high_confidence_germline_vcf_variants_sum_duplex_coverage > 0),
-
+			
 			sensitivity = case_when(
 				calculate_sensitivity & sensitivity_parameters$genotype == "homozygous" ~
 					high_confidence_germline_vcf_variants_sum_zm_detected / high_confidence_germline_vcf_variants_sum_duplex_coverage,
-
+				
 				calculate_sensitivity & sensitivity_parameters$genotype == "heterozygous" ~
 					2 * (high_confidence_germline_vcf_variants_sum_zm_detected / high_confidence_germline_vcf_variants_sum_duplex_coverage),
-
+				
 				.default = sensitivity
 			),
-
+			
 			sensitivity = pmin(1, sensitivity),
-
+			
 			sensitivity_source = if_else(calculate_sensitivity, "calculated", sensitivity_source)
-
+			
 		) %>%
 		select(-calculate_sensitivity)
-
+	
 	#Change sensitivity to sqrt(sensitivity) for SBSindel_call_type = 'mismatch-ss' and 'mismatch-ds'. Do not do this transformation for SBSindel_call_type = 'mutation' since this involves detection in both strands. Although 'mismatch-ds' is detected in both strands, these are counted for burdens as two events for simplicity in output of mismatch-ds calls. SBSindel_call_type = 'mismatch-os' and 'match' are also not changed since these are for type MDB that is set in the yaml.config.
 	sensitivity <- sensitivity %>%
 		mutate(
@@ -1700,9 +1700,9 @@ if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_
 				sensitivity
 			)
 		)
-
+	
 	cat("DONE\n")
-
+	
 }else if(!is.null(sensitivity_parameters$use_chromgroup) & sensitivity_parameters$use_chromgroup != chromgroup_toanalyze){
 	cat("## All non-MDB sensitivities set to NA since the currently analyzed chromgroup is not equal to sensitivity_parameters$use_chromgroup.\n")
 	sensitivity <- sensitivity %>%
@@ -1734,7 +1734,7 @@ estimatedSBSMutationErrorProbability_by_channel <- left_join(
 		filter(call_class=="SBS", SBSindel_call_type=="mismatch-ss") %>%
 		pluck("bam.gr.filtertrack.reftnc_both_strands",1) %>%
 		select(reftnc, count),
-
+	
 	by = "reftnc",
 	suffix = c(".calls",".interrogated_bases")
 ) %>%
@@ -1784,15 +1784,15 @@ estimatedSBSMutationErrorProbability$by_channel_pyr <- estimatedSBSMutationError
 	arrange(channel_pyr)
 
 estimatedSBSMutationErrorProbability$total <- estimatedSBSMutationErrorProbability$by_channel_pyr %>%
-	pull(error_prob) %>%
+	pull(error_prob) %>% 
 	sum
 
 estimatedSBSMutationErrorProbability$total_corrected_to_genome <- estimatedSBSMutationErrorProbability$by_channel_pyr %>%
-	pull(error_prob_corrected_to_genome) %>%
+	pull(error_prob_corrected_to_genome) %>% 
 	sum
 
 estimatedSBSMutationErrorProbability$total_corrected_to_genome_chromgroup <- estimatedSBSMutationErrorProbability$by_channel_pyr %>%
-	pull(error_prob_corrected_to_genome_chromgroup) %>%
+	pull(error_prob_corrected_to_genome_chromgroup) %>% 
 	sum
 
 rm(estimatedSBSMutationErrorProbability_by_channel)

--- a/bin/extractCalls.R
+++ b/bin/extractCalls.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S Rscript --vanilla
 
 #extractCalls.R:
-# Perform initial molecule filtering and extract calls, including all call information required for analysis.
+# Perform initial molecule filtering and extract calls, including all call information required for analysis.  
 # Note: extracts calls of all call_types across all chromosomes, not just those in configured chromgroups. filterCalls then removes calls outside configured chromgroups.
 
 cat("#### Running extractCalls ####\n")
@@ -164,7 +164,7 @@ run_metadata <- bamFile %>%
           yamlruns <- yaml.config$runs %>%
           	modify_tree(leaf = as.character) %>%
             map_df(~ tibble(run_id = .x$run_id, reads_file = .x$reads_file))
-
+          
           yamlruns %>%
             pluck("run_id") %>%
             keep(yamlruns %>% pluck("reads_file") %>% str_detect(x))
@@ -364,7 +364,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
   #cigar.ops.input for the call_class: "X" for SBS; "I" for insertion; "D" for deletion; NULL for MDB
   #score_bamtag.input: tag in the BAM file containing the MDB score data (MDB only)
   #score_min.input: minimum score of MDBs to extract (MDB only)
-
+  
   #Initialize empty calls tibble
   calls.out <- tibble(
     zm=integer(),
@@ -390,30 +390,30 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
     call_type=factor(),
     indel_width=integer()
     )
-
+  
   #Extract call positions
   if(call_class.input %in% c("SBS","indel")){
-
+    
     #Extract call positions in query space, and name calls with the position to retain this in the final data frame
     cigar.queryspace.var <- cigarRangesAlongQuerySpace(bam.gr.input$cigar,ops=cigar.ops.input)
     cigar.queryspace.var <- cigar.queryspace.var %>%
       unlist(use.names=FALSE) %>%
       setNames(str_c(start(.),end(.),sep="_")) %>%
       relist(.,cigar.queryspace.var)
-
+    
     #Extract call positions in reference space
     cigar.refspace.var <- cigarRangesAlongReferenceSpace(bam.gr.input$cigar,ops=cigar.ops.input,pos=start(bam.gr.input))
-
+    
   }else if(call_class.input == "MDB"){
-
+    
   }
-
+  
   #Check if no calls
   if(cigar.queryspace.var %>% as.data.frame %>% nrow == 0){
     cat("  No calls extracted of type", call_class.input, " / ", call_type.input, "!\n")
     return(calls.out)
   }
-
+  
   #Call positions in query space
   # Note for indels: in query space, deletion width = 0.
   var_queryspace <- cigar.queryspace.var %>%
@@ -428,7 +428,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       start_queryspace = start,
       end_queryspace = end
       )
-
+  
   if(call_class.input %in% c("SBS","MDB")){
     var_queryspace <- var_queryspace %>%
       uncount(weights=width) %>%
@@ -446,7 +446,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       select(-group,-names) %>%
       as_tibble
   }
-
+  
   #Call positions in reference space, annotated with positions in query space for later joining
   # Note for indels: in reference space, insertion width = 0.
   var_refspace <- cigar.refspace.var %>%
@@ -477,7 +477,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       data.frame(seqnames=seqnames(bam.gr.input), zm=bam.gr.input$zm) %>% distinct,
       by = join_by(zm)
     )
-
+  
   if(call_class.input %in% c("SBS","MDB")){
     var_refspace <- var_refspace %>%
       uncount(weights=width) %>%
@@ -497,10 +497,10 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       select(-group) %>%
       as_tibble
   }
-
+  
   rm(cigar.refspace.var)
   invisible(gc())
-
+  
   #Call REF base sequences, relative to reference plus strand
   var_refspace$ref_plus_strand <- var_refspace %>%
     mutate(strand="+") %>%
@@ -513,7 +513,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
     ) %>%
     getSeq(eval(parse(text=BSgenome_name)),.) %>%
     as.character
-
+  
   #Call ALT base sequences, relative to reference plus strand
   var_alt <- extractAt(bam.gr.input$seq,cigar.queryspace.var) %>%
     as("CharacterList") %>%
@@ -529,7 +529,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       start_queryspace = as.integer(start_queryspace),
       end_queryspace = as.integer(end_queryspace)
     )
-
+  
   if(call_class.input %in% c("SBS","MDB")){
     var_alt <- var_alt %>%
       separate_longer_position(alt_plus_strand,width=1) %>%
@@ -540,7 +540,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       ) %>%
       ungroup
   }
-
+  
   #Call base qualities
   if(call_class.input %in% c("SBS","MDB")){
     cigar.queryspace.var.forqualdata <- cigar.queryspace.var
@@ -553,11 +553,11 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
     start(cigar.queryspace.var.forqualdata[deletionidx]) <- newstart[deletionidx]
     end(cigar.queryspace.var.forqualdata[deletionidx]) <- newend[deletionidx]
     cigar.queryspace.var.forqualdata <- cigar.queryspace.var.forqualdata %>% relist(.,cigar.queryspace.var)
-
+    
     rm(deletionidx,newstart,newend)
     invisible(gc())
   }
-
+  
   var_qual <- extractAt(bam.gr.input$qual,cigar.queryspace.var.forqualdata) %>%
     as("CharacterList") %>%
     setNames(str_c(bam.gr.input$zm,strand(bam.gr.input) %>% as.character,sep="_")) %>%
@@ -572,7 +572,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       start_queryspace = as.integer(start_queryspace),
       end_queryspace = as.integer(end_queryspace)
     )
-
+  
   if(call_class.input %in% c("SBS","MDB")){
     var_qual <- var_qual %>%
       separate_longer_position(qual,width=1) %>%
@@ -583,7 +583,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       ) %>%
       ungroup
   }
-
+  
   var_qual <- var_qual %>%
     mutate(
       qual = qual %>%
@@ -592,10 +592,10 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       	as.list %>%
       	set_names(NULL)
     )
-
+  
   rm(cigar.queryspace.var)
   invisible(gc())
-
+  
   #Call base qualities in opposite strand (matched via reference space).
   #For insertions, get the base qualities on the opposite strand from the left and right flanking bases in opposite strand query space that correspond to the call in reference space. For deletions, get base qualities from all bases in opposite strand query space that correspond to the call in reference space, or left and right flanking bases if opposite strand query space width = 0. For mutations, this temporarily assigns wrong values since for these the correct opposite strand bases to get quality from would be the inserted bases on the opposite strand for insertions and the bases flanking the deletion location for deletions. The issue is that we're going from call strand query space to reference space to opposite strand queryspace, rather than through direct alignment of the two strands to each other, which is too computationally complicated. For mutations, these imperfect values are later corrected to the precise opposite strand data: when we annotate which calls are mutations (i.e., on both strands), we reassign opposite strand data for each call from the call call on the opposite strand. For mismatches, this is not possible, so we use the above heuristics for filtering.
   #Set missing values to NA (for example, an SBS across from a deletion).
@@ -610,7 +610,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       keep.extra.columns=TRUE,
       seqinfo=BSgenome_name %>% get %>% seqinfo
     )
-
+  
    #Make GRanges of bam reads parallel to call refspace GRanges, but matching to the opposite strand read from the call
   bam.gr.input.opposite_strand.parallel_to_var_refspace <- bam.gr.input %>%
     select(zm, cigar, qual) %>%
@@ -626,14 +626,14 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
         names(.)
       )
     )
-
+  
    #Convert calls from reference space to query space of opposite strand
   vars_queryspace.opposite_strand <- var_refspace.gr %>%
     pmapToAlignments(bam.gr.input.opposite_strand.parallel_to_var_refspace %>% as("GAlignments")) %>%
     setNames(str_c(var_refspace.gr$start_queryspace, var_refspace.gr$end_queryspace,sep="_")) %>%
     (function(x) IRanges(start=start(x), end=end(x), names=names(x), seqnames = seqnames(x) %>% as.character)) %>%
     filter(seqnames != "UNMAPPED")
-
+  
   #For indels, if opposite strand query space width = 0, swap start/end to get flanking bases.
   if(call_class.input == "indel"){
     vars_queryspace.opposite_strand <- vars_queryspace.opposite_strand %>%
@@ -645,10 +645,10 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       ) %>%
       select(-start_tmp,-end_tmp)
   }
-
+  
   vars_queryspace.opposite_strand <- vars_queryspace.opposite_strand %>%
     split(mcols(.)$seqnames)
-
+  
    #Extract qual from opposite strand. Set missing values to NA.
   var_qual.opposite_strand <- extractAt(
     bam.gr.input.opposite_strand.parallel_to_var_refspace %>%
@@ -680,26 +680,26 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
         set_names(NULL) %>%
         map_if(~ length(.x) == 0, ~NA_integer_)
     )
-
+  
   rm(var_refspace.gr, bam.gr.input.opposite_strand.parallel_to_var_refspace)
   invisible(gc())
-
-
+  
+  
   #Extract sa/sm/sx tags
   # For insertions, get base qualities of inserted bases in query space, relative to reference plus strand. For deletions, get base qualities of left and right flanking bases in query space, relative to reference plus strand.
   #For insertions, get the base qualities on the opposite strand from the left and right flanking bases in opposite strand query space that correspond to the call in reference space. For deletions, get base qualities from all bases in opposite strand query space that correspond to the call in reference space. For mutations, this temporarily assigns wrong values since for these the correct opposite strand bases to get quality from would be the inserted bases on the opposite strand for insertions and the bases flanking the deletion location for deletions. The issue is that we're going from call strand query space to reference space to opposite strand queryspace, rather than through direct alignment of the two strands to each other, which is too computationally complicated. For mutations, these imperfect values are later corrected to the precise opposite strand data: when we annotate which calls are mutations (i.e., on both strands), we reassign opposite strand data for each call from the call on the opposite strand. For mismatches, this is not possible, so we use the above heuristics for filtering.
-
+  
   #Format sa, sm, sx inputs
   sa.input <- bam.gr.input$sa %>%
   	lapply(as.vector) %>%
   	setNames(str_c(bam.gr.input$zm, strand(bam.gr.input) %>% as.character,sep="_"))
-
+  
   sm.input <- bam.gr.input$sm %>%
   	setNames(str_c(bam.gr.input$zm, strand(bam.gr.input) %>% as.character,sep="_"))
-
+  
   sx.input <- bam.gr.input$sx %>%
   	setNames(str_c(bam.gr.input$zm, strand(bam.gr.input) %>% as.character,sep="_"))
-
+  
   if(call_class.input %in% c("SBS","MDB")){
     #Convert call positions in query space to list for faster retrieval below of sa, sm, sx tags
     var_queryspace.list <- var_queryspace %>%
@@ -708,14 +708,14 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       as.data.table %>%
       split(by="zm_strand",keep.by=F) %>%
       lapply(unlist,use.names=F)
-
+    
     var_queryspace.opposite_strand.list <- vars_queryspace.opposite_strand %>%
       as.data.table %>%
       filter(start==end) %>% #Remove sites whose opposite strand aligned to width = -1, meaning there is no reference-aligned base on the opposite strand. These will then become NA after the final join.
       select(seqnames, start) %>%
       split(by="seqnames",keep.by=F) %>%
       lapply(unlist,use.names=F)
-
+    
     vars_queryspace.coordconversion <- vars_queryspace.opposite_strand %>%
       as.data.table %>%
       as_tibble %>%
@@ -729,7 +729,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
         end_queryspace = start_queryspace
       ) %>%
       select(-group,-group_name,-width)
-
+    
     #Define extraction function
     extract_sasmsx <- function(tag.input, tagdata.input, var_queryspace.list.input, vars_queryspace.coordconversion.input=NULL){
       result <- map2(tagdata.input[var_queryspace.list.input %>% names], var_queryspace.list.input, ~ .x[.y] %>% set_names(.y)) %>%
@@ -743,7 +743,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
             end_queryspace = start_queryspace,
             !!tag.input := .data[[tag.input]] %>% as.list %>% set_names(NULL)
           )
-
+      
       #Convert query space coordinate of opposite strand to call strand (if extracting opposite strand data)
       if(!is.null(vars_queryspace.coordconversion.input)){
         result <- result  %>%
@@ -757,23 +757,23 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
           ) %>%
           select(-start,-end)
       }
-
+      
       return(result)
     }
-
+    
     #Extract data
     var_sa <- extract_sasmsx(
       "sa",
       sa.input,
       var_queryspace.list
       )
-
+    
     var_sm <- extract_sasmsx(
       "sm",
       sm.input,
       var_queryspace.list
     )
-
+ 
     var_sx <- extract_sasmsx(
       "sx",
       sx.input,
@@ -786,24 +786,24 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       var_queryspace.opposite_strand.list,
       vars_queryspace.coordconversion
     )
-
+    
     var_sm.opposite_strand <- extract_sasmsx(
       "sm.opposite_strand",
       sm.input %>% setNames(names(.) %>% chartr("+-","-+",.)),
       var_queryspace.opposite_strand.list,
       vars_queryspace.coordconversion
     )
-
+    
     var_sx.opposite_strand <- extract_sasmsx(
       "sx.opposite_strand",
       sx.input %>% setNames(names(.) %>% chartr("+-","-+",.)),
       var_queryspace.opposite_strand.list,
       vars_queryspace.coordconversion
     )
-
+    
     rm(var_queryspace.list, var_queryspace.opposite_strand.list, vars_queryspace.coordconversion)
     invisible(gc())
-
+    
   }else if(call_class.input == "indel"){
     #Convert indel positions in query space to a format for faster retrieval below of sa, sm, sx tags.
     # Flatten indel ranges, annotate with start_end_queryspace, then expand the ranges into the needed query_pos, preserving start_end_queryspace.
@@ -823,7 +823,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       mutate(pos_queryspace = start_queryspace + row_number() - 1) %>%
       select(zm_strand,start_end_queryspace,pos_queryspace) %>%
       as.data.table
-
+    
     indels_queryspace_pos.opposite_strand <- vars_queryspace.opposite_strand %>%
       as.data.frame %>%
       select(-seqnames) %>%
@@ -840,15 +840,15 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       mutate(pos_queryspace = start_queryspace + row_number() - 1) %>%
       select(zm_strand,start_end_queryspace,pos_queryspace) %>%
       as.data.table
-
+    
     setkey(indels_queryspace_pos, zm_strand, start_end_queryspace)
     setkey(indels_queryspace_pos.opposite_strand, zm_strand, start_end_queryspace)
-
+    
     #Extract data
     indels_queryspace_pos[, sa_val := sa.input[[zm_strand[1]]][pos_queryspace], by = zm_strand]
     indels_queryspace_pos[, sm_val := sm.input[[zm_strand[1]]][pos_queryspace], by = zm_strand]
     indels_queryspace_pos[, sx_val := sx.input[[zm_strand[1]]][pos_queryspace], by = zm_strand]
-
+    
     sa.input.opposite_strand <- sa.input %>% setNames(names(.) %>% chartr("+-","-+",.))
     sm.input.opposite_strand <- sm.input %>% setNames(names(.) %>% chartr("+-","-+",.))
     sx.input.opposite_strand <- sx.input %>% setNames(names(.) %>% chartr("+-","-+",.))
@@ -856,10 +856,10 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
     indels_queryspace_pos.opposite_strand[, sa_val := sa.input.opposite_strand[[zm_strand[1]]][pos_queryspace], by = zm_strand]
     indels_queryspace_pos.opposite_strand[, sm_val := sm.input.opposite_strand[[zm_strand[1]]][pos_queryspace], by = zm_strand]
     indels_queryspace_pos.opposite_strand[, sx_val := sx.input.opposite_strand[[zm_strand[1]]][pos_queryspace], by = zm_strand]
-
+    
     rm(cigar.queryspace.var.forqualdata, vars_queryspace.opposite_strand)
     invisible(gc())
-
+    
     #Aggregate back into a list-of-vectors per (name, start_end_queryspace), and reformat columns for later joining
     indels_queryspace_pos <- indels_queryspace_pos[, .(sa = list(sa_val), sm = list(sm_val), sx = list(sx_val)), by = .(zm_strand, start_end_queryspace)] %>%
       as_tibble %>%
@@ -871,7 +871,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
         start_queryspace = as.integer(start_queryspace),
         end_queryspace = as.integer(end_queryspace)
       )
-
+    
     indels_queryspace_pos.opposite_strand <- indels_queryspace_pos.opposite_strand[, .(sa.opposite_strand = list(sa_val), sm.opposite_strand = list(sm_val), sx.opposite_strand = list(sx_val)), by = .(zm_strand, start_end_queryspace)] %>%
       as_tibble %>%
       separate(zm_strand,sep="_",into=c("zm","strand")) %>%
@@ -882,14 +882,14 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
         start_queryspace = as.integer(start_queryspace),
         end_queryspace = as.integer(end_queryspace)
       )
-
+    
     rm(sa.input.opposite_strand, sm.input.opposite_strand, sx.input.opposite_strand)
     invisible(gc())
   }
-
+  
   rm(sa.input, sm.input, sx.input)
   invisible(gc())
-
+  
   #Combine call info with prior empty initialized tibble and return result
   if(call_class.input %in% c("SBS","MDB")){
     calls.out <- calls.out %>%
@@ -922,7 +922,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
           select(-deletion_width,-insertion_width)
       )
   }
-
+  
   #Replace NA/NULL opposite strand values with list(NA)
   calls.out <- calls.out %>%
     mutate(
@@ -931,7 +931,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
         ~ replace(.x, vapply(.x, function(el) is.null(el) || identical(el, NA), logical(1)), list(NA))
       )
     )
-
+  
   #Annotate barcode tag (bc) from input reads
   calls.out <- calls.out %>%
   	select(-bc) %>%
@@ -949,7 +949,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       call_class = !!call_class.input %>% factor,
       call_type = !!call_type.input %>% factor
       )
-
+  
   return(calls.out)
 }
 
@@ -967,12 +967,12 @@ calls <- list()
 for(i in bam.gr %>% names){
 
   cat("> Processing run:",i,"\n")
-
+  
   ######################
   ### Extract calls
   ######################
   cat("    Extracting single base substitutions...")
-
+  
   #SBS
   calls[[i]] <- extract_calls(
     bam.gr.input = bam.gr[[i]],
@@ -980,12 +980,12 @@ for(i in bam.gr %>% names){
     call_type.input = "SBS",
     cigar.ops.input = "X"
     )
-
+  
   cat("DONE\n")
-
+  
   #Insertions
   cat("    Extracting insertions...")
-
+  
   calls[[i]] <- calls[[i]] %>%
     bind_rows(
       extract_calls(
@@ -997,10 +997,10 @@ for(i in bam.gr %>% names){
     )
 
   cat("DONE\n")
-
+  
   #Deletions
   cat("    Extracting deletions...")
-
+  
   calls[[i]] <- calls[[i]] %>%
     bind_rows(
       extract_calls(
@@ -1010,15 +1010,15 @@ for(i in bam.gr %>% names){
         cigar.ops.input = c("D")
       )
     )
-
+  
   cat("DONE\n")
-
-
+  
+  
   #MDBs
   for(j in seq_len(nrow(call_types_MDB))){
-
+    
     cat("    Extracting",call_types_MDB %>% pluck("call_type",j),"...")
-
+    
     calls[[i]] <- calls[[i]] %>%
       bind_rows(
         extract_calls(
@@ -1029,10 +1029,10 @@ for(i in bam.gr %>% names){
           call_bam_scoretag_min.input = call_types_MDB %>% pluck("call_bam_scoretag_min",j)
         )
       )
-
+    
     cat("DONE\n")
   }
-
+  
 }
 
 ######################
@@ -1073,32 +1073,32 @@ calls <- calls %>%
 			) %>%
 			resize(width=3,fix="center") %>%
 			suppressWarnings %>% #remove warnings of out of bounds regions due to resize
-
+			
 			#Remove trinucleotide contexts that extend past a non-circular chromosome edge (after trim, width < 3) to yield NA tnc value
 			trim %>%
 			filter(width == 3) %>%
-
+			
 			#Get trinucleotide context sequence for the reference plus and minus strands. The latter is calculated here to avoid error when calculating it for NA values, and it is used for later assignment to synthesized and template strand trinucleotide columns. Also calculate trinucleotide context with central pyrimidine
 			mutate(
 				reftnc_plus_strand = getSeq(eval(parse(text=BSgenome_name)),.) %>%
 					as.character %>%
 					factor(levels = trinucleotides_64)
 			) %>%
-
+			
 			#Remove trinucleotide contexts that are NA, which occurs when the trinucleotide sequence contains 'N'
 			filter(!is.na(reftnc_plus_strand)) %>%
-
+			
 			mutate(
 				reftnc_minus_strand = reftnc_plus_strand %>%
 					DNAStringSet %>%
 					reverseComplement %>%
 					as.character %>%
 					factor(levels = trinucleotides_64),
-
+				
 				reftnc_pyr = if_else(str_sub(reftnc_plus_strand,2,2) %in% c("C","T"), reftnc_plus_strand, reftnc_minus_strand) %>%
 					factor(levels = trinucleotides_32_pyr)
 			) %>%
-
+			
 			#Resize back to original start/end, and make tibble
 			resize(width=1,fix="center") %>%
 			as_tibble %>%
@@ -1117,14 +1117,14 @@ calls <- calls %>%
 		ref_minus_strand = ref_plus_strand %>% DNAStringSet %>% reverseComplement %>% as.character,
 		ref_synthesized_strand = if_else(strand=="+",ref_plus_strand,ref_minus_strand),
 		ref_template_strand = if_else(strand=="+",ref_minus_strand,ref_plus_strand),
-
+		
 		alt_minus_strand = alt_plus_strand %>% DNAStringSet %>% reverseComplement %>% as.character,
 		alt_synthesized_strand = if_else(strand=="+",alt_plus_strand,alt_minus_strand),
 		alt_template_strand = if_else(strand=="+",alt_minus_strand,alt_plus_strand),
-
+		
 		reftnc_synthesized_strand = if_else(strand=="+",reftnc_plus_strand,reftnc_minus_strand),
 		reftnc_template_strand = if_else(strand=="+",reftnc_minus_strand,reftnc_plus_strand),
-
+		
 		alttnc_plus_strand = str_c(
 			str_sub(reftnc_plus_strand,1,1),
 			alt_plus_strand,
@@ -1144,10 +1144,10 @@ calls <- calls %>%
 			alttnc_minus_strand
 		) %>%
 			factor(levels = trinucleotides_64),
-
+		
 		alttnc_synthesized_strand = if_else(strand=="+",alttnc_plus_strand,alttnc_minus_strand),
 		alttnc_template_strand = if_else(strand=="+",alttnc_minus_strand,alttnc_plus_strand)
-
+	
 	) %>%
 	select(-c(ref_minus_strand,alt_minus_strand,reftnc_minus_strand,alttnc_minus_strand))
 
@@ -1221,7 +1221,7 @@ s_call_type <- calls.gr.keyed.opposite$call_type[sh]
 s_start_refspace <- calls.gr.keyed.opposite$start_refspace[sh]
 s_end_refspace <- calls.gr.keyed.opposite$end_refspace[sh]
 
-calls.gr.hits.keep <-
+calls.gr.hits.keep <- 
 	(
 		q_call_class %in% c("SBS","MDB") & s_call_type == "SBS" &
 			q_start_refspace == s_start_refspace & q_end_refspace == s_end_refspace
@@ -1261,7 +1261,7 @@ calls.gr$alt_plus_strand.opposite_strand <- calls.gr.keyed.opposite$alt_plus_str
 calls.gr$start_refspace.opposite_strand <- calls.gr.keyed.opposite$start_refspace
 calls.gr$end_refspace.opposite_strand <- calls.gr.keyed.opposite$end_refspace
 
-calls.gr <- calls.gr %>%
+calls.gr <- calls.gr %>% 
 	mutate(
 		deletion.bothstrands.startendmatch = case_when(
 			call_type != "deletion" | call_type.opposite_strand != "deletion" ~ NA,

--- a/bin/extractCalls.R
+++ b/bin/extractCalls.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S Rscript --vanilla
 
 #extractCalls.R:
-# Perform initial molecule filtering and extract calls, including all call information required for analysis.  
+# Perform initial molecule filtering and extract calls, including all call information required for analysis.
 # Note: extracts calls of all call_types across all chromosomes, not just those in configured chromgroups. filterCalls then removes calls outside configured chromgroups.
 
 cat("#### Running extractCalls ####\n")
@@ -20,6 +20,11 @@ suppressPackageStartupMessages(library(plyranges))
 suppressPackageStartupMessages(library(configr))
 suppressPackageStartupMessages(library(qs2))
 suppressPackageStartupMessages(library(tidyverse))
+
+######################
+### Load custom shared functions
+######################
+source(Sys.which("sharedFunctions.R"))
 
 ######################
 ### Load configuration
@@ -49,9 +54,10 @@ if(is.null(opt$config) | is.null(opt$bam) | is.null(opt$output)){
 yaml.config <- suppressWarnings(read.config(opt$config))
 bamFile <- opt$bam
 outputFile <- opt$output
+BSgenome_name <- get_bsgenome_name(yaml.config)
 
 #Load the BSgenome reference
-suppressPackageStartupMessages(library(yaml.config$BSgenome$BSgenome_name,character.only=TRUE,lib.loc=yaml.config$cache_dir))
+suppressPackageStartupMessages(library(BSgenome_name,character.only=TRUE,lib.loc=yaml.config$cache_dir))
 
 #General parameters
 strand_levels <- c("+","-")
@@ -84,16 +90,11 @@ chroms_toanalyze <- yaml.config$chromgroups %>%
 		),
 		tibble(
 			chromgroup = "all_chroms",
-			chroms = yaml.config$BSgenome$BSgenome_name %>% get %>% seqnames %>% list
+			chroms = BSgenome_name %>% get %>% seqnames %>% list
 		)
 	)
 
 cat("DONE\n")
-
-######################
-### Load custom shared functions
-######################
-source(Sys.which("sharedFunctions.R"))
 
 ######################
 ### Define custom functions
@@ -163,7 +164,7 @@ run_metadata <- bamFile %>%
           yamlruns <- yaml.config$runs %>%
           	modify_tree(leaf = as.character) %>%
             map_df(~ tibble(run_id = .x$run_id, reads_file = .x$reads_file))
-          
+
           yamlruns %>%
             pluck("run_id") %>%
             keep(yamlruns %>% pluck("reads_file") %>% str_detect(x))
@@ -248,7 +249,7 @@ bam.gr <- bam.df %>%
     end.field="end",
     strand.field="strand",
     keep.extra.columns=TRUE,
-    seqinfo=yaml.config$BSgenome$BSgenome_name %>% get %>% seqinfo
+    seqinfo=BSgenome_name %>% get %>% seqinfo
   )
 
 rm(bam.df)
@@ -363,7 +364,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
   #cigar.ops.input for the call_class: "X" for SBS; "I" for insertion; "D" for deletion; NULL for MDB
   #score_bamtag.input: tag in the BAM file containing the MDB score data (MDB only)
   #score_min.input: minimum score of MDBs to extract (MDB only)
-  
+
   #Initialize empty calls tibble
   calls.out <- tibble(
     zm=integer(),
@@ -389,30 +390,30 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
     call_type=factor(),
     indel_width=integer()
     )
-  
+
   #Extract call positions
   if(call_class.input %in% c("SBS","indel")){
-    
+
     #Extract call positions in query space, and name calls with the position to retain this in the final data frame
     cigar.queryspace.var <- cigarRangesAlongQuerySpace(bam.gr.input$cigar,ops=cigar.ops.input)
     cigar.queryspace.var <- cigar.queryspace.var %>%
       unlist(use.names=FALSE) %>%
       setNames(str_c(start(.),end(.),sep="_")) %>%
       relist(.,cigar.queryspace.var)
-    
+
     #Extract call positions in reference space
     cigar.refspace.var <- cigarRangesAlongReferenceSpace(bam.gr.input$cigar,ops=cigar.ops.input,pos=start(bam.gr.input))
-    
+
   }else if(call_class.input == "MDB"){
-    
+
   }
-  
+
   #Check if no calls
   if(cigar.queryspace.var %>% as.data.frame %>% nrow == 0){
     cat("  No calls extracted of type", call_class.input, " / ", call_type.input, "!\n")
     return(calls.out)
   }
-  
+
   #Call positions in query space
   # Note for indels: in query space, deletion width = 0.
   var_queryspace <- cigar.queryspace.var %>%
@@ -427,7 +428,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       start_queryspace = start,
       end_queryspace = end
       )
-  
+
   if(call_class.input %in% c("SBS","MDB")){
     var_queryspace <- var_queryspace %>%
       uncount(weights=width) %>%
@@ -445,7 +446,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       select(-group,-names) %>%
       as_tibble
   }
-  
+
   #Call positions in reference space, annotated with positions in query space for later joining
   # Note for indels: in reference space, insertion width = 0.
   var_refspace <- cigar.refspace.var %>%
@@ -476,7 +477,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       data.frame(seqnames=seqnames(bam.gr.input), zm=bam.gr.input$zm) %>% distinct,
       by = join_by(zm)
     )
-  
+
   if(call_class.input %in% c("SBS","MDB")){
     var_refspace <- var_refspace %>%
       uncount(weights=width) %>%
@@ -496,10 +497,10 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       select(-group) %>%
       as_tibble
   }
-  
+
   rm(cigar.refspace.var)
   invisible(gc())
-  
+
   #Call REF base sequences, relative to reference plus strand
   var_refspace$ref_plus_strand <- var_refspace %>%
     mutate(strand="+") %>%
@@ -508,11 +509,11 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       start.field="start_refspace",
       end.field="end_refspace",
       strand.field="strand",
-      seqinfo=yaml.config$BSgenome$BSgenome_name %>% get %>% seqinfo
+      seqinfo=BSgenome_name %>% get %>% seqinfo
     ) %>%
-    getSeq(eval(parse(text=yaml.config$BSgenome$BSgenome_name)),.) %>%
+    getSeq(eval(parse(text=BSgenome_name)),.) %>%
     as.character
-  
+
   #Call ALT base sequences, relative to reference plus strand
   var_alt <- extractAt(bam.gr.input$seq,cigar.queryspace.var) %>%
     as("CharacterList") %>%
@@ -528,7 +529,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       start_queryspace = as.integer(start_queryspace),
       end_queryspace = as.integer(end_queryspace)
     )
-  
+
   if(call_class.input %in% c("SBS","MDB")){
     var_alt <- var_alt %>%
       separate_longer_position(alt_plus_strand,width=1) %>%
@@ -539,7 +540,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       ) %>%
       ungroup
   }
-  
+
   #Call base qualities
   if(call_class.input %in% c("SBS","MDB")){
     cigar.queryspace.var.forqualdata <- cigar.queryspace.var
@@ -552,11 +553,11 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
     start(cigar.queryspace.var.forqualdata[deletionidx]) <- newstart[deletionidx]
     end(cigar.queryspace.var.forqualdata[deletionidx]) <- newend[deletionidx]
     cigar.queryspace.var.forqualdata <- cigar.queryspace.var.forqualdata %>% relist(.,cigar.queryspace.var)
-    
+
     rm(deletionidx,newstart,newend)
     invisible(gc())
   }
-  
+
   var_qual <- extractAt(bam.gr.input$qual,cigar.queryspace.var.forqualdata) %>%
     as("CharacterList") %>%
     setNames(str_c(bam.gr.input$zm,strand(bam.gr.input) %>% as.character,sep="_")) %>%
@@ -571,7 +572,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       start_queryspace = as.integer(start_queryspace),
       end_queryspace = as.integer(end_queryspace)
     )
-  
+
   if(call_class.input %in% c("SBS","MDB")){
     var_qual <- var_qual %>%
       separate_longer_position(qual,width=1) %>%
@@ -582,7 +583,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       ) %>%
       ungroup
   }
-  
+
   var_qual <- var_qual %>%
     mutate(
       qual = qual %>%
@@ -591,10 +592,10 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       	as.list %>%
       	set_names(NULL)
     )
-  
+
   rm(cigar.queryspace.var)
   invisible(gc())
-  
+
   #Call base qualities in opposite strand (matched via reference space).
   #For insertions, get the base qualities on the opposite strand from the left and right flanking bases in opposite strand query space that correspond to the call in reference space. For deletions, get base qualities from all bases in opposite strand query space that correspond to the call in reference space, or left and right flanking bases if opposite strand query space width = 0. For mutations, this temporarily assigns wrong values since for these the correct opposite strand bases to get quality from would be the inserted bases on the opposite strand for insertions and the bases flanking the deletion location for deletions. The issue is that we're going from call strand query space to reference space to opposite strand queryspace, rather than through direct alignment of the two strands to each other, which is too computationally complicated. For mutations, these imperfect values are later corrected to the precise opposite strand data: when we annotate which calls are mutations (i.e., on both strands), we reassign opposite strand data for each call from the call call on the opposite strand. For mismatches, this is not possible, so we use the above heuristics for filtering.
   #Set missing values to NA (for example, an SBS across from a deletion).
@@ -607,9 +608,9 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       end.field="end_refspace",
       strand.field="strand",
       keep.extra.columns=TRUE,
-      seqinfo=yaml.config$BSgenome$BSgenome_name %>% get %>% seqinfo
+      seqinfo=BSgenome_name %>% get %>% seqinfo
     )
-  
+
    #Make GRanges of bam reads parallel to call refspace GRanges, but matching to the opposite strand read from the call
   bam.gr.input.opposite_strand.parallel_to_var_refspace <- bam.gr.input %>%
     select(zm, cigar, qual) %>%
@@ -625,14 +626,14 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
         names(.)
       )
     )
-  
+
    #Convert calls from reference space to query space of opposite strand
   vars_queryspace.opposite_strand <- var_refspace.gr %>%
     pmapToAlignments(bam.gr.input.opposite_strand.parallel_to_var_refspace %>% as("GAlignments")) %>%
     setNames(str_c(var_refspace.gr$start_queryspace, var_refspace.gr$end_queryspace,sep="_")) %>%
     (function(x) IRanges(start=start(x), end=end(x), names=names(x), seqnames = seqnames(x) %>% as.character)) %>%
     filter(seqnames != "UNMAPPED")
-  
+
   #For indels, if opposite strand query space width = 0, swap start/end to get flanking bases.
   if(call_class.input == "indel"){
     vars_queryspace.opposite_strand <- vars_queryspace.opposite_strand %>%
@@ -644,10 +645,10 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       ) %>%
       select(-start_tmp,-end_tmp)
   }
-  
+
   vars_queryspace.opposite_strand <- vars_queryspace.opposite_strand %>%
     split(mcols(.)$seqnames)
-  
+
    #Extract qual from opposite strand. Set missing values to NA.
   var_qual.opposite_strand <- extractAt(
     bam.gr.input.opposite_strand.parallel_to_var_refspace %>%
@@ -679,26 +680,26 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
         set_names(NULL) %>%
         map_if(~ length(.x) == 0, ~NA_integer_)
     )
-  
+
   rm(var_refspace.gr, bam.gr.input.opposite_strand.parallel_to_var_refspace)
   invisible(gc())
-  
-  
+
+
   #Extract sa/sm/sx tags
   # For insertions, get base qualities of inserted bases in query space, relative to reference plus strand. For deletions, get base qualities of left and right flanking bases in query space, relative to reference plus strand.
   #For insertions, get the base qualities on the opposite strand from the left and right flanking bases in opposite strand query space that correspond to the call in reference space. For deletions, get base qualities from all bases in opposite strand query space that correspond to the call in reference space. For mutations, this temporarily assigns wrong values since for these the correct opposite strand bases to get quality from would be the inserted bases on the opposite strand for insertions and the bases flanking the deletion location for deletions. The issue is that we're going from call strand query space to reference space to opposite strand queryspace, rather than through direct alignment of the two strands to each other, which is too computationally complicated. For mutations, these imperfect values are later corrected to the precise opposite strand data: when we annotate which calls are mutations (i.e., on both strands), we reassign opposite strand data for each call from the call on the opposite strand. For mismatches, this is not possible, so we use the above heuristics for filtering.
-  
+
   #Format sa, sm, sx inputs
   sa.input <- bam.gr.input$sa %>%
   	lapply(as.vector) %>%
   	setNames(str_c(bam.gr.input$zm, strand(bam.gr.input) %>% as.character,sep="_"))
-  
+
   sm.input <- bam.gr.input$sm %>%
   	setNames(str_c(bam.gr.input$zm, strand(bam.gr.input) %>% as.character,sep="_"))
-  
+
   sx.input <- bam.gr.input$sx %>%
   	setNames(str_c(bam.gr.input$zm, strand(bam.gr.input) %>% as.character,sep="_"))
-  
+
   if(call_class.input %in% c("SBS","MDB")){
     #Convert call positions in query space to list for faster retrieval below of sa, sm, sx tags
     var_queryspace.list <- var_queryspace %>%
@@ -707,14 +708,14 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       as.data.table %>%
       split(by="zm_strand",keep.by=F) %>%
       lapply(unlist,use.names=F)
-    
+
     var_queryspace.opposite_strand.list <- vars_queryspace.opposite_strand %>%
       as.data.table %>%
       filter(start==end) %>% #Remove sites whose opposite strand aligned to width = -1, meaning there is no reference-aligned base on the opposite strand. These will then become NA after the final join.
       select(seqnames, start) %>%
       split(by="seqnames",keep.by=F) %>%
       lapply(unlist,use.names=F)
-    
+
     vars_queryspace.coordconversion <- vars_queryspace.opposite_strand %>%
       as.data.table %>%
       as_tibble %>%
@@ -728,7 +729,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
         end_queryspace = start_queryspace
       ) %>%
       select(-group,-group_name,-width)
-    
+
     #Define extraction function
     extract_sasmsx <- function(tag.input, tagdata.input, var_queryspace.list.input, vars_queryspace.coordconversion.input=NULL){
       result <- map2(tagdata.input[var_queryspace.list.input %>% names], var_queryspace.list.input, ~ .x[.y] %>% set_names(.y)) %>%
@@ -742,7 +743,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
             end_queryspace = start_queryspace,
             !!tag.input := .data[[tag.input]] %>% as.list %>% set_names(NULL)
           )
-      
+
       #Convert query space coordinate of opposite strand to call strand (if extracting opposite strand data)
       if(!is.null(vars_queryspace.coordconversion.input)){
         result <- result  %>%
@@ -756,23 +757,23 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
           ) %>%
           select(-start,-end)
       }
-      
+
       return(result)
     }
-    
+
     #Extract data
     var_sa <- extract_sasmsx(
       "sa",
       sa.input,
       var_queryspace.list
       )
-    
+
     var_sm <- extract_sasmsx(
       "sm",
       sm.input,
       var_queryspace.list
     )
- 
+
     var_sx <- extract_sasmsx(
       "sx",
       sx.input,
@@ -785,24 +786,24 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       var_queryspace.opposite_strand.list,
       vars_queryspace.coordconversion
     )
-    
+
     var_sm.opposite_strand <- extract_sasmsx(
       "sm.opposite_strand",
       sm.input %>% setNames(names(.) %>% chartr("+-","-+",.)),
       var_queryspace.opposite_strand.list,
       vars_queryspace.coordconversion
     )
-    
+
     var_sx.opposite_strand <- extract_sasmsx(
       "sx.opposite_strand",
       sx.input %>% setNames(names(.) %>% chartr("+-","-+",.)),
       var_queryspace.opposite_strand.list,
       vars_queryspace.coordconversion
     )
-    
+
     rm(var_queryspace.list, var_queryspace.opposite_strand.list, vars_queryspace.coordconversion)
     invisible(gc())
-    
+
   }else if(call_class.input == "indel"){
     #Convert indel positions in query space to a format for faster retrieval below of sa, sm, sx tags.
     # Flatten indel ranges, annotate with start_end_queryspace, then expand the ranges into the needed query_pos, preserving start_end_queryspace.
@@ -822,7 +823,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       mutate(pos_queryspace = start_queryspace + row_number() - 1) %>%
       select(zm_strand,start_end_queryspace,pos_queryspace) %>%
       as.data.table
-    
+
     indels_queryspace_pos.opposite_strand <- vars_queryspace.opposite_strand %>%
       as.data.frame %>%
       select(-seqnames) %>%
@@ -839,15 +840,15 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       mutate(pos_queryspace = start_queryspace + row_number() - 1) %>%
       select(zm_strand,start_end_queryspace,pos_queryspace) %>%
       as.data.table
-    
+
     setkey(indels_queryspace_pos, zm_strand, start_end_queryspace)
     setkey(indels_queryspace_pos.opposite_strand, zm_strand, start_end_queryspace)
-    
+
     #Extract data
     indels_queryspace_pos[, sa_val := sa.input[[zm_strand[1]]][pos_queryspace], by = zm_strand]
     indels_queryspace_pos[, sm_val := sm.input[[zm_strand[1]]][pos_queryspace], by = zm_strand]
     indels_queryspace_pos[, sx_val := sx.input[[zm_strand[1]]][pos_queryspace], by = zm_strand]
-    
+
     sa.input.opposite_strand <- sa.input %>% setNames(names(.) %>% chartr("+-","-+",.))
     sm.input.opposite_strand <- sm.input %>% setNames(names(.) %>% chartr("+-","-+",.))
     sx.input.opposite_strand <- sx.input %>% setNames(names(.) %>% chartr("+-","-+",.))
@@ -855,10 +856,10 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
     indels_queryspace_pos.opposite_strand[, sa_val := sa.input.opposite_strand[[zm_strand[1]]][pos_queryspace], by = zm_strand]
     indels_queryspace_pos.opposite_strand[, sm_val := sm.input.opposite_strand[[zm_strand[1]]][pos_queryspace], by = zm_strand]
     indels_queryspace_pos.opposite_strand[, sx_val := sx.input.opposite_strand[[zm_strand[1]]][pos_queryspace], by = zm_strand]
-    
+
     rm(cigar.queryspace.var.forqualdata, vars_queryspace.opposite_strand)
     invisible(gc())
-    
+
     #Aggregate back into a list-of-vectors per (name, start_end_queryspace), and reformat columns for later joining
     indels_queryspace_pos <- indels_queryspace_pos[, .(sa = list(sa_val), sm = list(sm_val), sx = list(sx_val)), by = .(zm_strand, start_end_queryspace)] %>%
       as_tibble %>%
@@ -870,7 +871,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
         start_queryspace = as.integer(start_queryspace),
         end_queryspace = as.integer(end_queryspace)
       )
-    
+
     indels_queryspace_pos.opposite_strand <- indels_queryspace_pos.opposite_strand[, .(sa.opposite_strand = list(sa_val), sm.opposite_strand = list(sm_val), sx.opposite_strand = list(sx_val)), by = .(zm_strand, start_end_queryspace)] %>%
       as_tibble %>%
       separate(zm_strand,sep="_",into=c("zm","strand")) %>%
@@ -881,14 +882,14 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
         start_queryspace = as.integer(start_queryspace),
         end_queryspace = as.integer(end_queryspace)
       )
-    
+
     rm(sa.input.opposite_strand, sm.input.opposite_strand, sx.input.opposite_strand)
     invisible(gc())
   }
-  
+
   rm(sa.input, sm.input, sx.input)
   invisible(gc())
-  
+
   #Combine call info with prior empty initialized tibble and return result
   if(call_class.input %in% c("SBS","MDB")){
     calls.out <- calls.out %>%
@@ -921,7 +922,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
           select(-deletion_width,-insertion_width)
       )
   }
-  
+
   #Replace NA/NULL opposite strand values with list(NA)
   calls.out <- calls.out %>%
     mutate(
@@ -930,7 +931,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
         ~ replace(.x, vapply(.x, function(el) is.null(el) || identical(el, NA), logical(1)), list(NA))
       )
     )
-  
+
   #Annotate barcode tag (bc) from input reads
   calls.out <- calls.out %>%
   	select(-bc) %>%
@@ -948,7 +949,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
       call_class = !!call_class.input %>% factor,
       call_type = !!call_type.input %>% factor
       )
-  
+
   return(calls.out)
 }
 
@@ -966,12 +967,12 @@ calls <- list()
 for(i in bam.gr %>% names){
 
   cat("> Processing run:",i,"\n")
-  
+
   ######################
   ### Extract calls
   ######################
   cat("    Extracting single base substitutions...")
-  
+
   #SBS
   calls[[i]] <- extract_calls(
     bam.gr.input = bam.gr[[i]],
@@ -979,12 +980,12 @@ for(i in bam.gr %>% names){
     call_type.input = "SBS",
     cigar.ops.input = "X"
     )
-  
+
   cat("DONE\n")
-  
+
   #Insertions
   cat("    Extracting insertions...")
-  
+
   calls[[i]] <- calls[[i]] %>%
     bind_rows(
       extract_calls(
@@ -996,10 +997,10 @@ for(i in bam.gr %>% names){
     )
 
   cat("DONE\n")
-  
+
   #Deletions
   cat("    Extracting deletions...")
-  
+
   calls[[i]] <- calls[[i]] %>%
     bind_rows(
       extract_calls(
@@ -1009,15 +1010,15 @@ for(i in bam.gr %>% names){
         cigar.ops.input = c("D")
       )
     )
-  
+
   cat("DONE\n")
-  
-  
+
+
   #MDBs
   for(j in seq_len(nrow(call_types_MDB))){
-    
+
     cat("    Extracting",call_types_MDB %>% pluck("call_type",j),"...")
-    
+
     calls[[i]] <- calls[[i]] %>%
       bind_rows(
         extract_calls(
@@ -1028,10 +1029,10 @@ for(i in bam.gr %>% names){
           call_bam_scoretag_min.input = call_types_MDB %>% pluck("call_bam_scoretag_min",j)
         )
       )
-    
+
     cat("DONE\n")
   }
-  
+
 }
 
 ######################
@@ -1068,36 +1069,36 @@ calls <- calls %>%
 				start.field="start_refspace",
 				end.field="end_refspace",
 				keep.extra.columns=TRUE,
-				seqinfo=yaml.config$BSgenome$BSgenome_name %>% get %>% seqinfo
+				seqinfo=BSgenome_name %>% get %>% seqinfo
 			) %>%
 			resize(width=3,fix="center") %>%
 			suppressWarnings %>% #remove warnings of out of bounds regions due to resize
-			
+
 			#Remove trinucleotide contexts that extend past a non-circular chromosome edge (after trim, width < 3) to yield NA tnc value
 			trim %>%
 			filter(width == 3) %>%
-			
+
 			#Get trinucleotide context sequence for the reference plus and minus strands. The latter is calculated here to avoid error when calculating it for NA values, and it is used for later assignment to synthesized and template strand trinucleotide columns. Also calculate trinucleotide context with central pyrimidine
 			mutate(
-				reftnc_plus_strand = getSeq(eval(parse(text=yaml.config$BSgenome$BSgenome_name)),.) %>%
+				reftnc_plus_strand = getSeq(eval(parse(text=BSgenome_name)),.) %>%
 					as.character %>%
 					factor(levels = trinucleotides_64)
 			) %>%
-			
+
 			#Remove trinucleotide contexts that are NA, which occurs when the trinucleotide sequence contains 'N'
 			filter(!is.na(reftnc_plus_strand)) %>%
-			
+
 			mutate(
 				reftnc_minus_strand = reftnc_plus_strand %>%
 					DNAStringSet %>%
 					reverseComplement %>%
 					as.character %>%
 					factor(levels = trinucleotides_64),
-				
+
 				reftnc_pyr = if_else(str_sub(reftnc_plus_strand,2,2) %in% c("C","T"), reftnc_plus_strand, reftnc_minus_strand) %>%
 					factor(levels = trinucleotides_32_pyr)
 			) %>%
-			
+
 			#Resize back to original start/end, and make tibble
 			resize(width=1,fix="center") %>%
 			as_tibble %>%
@@ -1116,14 +1117,14 @@ calls <- calls %>%
 		ref_minus_strand = ref_plus_strand %>% DNAStringSet %>% reverseComplement %>% as.character,
 		ref_synthesized_strand = if_else(strand=="+",ref_plus_strand,ref_minus_strand),
 		ref_template_strand = if_else(strand=="+",ref_minus_strand,ref_plus_strand),
-		
+
 		alt_minus_strand = alt_plus_strand %>% DNAStringSet %>% reverseComplement %>% as.character,
 		alt_synthesized_strand = if_else(strand=="+",alt_plus_strand,alt_minus_strand),
 		alt_template_strand = if_else(strand=="+",alt_minus_strand,alt_plus_strand),
-		
+
 		reftnc_synthesized_strand = if_else(strand=="+",reftnc_plus_strand,reftnc_minus_strand),
 		reftnc_template_strand = if_else(strand=="+",reftnc_minus_strand,reftnc_plus_strand),
-		
+
 		alttnc_plus_strand = str_c(
 			str_sub(reftnc_plus_strand,1,1),
 			alt_plus_strand,
@@ -1143,10 +1144,10 @@ calls <- calls %>%
 			alttnc_minus_strand
 		) %>%
 			factor(levels = trinucleotides_64),
-		
+
 		alttnc_synthesized_strand = if_else(strand=="+",alttnc_plus_strand,alttnc_minus_strand),
 		alttnc_template_strand = if_else(strand=="+",alttnc_minus_strand,alttnc_plus_strand)
-	
+
 	) %>%
 	select(-c(ref_minus_strand,alt_minus_strand,reftnc_minus_strand,alttnc_minus_strand))
 
@@ -1169,7 +1170,7 @@ calls.gr <- calls %>%
     end.field="end",
     strand.field="strand",
     keep.extra.columns=TRUE,
-    seqinfo=yaml.config$BSgenome$BSgenome_name %>% get %>% seqinfo
+    seqinfo=BSgenome_name %>% get %>% seqinfo
   )
 
  #Initialize new opposite strand columns
@@ -1220,7 +1221,7 @@ s_call_type <- calls.gr.keyed.opposite$call_type[sh]
 s_start_refspace <- calls.gr.keyed.opposite$start_refspace[sh]
 s_end_refspace <- calls.gr.keyed.opposite$end_refspace[sh]
 
-calls.gr.hits.keep <- 
+calls.gr.hits.keep <-
 	(
 		q_call_class %in% c("SBS","MDB") & s_call_type == "SBS" &
 			q_start_refspace == s_start_refspace & q_end_refspace == s_end_refspace
@@ -1260,7 +1261,7 @@ calls.gr$alt_plus_strand.opposite_strand <- calls.gr.keyed.opposite$alt_plus_str
 calls.gr$start_refspace.opposite_strand <- calls.gr.keyed.opposite$start_refspace
 calls.gr$end_refspace.opposite_strand <- calls.gr.keyed.opposite$end_refspace
 
-calls.gr <- calls.gr %>% 
+calls.gr <- calls.gr %>%
 	mutate(
 		deletion.bothstrands.startendmatch = case_when(
 			call_type != "deletion" | call_type.opposite_strand != "deletion" ~ NA,

--- a/bin/filterCalls.R
+++ b/bin/filterCalls.R
@@ -118,7 +118,7 @@ filtergroup_toanalyze_config <- yaml.config$filtergroups %>%
   enframe(name=NULL) %>%
   unnest_wider(value) %>%
 	filter(filtergroup == filtergroup_toanalyze)
-
+  
  #region filter parameters (restrict to selected chromgroup_toanalyze and filtergroup_toanalyze)
 region_read_filters_config <- yaml.config$region_filters %>%
   map("read_filters") %>%
@@ -158,7 +158,7 @@ cat("DONE\n")
 
 #Function to calculate number of molecules and reference space bases passing each individual filter matching a pattern (starting from the upstream filtered bam of extractCalls, i.e. starting after minstrandoverlapfilter), and passing all filters so far (if all_filter_suffix is not NULL), from bam input.
 calculate_molecule_stats_frombam <- function(bam.input, individual_filter_pattern, all_filter_suffix=NULL, chromgroup_toanalyze.input, filtergroup_toanalyze.input, extractCallsFile.input){
-
+	
 	#Number of molecules and reference space bases passing each basic molecule filter, each applied separately
 	filter_stats <- bam.input %>%
 		group_by(run_id) %>%
@@ -172,7 +172,7 @@ calculate_molecule_stats_frombam <- function(bam.input, individual_filter_patter
 				.names = "{.fn}_individualfilter.{.col}"
 			)
 		)
-
+	
 	#Number of molecules and reference space bases passing all the basic molecule filters
 	if(!is.null(all_filter_suffix)){
 		filter_stats <- filter_stats %>%
@@ -187,32 +187,32 @@ calculate_molecule_stats_frombam <- function(bam.input, individual_filter_patter
 				by = "run_id"
 			)
 	}
-
+	
 	filter_stats %>%
 		complete(run_id) %>%
 		mutate(across(-run_id, ~ .x %>% replace_na(0))) %>%
-
+		
 		#Pivot longer
 		pivot_longer(
 			-run_id,
 			names_to = "stat",
 			values_to = "value"
 		) %>%
-
+		
 		#Annotate extractCallsFile, chromgroup, filtergroup of this process
 		mutate(
 			chromgroup = chromgroup_toanalyze.input,
 			filtergroup = filtergroup_toanalyze.input,
 			extractCallsFile = extractCallsFile.input %>% basename
 		) %>%
-
+		
 		#Reorder columns
 		relocate(run_id,chromgroup,filtergroup,extractCallsFile)
 }
 
 #Function to calculate number of molecules and refspace bases remaining in bam filtertracker.
 calculate_molecule_stats_frombamfiltertrack <- function(bam.gr.filtertrack.input, stat_label.suffix){
-
+	
 	bam.gr.filtertrack.input %>%
 		as_tibble %>%
 		group_by(run_id) %>%
@@ -236,39 +236,39 @@ calculate_molecule_stats_frombamfiltertrack <- function(bam.gr.filtertrack.input
 
 #Function returning a TRUE/FALSE vector signifying for each element of a query GRanges if it overlaps any element of a subject GRanges, joining on optional columns. If overlap_adjacent_query_insertion = TRUE, then insertions (zero width) in query will be considered an overlap to an immediately adjacent non-insertion subject range.
 overlapsAny_bymcols <- function(query, subject, join_mcols = character(), ignore.strand = TRUE, overlap_adjacent_query_insertion = FALSE) {
-
+	
 	stopifnot(inherits(query, "GenomicRanges"), inherits(subject, "GenomicRanges"))
-
+	
 	nq <- length(query)
 	ns <- length(subject)
-
+	
 	if(nq == 0){return(logical())} #Empty query
 	if(ns == 0){return(rep(FALSE, nq))} #Empty subject
-
+	
 	if(length(join_mcols) > 0){
 		q_mcols <- mcols(query)
 		s_mcols <- mcols(subject)
-
+		
 		if(!all(join_mcols %in% colnames(q_mcols)) || !all(join_mcols %in% colnames(s_mcols))){
 			stop("All `join_mcols` must exist as metadata columns in both query and subject.")
 		}
-
+		
 		key_q <- query %>%
 			as_tibble %>%
 			select(all_of(join_mcols)) %>%
 			as.list %>%
 			interaction(drop = TRUE)
-
+		
 		key_s <- subject %>%
 			as_tibble %>%
 			select(all_of(join_mcols)) %>%
 			as.list %>%
 			interaction(drop = TRUE)
-
+		
 		keys_all <- factor(c(key_q,key_s))
 		id_q <- as.integer(keys_all)[seq_len(nq)]
 		id_s <- as.integer(keys_all)[nq + seq_len(ns)]
-
+		
 		# Make NA ids unique and disjoint between query and subject so they never overlap.
 		if(anyNA(id_q)){
 			idx <- id_q %>% is.na %>% which
@@ -278,45 +278,45 @@ overlapsAny_bymcols <- function(query, subject, join_mcols = character(), ignore
 			idx <- id_s %>% is.na %>% which
 			id_s[idx] <- -(nq + idx)
 		}
-
+		
 	}else{
 		#No join keys: everyone shares the same id => equivalent to no join constraint.
 		id_q <- rep.int(1L, nq)
 		id_s <- rep.int(1L, ns)
 	}
-
+	
 	#Change seqnames to contain key
 	q2 <- GRanges(
 		seqnames = str_c(as.character(seqnames(query)), "|", id_q),
 		ranges = ranges(query),
 		strand = strand(query)
 	)
-
+	
 	s2 <- GRanges(
 		seqnames = str_c(as.character(seqnames(subject)), "|", id_s),
 		ranges = ranges(subject),
 		strand = strand(subject)
 	) %>%
 		GNCList
-
+	
 	hits <- findOverlaps(q2, s2, ignore.strand = ignore.strand) %>%
 		suppressWarnings #Hide warning about unshared seqlevels between q2 and s2
-
+	
 	if(overlap_adjacent_query_insertion == TRUE){
 		hits_adj <- findOverlaps(q2, s2, ignore.strand = ignore.strand, maxgap = 0) %>%
 			suppressWarnings
-
+		
 		qh_adj <- queryHits(hits_adj)
 		sh_adj <- subjectHits(hits_adj)
-
+		
 		hits_adj <- hits_adj[
 			(query[qh_adj] %>% width == 0) & (subject[sh_adj] %>% width != 0)
 			]
-
+		
 		hits <- GenomicRanges::union(hits, hits_adj)
 		rm(hits_adj)
 	}
-
+	
 	if(length(hits) == 0){return(rep(FALSE, nq))} #No overlap
 
 	#Output result
@@ -326,7 +326,7 @@ overlapsAny_bymcols <- function(query, subject, join_mcols = character(), ignore
 #Convert positions of bases from query space to reference space, while retaining run_id and zm info
 #iranges.input: IRangesList with query space positions, with the IRangesList length the same as the number of rows in bam.input
 convert_query_to_refspace <- function(irangeslist.input, bam.input, BSgenome_name.input){
-
+	
 	#Format irangeslist.input to GRanges of positions failing subreads filters in query space, with annotated bam read id
 	irangeslist.input <- irangeslist.input %>%
 		setNames(bam.input %>% pull(seqnames)) %>%
@@ -338,20 +338,20 @@ convert_query_to_refspace <- function(irangeslist.input, bam.input, BSgenome_nam
 		) %>%
 		setNames(.$group) %>%
 		select(-group)
-
+	
 	if(length(irangeslist.input) == 0){
 		return(
 			GRanges(run_id=factor(), zm=integer())
 		)
 	}
-
+	
 	mapFromAlignments( #Main function
-
+		
 		irangeslist.input,
-
+		
 		#GAlignments of reads in reference space
 		bam.input %>%
-			select(seqnames, start, end, cigar) %>%
+			select(seqnames, start, end, cigar) %>% 
 			makeGRangesFromDataFrame(
 				keep.extra.columns=TRUE,
 				seqinfo=BSgenome_name.input %>% get %>% seqinfo
@@ -359,7 +359,7 @@ convert_query_to_refspace <- function(irangeslist.input, bam.input, BSgenome_nam
 			as("GAlignments") %>%
 			setNames(1:nrow(bam.input))
 	) %>%
-
+		
 		#Annotate result with run_id, zm, and strand
 		as_tibble %>%
 		left_join(
@@ -474,23 +474,23 @@ bam <- bam %>%
 	mutate(num_softclipbases = cigar %>% cigarOpTable %>% as_tibble %>% pull(S)) %>%
 	group_by(run_id,zm) %>%
 	mutate(
-
+		
 		#rq
 		min_rq_eachstrand.passfilter = all(rq >= filtergroup_toanalyze_config$min_rq_eachstrand),
 		min_rq_avgstrands.passfilter = mean(rq) >= filtergroup_toanalyze_config$min_rq_avgstrands,
-
+		
 		#ec
 		min_ec_eachstrand.passfilter = all(ec >= filtergroup_toanalyze_config$min_ec_eachstrand),
 		min_ec_avgstrands.passfilter = mean(ec) >= filtergroup_toanalyze_config$min_ec_avgstrands,
-
+		
 		#mapq
 		min_mapq_eachstrand.passfilter = all(mapq >= filtergroup_toanalyze_config$min_mapq_eachstrand),
 		min_mapq_avgstrands.passfilter = mean(mapq) >= filtergroup_toanalyze_config$min_mapq_avgstrands,
-
+		
 		#num_softclipbases
 		max_num_softclipbases_eachstrand.passfilter = all(num_softclipbases <= filtergroup_toanalyze_config$max_num_softclipbases_eachstrand),
 		max_num_softclipbases_avgstrands.passfilter = mean(num_softclipbases) <= filtergroup_toanalyze_config$max_num_softclipbases_avgstrands
-
+		
 	) %>%
 	select(-num_softclipbases) %>%
 	ungroup
@@ -498,16 +498,16 @@ bam <- bam %>%
 #Annotate reads for filters: max_num_SBScalls_eachstrand, max_num_SBScalls_stranddiff, max_num_indelcalls_eachstrand, max_num_indelcalls_stranddiff
 bam <- bam %>%
 	left_join(
-
+			
 			#Filter for SBS and indel calls
 			calls %>%
 				filter(
 				  call_class %in% c("SBS","indel")
 				  ) %>%
-
+			  
 				#Change call_class to factor so that count results are listed for both SBS and indel below.
-				mutate(call_class = call_class %>% factor(levels=c("SBS","indel"))) %>%
-
+				mutate(call_class = call_class %>% factor(levels=c("SBS","indel"))) %>% 
+				
 				#Count number of SBS and indel calls per strand while completing missing strand and SBS/indel values for each molecule so that num_{call_class}calls are calculated correctly
 				count(run_id,zm,strand,call_class) %>%
 			  complete(run_id,zm,strand,call_class,fill = list(n=0)) %>%
@@ -517,29 +517,29 @@ bam <- bam %>%
 					names_glue = "num_{call_class}calls",
 					names_expand = TRUE #Necessary if there are no calls
 					) %>%
-
+				
 				#Calculate filters for each molecule
 				group_by(run_id,zm) %>%
 				summarize(
 					#max_num_SBScalls_eachstrand.passfilter
 					max_num_SBScalls_eachstrand.passfilter = all(num_SBScalls <= filtergroup_toanalyze_config$max_num_SBScalls_eachstrand),
-
+					
 					#max_num_indelcalls_eachstrand.passfilter
 					max_num_indelcalls_eachstrand.passfilter = all(num_indelcalls <= filtergroup_toanalyze_config$max_num_indelcalls_eachstrand),
-
+					
 					#max_num_SBScalls_stranddiff.passfilter
 					max_num_SBScalls_stranddiff.passfilter = (num_SBScalls * if_else(strand == "+",  1L, -1L)) %>%
 						sum %>%
 						abs %>%
 						#Curly braces ensure the '.' refers to the immediately preceding result
 						{. <= filtergroup_toanalyze_config$max_num_SBScalls_stranddiff},
-
+					
 					#max_num_indelcalls_stranddiff.passfilter
 					max_num_indelcalls_stranddiff.passfilter = (num_indelcalls * if_else(strand == "+",  1L, -1L)) %>%
 						sum %>%
 						abs %>%
 					  {. <= filtergroup_toanalyze_config$max_num_indelcalls_stranddiff},
-
+	
 					.groups = "drop"
 				),
 		by = join_by(run_id,zm)
@@ -557,16 +557,16 @@ bam <- bam %>%
 #Annotate reads for filters: max_num_SBSmutations, max_num_indelmutations
 bam <- bam %>%
 	left_join(
-
+			
 			#Filter for SBS and indel mutations. Not filtering here on only '+' or only '-' strand since the below code won't double count mutations, because it counts mutations for each strand and those numbers will be identical for each strand of a molecule.
 		calls %>%
 			filter(
 				call_class %in% c("SBS","indel"),
 				SBSindel_call_type == "mutation"
 				) %>%
-
+		  
 		  #Count number of SBS and indel mutations per molecule while completing missing SBS/indel values for each molecule so that num_{call_class}mutations are calculated correctly.
-		  mutate(call_class = call_class %>% factor(levels=c("SBS","indel"))) %>%
+		  mutate(call_class = call_class %>% factor(levels=c("SBS","indel"))) %>% 
 		  count(run_id,zm,strand,call_class) %>%
 		  complete(run_id,zm,strand,call_class,fill = list(n=0)) %>%
 			pivot_wider(
@@ -575,16 +575,16 @@ bam <- bam %>%
 				names_glue = "num_{call_class}mutations",
 				names_expand = TRUE #Necessary if there are no calls
 			) %>%
-
+			
 			#Calculate filters for each molecule
 			group_by(run_id,zm) %>%
 			summarize(
 				#max_num_SBSmutations
 				max_num_SBSmutations.passfilter = all(num_SBSmutations <= filtergroup_toanalyze_config$max_num_SBSmutations),
-
+				
 				#max_num_indelmutations
 				max_num_indelmutations.passfilter = all(num_indelmutations <= filtergroup_toanalyze_config$max_num_indelmutations),
-
+				
 				.groups = "drop"
 			),
 		by = join_by(run_id,zm)
@@ -646,7 +646,7 @@ germline_vcf_variants <- qs_read(
 		)
 	) %>%
   as_tibble
-
+  
 #Filter to keep germline VCF variants that pass configured germline VCF filters and keep only columns necessary for downstream filtering
 germline_vcf_variants <- germline_vcf_variants  %>%
   group_by(germline_vcf_type) %>% #split by germline_vcf_type
@@ -655,7 +655,7 @@ germline_vcf_variants <- germline_vcf_variants  %>%
   imap(
     function(x,idx){
       filters <- germline_vcf_types_config %>% filter(germline_vcf_type == idx)
-
+      
       x %>%
         filter(
           (
@@ -709,19 +709,19 @@ cat("## Applying post-germline VCF variant filtering molecule filters...")
 #Annotate reads for filters: max_num_SBScalls_postVCF_eachstrand, max_num_indelcalls_postVCF_eachstrand
 bam <- bam %>%
   left_join(
-
+    
     #Filter to keep SBS and indel calls that pass all filters applied so far
     calls %>%
       filter(
         call_class %in% c("SBS","indel"),
         if_all(contains("passfilter"), ~ .x == TRUE)
       ) %>%
-
+      
       #Count number of SBS and indel calls per strand while completing missing strand and SBS/indel values for each molecule so that num_{call_class}calls are calculated correctly. Fix strand levels to '+/-' to avoid expanding strand = '*'.
       mutate(
         call_class = call_class %>% factor(levels=c("SBS","indel")),
         strand = strand %>% factor(levels=c("+","-"))
-      ) %>%
+      ) %>% 
       count(run_id,zm,strand,call_class) %>%
       complete(run_id, zm, strand, call_class, fill = list(n=0)) %>%
       pivot_wider(
@@ -730,13 +730,13 @@ bam <- bam %>%
         names_glue = "num_{call_class}calls",
         names_expand = TRUE #Necessary if there are no calls
       ) %>%
-
+      
       #Calculate filters for each molecule
       group_by(run_id,zm) %>%
       summarize(
         #max_num_SBScalls_postVCF_eachstrand
         max_num_SBScalls_postVCF_eachstrand.passfilter = all(num_SBScalls <= filtergroup_toanalyze_config$max_num_SBScalls_postVCF_eachstrand),
-
+        
         #max_num_indelcalls_postVCF_eachstrand
         max_num_indelcalls_postVCF_eachstrand.passfilter = all(num_indelcalls <= filtergroup_toanalyze_config$max_num_indelcalls_postVCF_eachstrand),
         ,.groups = "drop"
@@ -754,7 +754,7 @@ bam <- bam %>%
 #Annotate reads for filters: max_num_SBSmutations_postVCF, max_num_indelmutations_postVCF
 bam <- bam %>%
   left_join(
-
+    
     #Filter to keep SBS and indel calls that pass all filters applied so far
     calls %>%
       filter(
@@ -762,9 +762,9 @@ bam <- bam %>%
         SBSindel_call_type == "mutation",
         if_all(contains("passfilter"), ~ .x == TRUE)
       ) %>%
-
+      
       #Count number of SBS and indel mutations per molecule while completing missing SBS/indel values for each molecule so that num_{call_class}mutations are calculated correctly
-      mutate(call_class = call_class %>% factor(levels=c("SBS","indel"))) %>%
+      mutate(call_class = call_class %>% factor(levels=c("SBS","indel"))) %>% 
       count(run_id,zm,strand,call_class) %>%
       complete(run_id,zm,strand,call_class,fill = list(n=0)) %>%
       pivot_wider(
@@ -773,16 +773,16 @@ bam <- bam %>%
         names_glue = "num_{call_class}mutations",
         names_expand = TRUE #Necessary if there are no calls
       ) %>%
-
+      
       #Calculate filters for each molecule
       group_by(run_id,zm) %>%
       summarize(
         #max_num_SBSmutations_postVCF
         max_num_SBSmutations_postVCF.passfilter = all(num_SBSmutations <= filtergroup_toanalyze_config$max_num_SBSmutations_postVCF),
-
+        
         #max_num_indelmutations_postVCF
         max_num_indelmutations_postVCF.passfilter = all(num_indelmutations <= filtergroup_toanalyze_config$max_num_indelmutations_postVCF),
-
+        
         .groups = "drop"
       ),
     by = join_by(run_id,zm)
@@ -987,7 +987,7 @@ bam.gr.trim <- c(
 	      end = if_else(temp_end < end, temp_end, end)  #prevents exceeding genome boundaries
 	      ) %>%
 	    select(-temp_end),
-
+    
     bam.gr.onlyranges %>%
       mutate(
         temp_start = end - filtergroup_toanalyze_config$read_trim_bp + 1,
@@ -1043,7 +1043,7 @@ if(!is.na(ccs_sbs_flank)){
 			flank(width=ccs_sbs_flank, start = TRUE, ignore.strand = TRUE) %>%
 			suppressWarnings %>% #remove warnings of out of bounds regions due to resize
 			trim,
-
+		
 		#Right flank
 		calls.gr %>%
 			filter(call_class=="SBS") %>%
@@ -1098,7 +1098,7 @@ if(!is.na(ccs_ins_pad)){
 	ccs_ins_pad <- ccs_ins_pad %>%
 	  tibble(pad=.) %>%
 	  extract(pad, into = c("m", "b"), regex = "m(\\d+)b(\\d+)", convert = TRUE)
-
+	
 	read_ins_region_filter <- calls.gr %>%
 		filter(call_class=="indel", call_type == "insertion") %>%
 		mutate(
@@ -1110,7 +1110,7 @@ if(!is.na(ccs_ins_pad)){
 		suppressWarnings %>% #remove warnings of out of bounds regions due to resize
 		trim %>%
 		select(run_id, zm)
-
+	
 }else{
 	read_ins_region_filter <- calls.gr %>%
 		select(run_id, zm) %>%
@@ -1122,7 +1122,7 @@ if(!is.na(ccs_del_pad)){
 	ccs_del_pad <- ccs_del_pad %>%
 	  tibble(pad=.) %>%
 	  extract(pad, into = c("m", "b"), regex = "m(\\d+)b(\\d+)", convert = TRUE)
-
+	
 	read_del_region_filter <- calls.gr %>%
 		filter(call_class=="indel", call_type == "deletion") %>%
 		mutate(
@@ -1134,7 +1134,7 @@ if(!is.na(ccs_del_pad)){
 		suppressWarnings %>% #remove warnings of out of bounds regions due to resize
 		trim %>%
 		select(run_id, zm)
-
+	
 }else{
 	read_del_region_filter <- calls.gr %>%
 		select(run_id, zm) %>%
@@ -1143,7 +1143,7 @@ if(!is.na(ccs_del_pad)){
 
 #Combine insertion and deletion GRanges with configured padding
 read_indel_region_filter <- c(read_ins_region_filter, read_del_region_filter)
-
+ 
 #Annotate calls filtered by read_indel_region_filter without taking strand into account, so that if a call on either strand fails the filter, calls on both strands fail the filter. Not applied to indels.
 calls[["read_indel_region_filter.passfilter"]] <- ! overlapsAny_bymcols(
 	calls.gr, read_indel_region_filter,
@@ -1340,7 +1340,7 @@ germline_bam_bcftools_mpileup_BAMVAF_filter <- germline_bam_bcftools_mpileup_fil
 #Annotate SBS calls with germline BAM bcftools mpileup VCF filters.
 calls[["max_germlineBAM_VariantReads.passfilter"]] <- ! overlapsAny_bymcols(
 	calls.gr, germline_bam_bcftools_mpileup_BAMVariantReads_filter,
-	join_mcols = c("call_class","call_type","ref_plus_strand","alt_plus_strand"), #Not joining by SBSindel_call_type so filter is also applied to mismatch-ss and mismatch-ds calls
+	join_mcols = c("call_class","call_type","ref_plus_strand","alt_plus_strand"), #Not joining by SBSindel_call_type so filter is also applied to mismatch-ss and mismatch-ds calls 
 	ignore.strand = TRUE
 )
 
@@ -1361,7 +1361,7 @@ cat("DONE\n")
 cat("## Applying subread filters...")
 
 #Convert positions of bases failing subread filters from query space to reference space, while retaining run_id and zm info
- #min_frac_subreads_cvg (sa/max(sa))
+ #min_frac_subreads_cvg (sa/max(sa)) 
 frac_subreads_cvg.fail.gr <- bam %>%
 		pull(sa) %>%
 		map(
@@ -1487,7 +1487,7 @@ calls <- calls %>%
 			select(run_id,zm,strand,max_sa.opposite_strand),
 		by = join_by(run_id,zm,strand)
 	) %>%
-
+	
 	#Calculate frac_subreads_cvg for both strands
 	mutate(
 		frac_subreads_cvg = map2(
@@ -1501,7 +1501,7 @@ calls <- calls %>%
 			function(x,y){x/y}
 		)
 	) %>%
-
+	
 	#Perform filtering. NA in any base on the opposite strand is assigned passfilter = FALSE.
 	mutate(
 		min_frac_subreads_cvg.passfilter = map2_lgl(
@@ -1529,7 +1529,7 @@ calls <- calls %>%
 			)
 		)
 	)
-
+	
 #min_frac_subreads_match
 calls <- calls %>%
 	#Calculate frac_subreads_match for both strands
@@ -1545,7 +1545,7 @@ calls <- calls %>%
 			function(x,y){x/(x+y)}
 		)
 	) %>%
-
+	
 	#Perform filtering. If any base on the call strand or opposite strand has (sm+sx) = 0, evaluate frac_subreads_match as 0. If any opposite strand base has sm or sx = NA, then assign passfilter = FALSE.
 	mutate(
 		min_frac_subreads_match.passfilter = map2_lgl(
@@ -1559,7 +1559,7 @@ calls <- calls %>%
 		)
 	) %>%
 	select(-c(frac_subreads_match,frac_subreads_match.opposite_strand))
-
+	
 rm(frac_subreads_cvg.fail.gr, num_subreads_match.fail.gr, frac_subreads_match.fail.gr)
 invisible(gc())
 
@@ -1579,7 +1579,7 @@ duplex_coverage.fail.indelanalysis.gr <- c(
 	bam.gr.filtertrack.indelanalysis %>%
 		filter(strand=="+") %>%
 		GRanges_subtract_bymcols(bam.gr.filtertrack.indelanalysis %>% filter(strand=="-"), join_mcols = c("run_id","zm"), ignore.strand = TRUE),
-
+	
 	#Minus strand only
 	bam.gr.filtertrack.indelanalysis %>%
 		filter(strand=="-") %>%
@@ -1592,7 +1592,7 @@ duplex_coverage.fail.nonindelanalysis.gr <- c(
 	bam.gr.filtertrack.nonindelanalysis %>%
 		filter(strand=="+") %>%
 		GRanges_subtract_bymcols(bam.gr.filtertrack.nonindelanalysis %>% filter(strand=="-"), join_mcols = c("run_id","zm"), ignore.strand = TRUE),
-
+	
 	#Minus strand only
 	bam.gr.filtertrack.nonindelanalysis %>%
 		filter(strand=="-") %>%
@@ -1658,28 +1658,28 @@ bam.gr.filtertrack.nonindelanalysis.except_germline_filters <- bam.gr.filtertrac
 
 #Split germline_vcf_variants by germline_vcf_file
 germline_vcf_variants <- germline_vcf_variants  %>%
-	group_by(germline_vcf_file) %>%
+	group_by(germline_vcf_file) %>% 
 	nest %>%
 	deframe
 
 for(i in names(germline_vcf_variants)){
-
+	
 	#Construct label for the newly created filter column
 	passfilter_label <- i %>%
 		basename %>%
 		str_c("germline_vcf_indel_region_filter_",.,".passfilter")
-
+	
 	#Extract germline VCF type and padding configuration
 	vcf_type <- germline_vcf_variants %>% pluck(i,"germline_vcf_type",1)
 	indel_ins_pad <- germline_vcf_types_config %>% filter(germline_vcf_type == vcf_type) %>% pull(indel_ins_pad)
 	indel_del_pad <- germline_vcf_types_config %>% filter(germline_vcf_type == vcf_type) %>% pull(indel_del_pad)
-
+	
 	#Create GRanges of insertions with configured padding
 	if(!is.na(indel_ins_pad)){
 		indel_ins_pad <- indel_ins_pad %>%
 			tibble(pad=.) %>%
 			extract(pad, into = c("m", "b"), regex = "m(\\d+)b(\\d+)", convert = TRUE)
-
+		
 		germline_vcf_ins_region_filter <- germline_vcf_variants %>%
 			pluck(i) %>%
 			filter(call_class=="indel", call_type == "insertion") %>%
@@ -1694,13 +1694,13 @@ for(i in names(germline_vcf_variants)){
 			pluck(i) %>%
 			slice(0)
 	}
-
+	
 	#Create GRanges of deletions with configured padding
 	if(!is.na(indel_del_pad)){
 		indel_del_pad <- indel_del_pad %>%
 			tibble(pad=.) %>%
 			extract(pad, into = c("m", "b"), regex = "m(\\d+)b(\\d+)", convert = TRUE)
-
+		
 		germline_vcf_del_region_filter <- germline_vcf_variants %>%
 			pluck(i) %>%
 			filter(call_class=="indel", call_type == "deletion") %>%
@@ -1715,7 +1715,7 @@ for(i in names(germline_vcf_variants)){
 			pluck(i) %>%
 			slice(0)
 	}
-
+	
 	#Combine insertion and deletion GRanges with configured padding
 	germline_vcf_indel_region_filter <- bind_rows(germline_vcf_ins_region_filter, germline_vcf_del_region_filter) %>%
 		makeGRangesFromDataFrame(
@@ -1724,23 +1724,23 @@ for(i in names(germline_vcf_variants)){
 		suppressWarnings %>% #remove warnings of out of bounds regions due to resize
 		trim %>%
 		GenomicRanges::reduce(ignore.strand=TRUE)
-
+	
 	#Subtract filtered regions from filter trackers
 	bam.gr.filtertrack.indelanalysis <- bam.gr.filtertrack.indelanalysis %>%
 		GRanges_subtract(germline_vcf_indel_region_filter, ignore.strand = TRUE)
-
+	
 	bam.gr.filtertrack.nonindelanalysis <- bam.gr.filtertrack.nonindelanalysis %>%
 		GRanges_subtract(germline_vcf_indel_region_filter, ignore.strand = TRUE)
-
+	
 	genome_chromgroup.gr.filtertrack <- genome_chromgroup.gr.filtertrack %>%
 		GRanges_subtract(germline_vcf_indel_region_filter)
-
+	
 	#Annotate filtered calls. Annotates even if partial overlap (relevant for deletions).
 	calls[[passfilter_label]] <- ! overlapsAny_bymcols(
 		calls.gr, germline_vcf_indel_region_filter,
 		ignore.strand = TRUE
 	)
-
+	
 	#Record number of filtered genome bases to stats
 	region_genome_filter_stats <- region_genome_filter_stats %>%
 		bind_rows(
@@ -1783,22 +1783,22 @@ cat("DONE\n")
 cat("## Applying region-based molecule filters...")
 
 for(i in seq_len(nrow(region_read_filters_config))){
-
+	
 	#Construct label for the newly created filter column
 	passfilter_label <- region_read_filters_config %>%
 		pluck("region_filter_threshold_file",i) %>%
 		basename %>%
 		str_c("region_read_filter_",.,".passfilter")
-
+	
 	#Extract read threshold
 	read_threshold_type <- region_read_filters_config %>%
 		pluck("read_threshold",i) %>%
 		str_extract("^(gt|gte|lt|lte)")
-
+	
 	read_threshold_value <- region_read_filters_config %>%
 		pluck("read_threshold",i) %>%
 		str_extract("[0-9.]+$")
-
+	
 	#Load region read filter bigwig
 	region_read_filter <- region_read_filters_config %>%
 		pluck("region_filter_threshold_file",i) %>%
@@ -1808,7 +1808,7 @@ for(i in seq_len(nrow(region_read_filters_config))){
 			seqinfo(.) <- seqinfo(genome_chromgroup.gr)
 			.
 		} %>%
-
+		
 		#Add padding
 		resize(
 			width = width(.) + 2 * (region_read_filters_config %>% pluck("padding",i)),
@@ -1817,11 +1817,11 @@ for(i in seq_len(nrow(region_read_filters_config))){
 		suppressWarnings %>% #remove warnings of out of bounds regions due to resize
 		trim %>%
 		GenomicRanges::reduce(ignore.strand=TRUE) %>%
-
+		
 		#Create a logical TRUE/FALSE RLE of genomic bases covered so that the below binnedAverage function calculates, for each read, the fraction covered by the region_read_filter
 		coverage %>%
 		{. > 0}
-
+	
 	#Annotate which molecules pass the filter
 	bam <- bam %>%
 		left_join(
@@ -1832,10 +1832,10 @@ for(i in seq_len(nrow(region_read_filters_config))){
 					keep.extra.columns=TRUE,
 					seqinfo=BSgenome_name %>% get %>% seqinfo
 				) %>%
-
+				
 				#Calculate fraction of coverage by the region read filter
 				binnedAverage(region_read_filter,varname="frac") %>%
-
+				
 				#Annotate which molecules have a fraction of their length filtered by the above bigwig (averaged across plus and minus strands) that is either greater than (gt), greater than or equal (gte), less than (lt), or less than or equal (lte) to a read_threshold_value
 				as_tibble %>%
 				group_by(run_id, zm) %>%
@@ -1850,7 +1850,7 @@ for(i in seq_len(nrow(region_read_filters_config))){
 				),
 			by = join_by(run_id,zm)
 		)
-
+	
 	#Remove filtered molecules from bam.gr.filtertrack
 	bam.gr.filtertrack.indelanalysis <- bam.gr.filtertrack.indelanalysis[
 		!vctrs::vec_in(
@@ -1863,7 +1863,7 @@ for(i in seq_len(nrow(region_read_filters_config))){
 				distinct(run_id,zm)
 			)
 		]
-
+		
 		bam.gr.filtertrack.nonindelanalysis <- bam.gr.filtertrack.nonindelanalysis[
 			!vctrs::vec_in(
 				bam.gr.filtertrack.nonindelanalysis %>%
@@ -1875,7 +1875,7 @@ for(i in seq_len(nrow(region_read_filters_config))){
 					distinct(run_id,zm)
 			)
 		]
-
+		
 		#Remove filtered molecules from bam.gr.filtertrack.except_germline_filters only if it is a non-germline filter
 		if(region_read_filters_config %>% pluck("is_germline_filter",i) == FALSE){
 			bam.gr.filtertrack.indelanalysis.except_germline_filters <- bam.gr.filtertrack.indelanalysis.except_germline_filters[
@@ -1889,7 +1889,7 @@ for(i in seq_len(nrow(region_read_filters_config))){
 						distinct(run_id,zm)
 				)
 			]
-
+			
 			bam.gr.filtertrack.nonindelanalysis.except_germline_filters <- bam.gr.filtertrack.nonindelanalysis.except_germline_filters[
 				!vctrs::vec_in(
 					bam.gr.filtertrack.nonindelanalysis.except_germline_filters %>%
@@ -1902,7 +1902,7 @@ for(i in seq_len(nrow(region_read_filters_config))){
 				)
 			]
 		}
-
+		
 		#Update molecule stats of remaining molecules and bases after each filter is added
 		molecule_stats <- molecule_stats %>%
 			bind_rows(
@@ -1917,7 +1917,7 @@ for(i in seq_len(nrow(region_read_filters_config))){
 			)
 
 	rm(region_read_filter)
-	invisible(gc())
+	invisible(gc())		
 }
 
 #Update molecule stats of each filter applied individually regardless of any prior filters. This is possible in this case since these are molecule-level filters. Note, all_filter_suffix = NULL, because can't calculate all_filter stats from bam at this point since non-molecule filters have already been applied upstream.
@@ -1967,13 +1967,13 @@ cat("## Applying genome region filters...")
 
 #Perform filtering
 for(i in seq_len(nrow(region_genome_filters_config))){
-
+	
 	#Construct label for the newly created filter column
 	passfilter_label <- region_genome_filters_config %>%
 		pluck("region_filter_threshold_file",i) %>%
 		basename %>%
 		str_c("region_genome_filter_",.,".passfilter")
-
+	
 	#Load region read filter bigwig
 	region_genome_filter <- region_genome_filters_config %>%
 		pluck("region_filter_threshold_file",i) %>%
@@ -1983,7 +1983,7 @@ for(i in seq_len(nrow(region_genome_filters_config))){
 			seqinfo(.) <- seqinfo(genome_chromgroup.gr)
 			.
 		} %>%
-
+		
 		#Add padding
 		resize(
 			width = width(.) + 2 * (region_genome_filters_config %>% pluck("padding",i)),
@@ -1992,32 +1992,32 @@ for(i in seq_len(nrow(region_genome_filters_config))){
 		suppressWarnings %>% #remove warnings of out of bounds regions due to resize
 		trim %>%
 		GenomicRanges::reduce(ignore.strand=TRUE)
-
+	
 	#Subtract genome region filters from filter trackers
 	bam.gr.filtertrack.indelanalysis <- bam.gr.filtertrack.indelanalysis %>%
 		GRanges_subtract(region_genome_filter, ignore.strand=TRUE) #GRanges_subtract to retain run_id and zm columns
-
+	
 	bam.gr.filtertrack.nonindelanalysis <- bam.gr.filtertrack.nonindelanalysis %>%
 		GRanges_subtract(region_genome_filter, ignore.strand=TRUE)
-
+	
 	#Remove filtered regions from bam.gr.filtertrack.except_germline_filters only if it is a non-germline filter
 	if(region_genome_filters_config %>% pluck("is_germline_filter",i) == FALSE){
 		bam.gr.filtertrack.indelanalysis.except_germline_filters <- bam.gr.filtertrack.indelanalysis.except_germline_filters %>%
 			GRanges_subtract(region_genome_filter, ignore.strand=TRUE)
-
+		
 		bam.gr.filtertrack.nonindelanalysis.except_germline_filters <- bam.gr.filtertrack.nonindelanalysis.except_germline_filters %>%
 			GRanges_subtract(region_genome_filter, ignore.strand=TRUE)
 	}
-
+	
 	genome_chromgroup.gr.filtertrack <- genome_chromgroup.gr.filtertrack %>%
 		GRanges_subtract(region_genome_filter)
-
+	
 	#Annotate filtered calls. Annotates even if partial overlap (relevant for deletions).
 	calls[[passfilter_label]] <- ! overlapsAny_bymcols(
 		calls.gr, region_genome_filter,
 		ignore.strand = TRUE
 	)
-
+	
 	#Update molecule stats
 	molecule_stats <- molecule_stats %>%
 		bind_rows(
@@ -2030,7 +2030,7 @@ for(i in seq_len(nrow(region_genome_filters_config))){
 				stat_label.suffix = str_c("nonindelanalysis.",passfilter_label)
 			)
 		)
-
+	
 	#Record number of filtered genome bases to stats
 	region_genome_filter_stats <- region_genome_filter_stats %>%
 		bind_rows(
@@ -2048,7 +2048,7 @@ for(i in seq_len(nrow(region_genome_filters_config))){
 				) %>%
 				select(-c(applyto_chromgroups,applyto_filtergroups))
 		)
-
+	
 	rm(region_genome_filter)
 	invisible(gc())
 }
@@ -2086,10 +2086,10 @@ max_finalcalls_eachstrand.filter <- calls %>%
 
 #Subtract filtered molecules from bam.gr.filtertrack, creating a new bam.gr.filtertrack.bytype for each call_type x SBSindel_call_type combination being analyzed. For only bam.gr.filtertrack.bytype, also add a row for SBS/mismatch-ss (if not already there) for later calculation of SBS mutation error probability. Perform for both standard and 'except_germline_filters' filter trackers.
 bam.gr.filtertrack.bytype <- call_types_toanalyze %>%
-
+	
 	#Remove analyzein_chromgroups and MDB configuration parameters from call_types_toanalyze that are not needed here
 	select(-analyzein_chromgroups, -starts_with("MDB")) %>%
-
+	
 	#Add row for SBS/mismatch-ss
 	bind_rows(
 		tibble(
@@ -2100,7 +2100,7 @@ bam.gr.filtertrack.bytype <- call_types_toanalyze %>%
 		)
 	) %>%
 	distinct %>%
-
+	
 	mutate(
 		bam.gr.filtertrack = if_else(
 			call_class == "indel",
@@ -2117,14 +2117,14 @@ bam.gr.filtertrack.bytype <- call_types_toanalyze %>%
 						max_finalcalls_eachstrand.passfilter == FALSE
 						) %>%
 					distinct(run_id,zm)
-
+					
 				x[
 					!vctrs::vec_in(
 						x %>% mcols %>% as_tibble %>% select(run_id,zm),
 						molecules_to_filter
 					)
 				]
-
+				
 			}
 		)
 	)
@@ -2147,14 +2147,14 @@ bam.gr.filtertrack.except_germline_filters.bytype <- call_types_toanalyze %>%
 						max_finalcalls_eachstrand.passfilter == FALSE
 					) %>%
 					distinct(run_id,zm)
-
+				
 				x[
 					!vctrs::vec_in(
 						x %>% mcols %>% as_tibble %>% select(run_id,zm),
 						molecules_to_filter
 					)
 				]
-
+				
 			}
 		)
 	)
@@ -2163,7 +2163,7 @@ bam.gr.filtertrack.except_germline_filters.bytype <- call_types_toanalyze %>%
 molecule_stats <- molecule_stats %>%
 	bind_rows(
 		bam.gr.filtertrack.bytype %>%
-			#Exclude SBS/mismatch-ss row if it was only added to bam.gr.filtertrack.bytype for downstream calculation of SBS mutation error probability.
+			#Exclude SBS/mismatch-ss row if it was only added to bam.gr.filtertrack.bytype for downstream calculation of SBS mutation error probability. 
 			semi_join(
 				call_types_toanalyze,
 				by = join_by(call_type, call_class, SBSindel_call_type, filtergroup)

--- a/bin/filterCalls.R
+++ b/bin/filterCalls.R
@@ -23,6 +23,11 @@ suppressPackageStartupMessages(library(qs2))
 suppressPackageStartupMessages(library(tidyverse))
 
 ######################
+### Load custom shared functions
+######################
+source(Sys.which("sharedFunctions.R"))
+
+######################
 ### Load configuration
 ######################
 cat("## Loading configuration...\n")
@@ -58,9 +63,10 @@ sample_id_toanalyze <- opt$sample_id_toanalyze
 chromgroup_toanalyze <- opt$chromgroup_toanalyze
 filtergroup_toanalyze <- opt$filtergroup_toanalyze
 outputFile <- opt$output
+BSgenome_name <- get_bsgenome_name(yaml.config)
 
 #Load the BSgenome reference
-suppressPackageStartupMessages(library(yaml.config$BSgenome$BSgenome_name,character.only=TRUE,lib.loc=yaml.config$cache_dir))
+suppressPackageStartupMessages(library(BSgenome_name,character.only=TRUE,lib.loc=yaml.config$cache_dir))
 
 #Load miscellaneous configuration parameters
  #chromosomes to analyze
@@ -73,7 +79,7 @@ chroms_toanalyze <- yaml.config$chromgroups %>%
 	str_trim
 
  #GRanges of chroms to analyze, required as input for some analyses
-genome_chromgroup.gr <- yaml.config$BSgenome$BSgenome_name %>%
+genome_chromgroup.gr <- BSgenome_name %>%
 	get %>%
 	seqinfo %>%
 	GRanges %>%
@@ -112,7 +118,7 @@ filtergroup_toanalyze_config <- yaml.config$filtergroups %>%
   enframe(name=NULL) %>%
   unnest_wider(value) %>%
 	filter(filtergroup == filtergroup_toanalyze)
-  
+
  #region filter parameters (restrict to selected chromgroup_toanalyze and filtergroup_toanalyze)
 region_read_filters_config <- yaml.config$region_filters %>%
   map("read_filters") %>%
@@ -147,17 +153,12 @@ cat("    filtergroup:",filtergroup_toanalyze,"\n")
 cat("DONE\n")
 
 ######################
-### Load custom shared functions
-######################
-source(Sys.which("sharedFunctions.R"))
-
-######################
 ### Define custom functions
 ######################
 
 #Function to calculate number of molecules and reference space bases passing each individual filter matching a pattern (starting from the upstream filtered bam of extractCalls, i.e. starting after minstrandoverlapfilter), and passing all filters so far (if all_filter_suffix is not NULL), from bam input.
 calculate_molecule_stats_frombam <- function(bam.input, individual_filter_pattern, all_filter_suffix=NULL, chromgroup_toanalyze.input, filtergroup_toanalyze.input, extractCallsFile.input){
-	
+
 	#Number of molecules and reference space bases passing each basic molecule filter, each applied separately
 	filter_stats <- bam.input %>%
 		group_by(run_id) %>%
@@ -171,7 +172,7 @@ calculate_molecule_stats_frombam <- function(bam.input, individual_filter_patter
 				.names = "{.fn}_individualfilter.{.col}"
 			)
 		)
-	
+
 	#Number of molecules and reference space bases passing all the basic molecule filters
 	if(!is.null(all_filter_suffix)){
 		filter_stats <- filter_stats %>%
@@ -186,32 +187,32 @@ calculate_molecule_stats_frombam <- function(bam.input, individual_filter_patter
 				by = "run_id"
 			)
 	}
-	
+
 	filter_stats %>%
 		complete(run_id) %>%
 		mutate(across(-run_id, ~ .x %>% replace_na(0))) %>%
-		
+
 		#Pivot longer
 		pivot_longer(
 			-run_id,
 			names_to = "stat",
 			values_to = "value"
 		) %>%
-		
+
 		#Annotate extractCallsFile, chromgroup, filtergroup of this process
 		mutate(
 			chromgroup = chromgroup_toanalyze.input,
 			filtergroup = filtergroup_toanalyze.input,
 			extractCallsFile = extractCallsFile.input %>% basename
 		) %>%
-		
+
 		#Reorder columns
 		relocate(run_id,chromgroup,filtergroup,extractCallsFile)
 }
 
 #Function to calculate number of molecules and refspace bases remaining in bam filtertracker.
 calculate_molecule_stats_frombamfiltertrack <- function(bam.gr.filtertrack.input, stat_label.suffix){
-	
+
 	bam.gr.filtertrack.input %>%
 		as_tibble %>%
 		group_by(run_id) %>%
@@ -235,39 +236,39 @@ calculate_molecule_stats_frombamfiltertrack <- function(bam.gr.filtertrack.input
 
 #Function returning a TRUE/FALSE vector signifying for each element of a query GRanges if it overlaps any element of a subject GRanges, joining on optional columns. If overlap_adjacent_query_insertion = TRUE, then insertions (zero width) in query will be considered an overlap to an immediately adjacent non-insertion subject range.
 overlapsAny_bymcols <- function(query, subject, join_mcols = character(), ignore.strand = TRUE, overlap_adjacent_query_insertion = FALSE) {
-	
+
 	stopifnot(inherits(query, "GenomicRanges"), inherits(subject, "GenomicRanges"))
-	
+
 	nq <- length(query)
 	ns <- length(subject)
-	
+
 	if(nq == 0){return(logical())} #Empty query
 	if(ns == 0){return(rep(FALSE, nq))} #Empty subject
-	
+
 	if(length(join_mcols) > 0){
 		q_mcols <- mcols(query)
 		s_mcols <- mcols(subject)
-		
+
 		if(!all(join_mcols %in% colnames(q_mcols)) || !all(join_mcols %in% colnames(s_mcols))){
 			stop("All `join_mcols` must exist as metadata columns in both query and subject.")
 		}
-		
+
 		key_q <- query %>%
 			as_tibble %>%
 			select(all_of(join_mcols)) %>%
 			as.list %>%
 			interaction(drop = TRUE)
-		
+
 		key_s <- subject %>%
 			as_tibble %>%
 			select(all_of(join_mcols)) %>%
 			as.list %>%
 			interaction(drop = TRUE)
-		
+
 		keys_all <- factor(c(key_q,key_s))
 		id_q <- as.integer(keys_all)[seq_len(nq)]
 		id_s <- as.integer(keys_all)[nq + seq_len(ns)]
-		
+
 		# Make NA ids unique and disjoint between query and subject so they never overlap.
 		if(anyNA(id_q)){
 			idx <- id_q %>% is.na %>% which
@@ -277,45 +278,45 @@ overlapsAny_bymcols <- function(query, subject, join_mcols = character(), ignore
 			idx <- id_s %>% is.na %>% which
 			id_s[idx] <- -(nq + idx)
 		}
-		
+
 	}else{
 		#No join keys: everyone shares the same id => equivalent to no join constraint.
 		id_q <- rep.int(1L, nq)
 		id_s <- rep.int(1L, ns)
 	}
-	
+
 	#Change seqnames to contain key
 	q2 <- GRanges(
 		seqnames = str_c(as.character(seqnames(query)), "|", id_q),
 		ranges = ranges(query),
 		strand = strand(query)
 	)
-	
+
 	s2 <- GRanges(
 		seqnames = str_c(as.character(seqnames(subject)), "|", id_s),
 		ranges = ranges(subject),
 		strand = strand(subject)
 	) %>%
 		GNCList
-	
+
 	hits <- findOverlaps(q2, s2, ignore.strand = ignore.strand) %>%
 		suppressWarnings #Hide warning about unshared seqlevels between q2 and s2
-	
+
 	if(overlap_adjacent_query_insertion == TRUE){
 		hits_adj <- findOverlaps(q2, s2, ignore.strand = ignore.strand, maxgap = 0) %>%
 			suppressWarnings
-		
+
 		qh_adj <- queryHits(hits_adj)
 		sh_adj <- subjectHits(hits_adj)
-		
+
 		hits_adj <- hits_adj[
 			(query[qh_adj] %>% width == 0) & (subject[sh_adj] %>% width != 0)
 			]
-		
+
 		hits <- GenomicRanges::union(hits, hits_adj)
 		rm(hits_adj)
 	}
-	
+
 	if(length(hits) == 0){return(rep(FALSE, nq))} #No overlap
 
 	#Output result
@@ -325,7 +326,7 @@ overlapsAny_bymcols <- function(query, subject, join_mcols = character(), ignore
 #Convert positions of bases from query space to reference space, while retaining run_id and zm info
 #iranges.input: IRangesList with query space positions, with the IRangesList length the same as the number of rows in bam.input
 convert_query_to_refspace <- function(irangeslist.input, bam.input, BSgenome_name.input){
-	
+
 	#Format irangeslist.input to GRanges of positions failing subreads filters in query space, with annotated bam read id
 	irangeslist.input <- irangeslist.input %>%
 		setNames(bam.input %>% pull(seqnames)) %>%
@@ -337,20 +338,20 @@ convert_query_to_refspace <- function(irangeslist.input, bam.input, BSgenome_nam
 		) %>%
 		setNames(.$group) %>%
 		select(-group)
-	
+
 	if(length(irangeslist.input) == 0){
 		return(
 			GRanges(run_id=factor(), zm=integer())
 		)
 	}
-	
+
 	mapFromAlignments( #Main function
-		
+
 		irangeslist.input,
-		
+
 		#GAlignments of reads in reference space
 		bam.input %>%
-			select(seqnames, start, end, cigar) %>% 
+			select(seqnames, start, end, cigar) %>%
 			makeGRangesFromDataFrame(
 				keep.extra.columns=TRUE,
 				seqinfo=BSgenome_name.input %>% get %>% seqinfo
@@ -358,7 +359,7 @@ convert_query_to_refspace <- function(irangeslist.input, bam.input, BSgenome_nam
 			as("GAlignments") %>%
 			setNames(1:nrow(bam.input))
 	) %>%
-		
+
 		#Annotate result with run_id, zm, and strand
 		as_tibble %>%
 		left_join(
@@ -426,7 +427,7 @@ molecule_stats <- extractedCalls %>%
 	filter(chromgroup %in% c(chromgroup_toanalyze,"all_chromgroups","all_chroms"))
 
 #Create tibble to track genome region filter stats and initialize with stats for whole genome and for chromgroup.
-genome_numbases <- yaml.config$BSgenome$BSgenome_name %>%
+genome_numbases <- BSgenome_name %>%
 	get %>%
 	seqinfo %>%
 	GRanges %>%
@@ -473,23 +474,23 @@ bam <- bam %>%
 	mutate(num_softclipbases = cigar %>% cigarOpTable %>% as_tibble %>% pull(S)) %>%
 	group_by(run_id,zm) %>%
 	mutate(
-		
+
 		#rq
 		min_rq_eachstrand.passfilter = all(rq >= filtergroup_toanalyze_config$min_rq_eachstrand),
 		min_rq_avgstrands.passfilter = mean(rq) >= filtergroup_toanalyze_config$min_rq_avgstrands,
-		
+
 		#ec
 		min_ec_eachstrand.passfilter = all(ec >= filtergroup_toanalyze_config$min_ec_eachstrand),
 		min_ec_avgstrands.passfilter = mean(ec) >= filtergroup_toanalyze_config$min_ec_avgstrands,
-		
+
 		#mapq
 		min_mapq_eachstrand.passfilter = all(mapq >= filtergroup_toanalyze_config$min_mapq_eachstrand),
 		min_mapq_avgstrands.passfilter = mean(mapq) >= filtergroup_toanalyze_config$min_mapq_avgstrands,
-		
+
 		#num_softclipbases
 		max_num_softclipbases_eachstrand.passfilter = all(num_softclipbases <= filtergroup_toanalyze_config$max_num_softclipbases_eachstrand),
 		max_num_softclipbases_avgstrands.passfilter = mean(num_softclipbases) <= filtergroup_toanalyze_config$max_num_softclipbases_avgstrands
-		
+
 	) %>%
 	select(-num_softclipbases) %>%
 	ungroup
@@ -497,16 +498,16 @@ bam <- bam %>%
 #Annotate reads for filters: max_num_SBScalls_eachstrand, max_num_SBScalls_stranddiff, max_num_indelcalls_eachstrand, max_num_indelcalls_stranddiff
 bam <- bam %>%
 	left_join(
-			
+
 			#Filter for SBS and indel calls
 			calls %>%
 				filter(
 				  call_class %in% c("SBS","indel")
 				  ) %>%
-			  
+
 				#Change call_class to factor so that count results are listed for both SBS and indel below.
-				mutate(call_class = call_class %>% factor(levels=c("SBS","indel"))) %>% 
-				
+				mutate(call_class = call_class %>% factor(levels=c("SBS","indel"))) %>%
+
 				#Count number of SBS and indel calls per strand while completing missing strand and SBS/indel values for each molecule so that num_{call_class}calls are calculated correctly
 				count(run_id,zm,strand,call_class) %>%
 			  complete(run_id,zm,strand,call_class,fill = list(n=0)) %>%
@@ -516,29 +517,29 @@ bam <- bam %>%
 					names_glue = "num_{call_class}calls",
 					names_expand = TRUE #Necessary if there are no calls
 					) %>%
-				
+
 				#Calculate filters for each molecule
 				group_by(run_id,zm) %>%
 				summarize(
 					#max_num_SBScalls_eachstrand.passfilter
 					max_num_SBScalls_eachstrand.passfilter = all(num_SBScalls <= filtergroup_toanalyze_config$max_num_SBScalls_eachstrand),
-					
+
 					#max_num_indelcalls_eachstrand.passfilter
 					max_num_indelcalls_eachstrand.passfilter = all(num_indelcalls <= filtergroup_toanalyze_config$max_num_indelcalls_eachstrand),
-					
+
 					#max_num_SBScalls_stranddiff.passfilter
 					max_num_SBScalls_stranddiff.passfilter = (num_SBScalls * if_else(strand == "+",  1L, -1L)) %>%
 						sum %>%
 						abs %>%
 						#Curly braces ensure the '.' refers to the immediately preceding result
 						{. <= filtergroup_toanalyze_config$max_num_SBScalls_stranddiff},
-					
+
 					#max_num_indelcalls_stranddiff.passfilter
 					max_num_indelcalls_stranddiff.passfilter = (num_indelcalls * if_else(strand == "+",  1L, -1L)) %>%
 						sum %>%
 						abs %>%
 					  {. <= filtergroup_toanalyze_config$max_num_indelcalls_stranddiff},
-	
+
 					.groups = "drop"
 				),
 		by = join_by(run_id,zm)
@@ -556,16 +557,16 @@ bam <- bam %>%
 #Annotate reads for filters: max_num_SBSmutations, max_num_indelmutations
 bam <- bam %>%
 	left_join(
-			
+
 			#Filter for SBS and indel mutations. Not filtering here on only '+' or only '-' strand since the below code won't double count mutations, because it counts mutations for each strand and those numbers will be identical for each strand of a molecule.
 		calls %>%
 			filter(
 				call_class %in% c("SBS","indel"),
 				SBSindel_call_type == "mutation"
 				) %>%
-		  
+
 		  #Count number of SBS and indel mutations per molecule while completing missing SBS/indel values for each molecule so that num_{call_class}mutations are calculated correctly.
-		  mutate(call_class = call_class %>% factor(levels=c("SBS","indel"))) %>% 
+		  mutate(call_class = call_class %>% factor(levels=c("SBS","indel"))) %>%
 		  count(run_id,zm,strand,call_class) %>%
 		  complete(run_id,zm,strand,call_class,fill = list(n=0)) %>%
 			pivot_wider(
@@ -574,16 +575,16 @@ bam <- bam %>%
 				names_glue = "num_{call_class}mutations",
 				names_expand = TRUE #Necessary if there are no calls
 			) %>%
-			
+
 			#Calculate filters for each molecule
 			group_by(run_id,zm) %>%
 			summarize(
 				#max_num_SBSmutations
 				max_num_SBSmutations.passfilter = all(num_SBSmutations <= filtergroup_toanalyze_config$max_num_SBSmutations),
-				
+
 				#max_num_indelmutations
 				max_num_indelmutations.passfilter = all(num_indelmutations <= filtergroup_toanalyze_config$max_num_indelmutations),
-				
+
 				.groups = "drop"
 			),
 		by = join_by(run_id,zm)
@@ -645,7 +646,7 @@ germline_vcf_variants <- qs_read(
 		)
 	) %>%
   as_tibble
-  
+
 #Filter to keep germline VCF variants that pass configured germline VCF filters and keep only columns necessary for downstream filtering
 germline_vcf_variants <- germline_vcf_variants  %>%
   group_by(germline_vcf_type) %>% #split by germline_vcf_type
@@ -654,7 +655,7 @@ germline_vcf_variants <- germline_vcf_variants  %>%
   imap(
     function(x,idx){
       filters <- germline_vcf_types_config %>% filter(germline_vcf_type == idx)
-      
+
       x %>%
         filter(
           (
@@ -708,19 +709,19 @@ cat("## Applying post-germline VCF variant filtering molecule filters...")
 #Annotate reads for filters: max_num_SBScalls_postVCF_eachstrand, max_num_indelcalls_postVCF_eachstrand
 bam <- bam %>%
   left_join(
-    
+
     #Filter to keep SBS and indel calls that pass all filters applied so far
     calls %>%
       filter(
         call_class %in% c("SBS","indel"),
         if_all(contains("passfilter"), ~ .x == TRUE)
       ) %>%
-      
+
       #Count number of SBS and indel calls per strand while completing missing strand and SBS/indel values for each molecule so that num_{call_class}calls are calculated correctly. Fix strand levels to '+/-' to avoid expanding strand = '*'.
       mutate(
         call_class = call_class %>% factor(levels=c("SBS","indel")),
         strand = strand %>% factor(levels=c("+","-"))
-      ) %>% 
+      ) %>%
       count(run_id,zm,strand,call_class) %>%
       complete(run_id, zm, strand, call_class, fill = list(n=0)) %>%
       pivot_wider(
@@ -729,13 +730,13 @@ bam <- bam %>%
         names_glue = "num_{call_class}calls",
         names_expand = TRUE #Necessary if there are no calls
       ) %>%
-      
+
       #Calculate filters for each molecule
       group_by(run_id,zm) %>%
       summarize(
         #max_num_SBScalls_postVCF_eachstrand
         max_num_SBScalls_postVCF_eachstrand.passfilter = all(num_SBScalls <= filtergroup_toanalyze_config$max_num_SBScalls_postVCF_eachstrand),
-        
+
         #max_num_indelcalls_postVCF_eachstrand
         max_num_indelcalls_postVCF_eachstrand.passfilter = all(num_indelcalls <= filtergroup_toanalyze_config$max_num_indelcalls_postVCF_eachstrand),
         ,.groups = "drop"
@@ -753,7 +754,7 @@ bam <- bam %>%
 #Annotate reads for filters: max_num_SBSmutations_postVCF, max_num_indelmutations_postVCF
 bam <- bam %>%
   left_join(
-    
+
     #Filter to keep SBS and indel calls that pass all filters applied so far
     calls %>%
       filter(
@@ -761,9 +762,9 @@ bam <- bam %>%
         SBSindel_call_type == "mutation",
         if_all(contains("passfilter"), ~ .x == TRUE)
       ) %>%
-      
+
       #Count number of SBS and indel mutations per molecule while completing missing SBS/indel values for each molecule so that num_{call_class}mutations are calculated correctly
-      mutate(call_class = call_class %>% factor(levels=c("SBS","indel"))) %>% 
+      mutate(call_class = call_class %>% factor(levels=c("SBS","indel"))) %>%
       count(run_id,zm,strand,call_class) %>%
       complete(run_id,zm,strand,call_class,fill = list(n=0)) %>%
       pivot_wider(
@@ -772,16 +773,16 @@ bam <- bam %>%
         names_glue = "num_{call_class}mutations",
         names_expand = TRUE #Necessary if there are no calls
       ) %>%
-      
+
       #Calculate filters for each molecule
       group_by(run_id,zm) %>%
       summarize(
         #max_num_SBSmutations_postVCF
         max_num_SBSmutations_postVCF.passfilter = all(num_SBSmutations <= filtergroup_toanalyze_config$max_num_SBSmutations_postVCF),
-        
+
         #max_num_indelmutations_postVCF
         max_num_indelmutations_postVCF.passfilter = all(num_indelmutations <= filtergroup_toanalyze_config$max_num_indelmutations_postVCF),
-        
+
         .groups = "drop"
       ),
     by = join_by(run_id,zm)
@@ -836,7 +837,7 @@ bam.gr.filtertrack <- bam %>%
 	select(run_id, zm, seqnames, start, end, strand) %>%
 	makeGRangesFromDataFrame(
 		keep.extra.columns = TRUE,
-		seqinfo=yaml.config$BSgenome$BSgenome_name %>% get %>% seqinfo
+		seqinfo=BSgenome_name %>% get %>% seqinfo
 	)
 
 #Create genome GRanges of selected chroms_toanalyze to track genome region filtering
@@ -846,7 +847,7 @@ genome_chromgroup.gr.filtertrack <- genome_chromgroup.gr
 calls.gr <- calls %>%
 	makeGRangesFromDataFrame(
 		keep.extra.columns=TRUE,
-		seqinfo=yaml.config$BSgenome$BSgenome_name %>% get %>% seqinfo
+		seqinfo=BSgenome_name %>% get %>% seqinfo
 	) %>%
 	select(run_id, zm, call_class, call_type, SBSindel_call_type, ref_plus_strand, alt_plus_strand)
 
@@ -860,7 +861,7 @@ cat("## Applying genome 'N' base sequence filter...")
 passfilter_label <- "region_genome_filter_Nbases.passfilter"
 
 #Extract 'N' base sequence ranges
-region_genome_filter <- yaml.config$BSgenome$BSgenome_name %>%
+region_genome_filter <- BSgenome_name %>%
 	get %>%
 	vmatchPattern("N",.) %>%
 	GenomicRanges::reduce(ignore.strand=TRUE)
@@ -928,7 +929,7 @@ min_qual.fail.gr <- bam %>%
 			IRangesList()
 		}
 	} %>%
-	convert_query_to_refspace(bam.input = bam, BSgenome_name.input = yaml.config$BSgenome$BSgenome_name)
+	convert_query_to_refspace(bam.input = bam, BSgenome_name.input = BSgenome_name)
 
 #Subtract bases below min_qual threshold from bam reads filter tracker, joining on run_id and zm. Set ignore.strand = TRUE so that if a position is filtered in one strand, also filter the same reference space position on the opposite strand, since that is how calls are filtered.
 bam.gr.filtertrack <- bam.gr.filtertrack %>%
@@ -976,7 +977,7 @@ bam.gr.onlyranges <- bam %>%
   select(seqnames, start, end, strand, run_id, zm) %>%
   makeGRangesFromDataFrame(
     keep.extra.columns=TRUE,
-    seqinfo=yaml.config$BSgenome$BSgenome_name %>% get %>% seqinfo
+    seqinfo=BSgenome_name %>% get %>% seqinfo
   )
 
 bam.gr.trim <- c(
@@ -986,7 +987,7 @@ bam.gr.trim <- c(
 	      end = if_else(temp_end < end, temp_end, end)  #prevents exceeding genome boundaries
 	      ) %>%
 	    select(-temp_end),
-    
+
     bam.gr.onlyranges %>%
       mutate(
         temp_start = end - filtergroup_toanalyze_config$read_trim_bp + 1,
@@ -1042,7 +1043,7 @@ if(!is.na(ccs_sbs_flank)){
 			flank(width=ccs_sbs_flank, start = TRUE, ignore.strand = TRUE) %>%
 			suppressWarnings %>% #remove warnings of out of bounds regions due to resize
 			trim,
-		
+
 		#Right flank
 		calls.gr %>%
 			filter(call_class=="SBS") %>%
@@ -1097,7 +1098,7 @@ if(!is.na(ccs_ins_pad)){
 	ccs_ins_pad <- ccs_ins_pad %>%
 	  tibble(pad=.) %>%
 	  extract(pad, into = c("m", "b"), regex = "m(\\d+)b(\\d+)", convert = TRUE)
-	
+
 	read_ins_region_filter <- calls.gr %>%
 		filter(call_class=="indel", call_type == "insertion") %>%
 		mutate(
@@ -1109,7 +1110,7 @@ if(!is.na(ccs_ins_pad)){
 		suppressWarnings %>% #remove warnings of out of bounds regions due to resize
 		trim %>%
 		select(run_id, zm)
-	
+
 }else{
 	read_ins_region_filter <- calls.gr %>%
 		select(run_id, zm) %>%
@@ -1121,7 +1122,7 @@ if(!is.na(ccs_del_pad)){
 	ccs_del_pad <- ccs_del_pad %>%
 	  tibble(pad=.) %>%
 	  extract(pad, into = c("m", "b"), regex = "m(\\d+)b(\\d+)", convert = TRUE)
-	
+
 	read_del_region_filter <- calls.gr %>%
 		filter(call_class=="indel", call_type == "deletion") %>%
 		mutate(
@@ -1133,7 +1134,7 @@ if(!is.na(ccs_del_pad)){
 		suppressWarnings %>% #remove warnings of out of bounds regions due to resize
 		trim %>%
 		select(run_id, zm)
-	
+
 }else{
 	read_del_region_filter <- calls.gr %>%
 		select(run_id, zm) %>%
@@ -1142,7 +1143,7 @@ if(!is.na(ccs_del_pad)){
 
 #Combine insertion and deletion GRanges with configured padding
 read_indel_region_filter <- c(read_ins_region_filter, read_del_region_filter)
- 
+
 #Annotate calls filtered by read_indel_region_filter without taking strand into account, so that if a call on either strand fails the filter, calls on both strands fail the filter. Not applied to indels.
 calls[["read_indel_region_filter.passfilter"]] <- ! overlapsAny_bymcols(
 	calls.gr, read_indel_region_filter,
@@ -1325,7 +1326,7 @@ germline_bam_bcftools_mpileup_filter <- load_vcf(
 	vcf_file = germline_bam_bcftools_mpileup_file,
 	regions = variant_regions_bcftools_mpileup,
 	genome_fasta = yaml.config$genome_fasta,
-	BSgenome_name = yaml.config$BSgenome$BSgenome_name,
+	BSgenome_name = BSgenome_name,
 	bcftools_bin = yaml.config$bcftools_bin
 )
 
@@ -1339,7 +1340,7 @@ germline_bam_bcftools_mpileup_BAMVAF_filter <- germline_bam_bcftools_mpileup_fil
 #Annotate SBS calls with germline BAM bcftools mpileup VCF filters.
 calls[["max_germlineBAM_VariantReads.passfilter"]] <- ! overlapsAny_bymcols(
 	calls.gr, germline_bam_bcftools_mpileup_BAMVariantReads_filter,
-	join_mcols = c("call_class","call_type","ref_plus_strand","alt_plus_strand"), #Not joining by SBSindel_call_type so filter is also applied to mismatch-ss and mismatch-ds calls 
+	join_mcols = c("call_class","call_type","ref_plus_strand","alt_plus_strand"), #Not joining by SBSindel_call_type so filter is also applied to mismatch-ss and mismatch-ds calls
 	ignore.strand = TRUE
 )
 
@@ -1360,7 +1361,7 @@ cat("DONE\n")
 cat("## Applying subread filters...")
 
 #Convert positions of bases failing subread filters from query space to reference space, while retaining run_id and zm info
- #min_frac_subreads_cvg (sa/max(sa)) 
+ #min_frac_subreads_cvg (sa/max(sa))
 frac_subreads_cvg.fail.gr <- bam %>%
 		pull(sa) %>%
 		map(
@@ -1373,7 +1374,7 @@ frac_subreads_cvg.fail.gr <- bam %>%
 				}
 		) %>%
 		IRangesList %>%
-		convert_query_to_refspace(bam.input = bam, BSgenome_name.input = yaml.config$BSgenome$BSgenome_name)
+		convert_query_to_refspace(bam.input = bam, BSgenome_name.input = BSgenome_name)
 
  #min_num_subreads_match (sm)
 num_subreads_match.fail.gr <- bam %>%
@@ -1386,7 +1387,7 @@ num_subreads_match.fail.gr <- bam %>%
 		}
 	) %>%
 	IRangesList %>%
-	convert_query_to_refspace(bam.input = bam, BSgenome_name.input = yaml.config$BSgenome$BSgenome_name)
+	convert_query_to_refspace(bam.input = bam, BSgenome_name.input = BSgenome_name)
 
  #min_frac_subreads_match (sm / [sm+sx])
 frac_subreads_match.fail.gr <- map2(
@@ -1401,7 +1402,7 @@ frac_subreads_match.fail.gr <- map2(
 			}
 	) %>%
 	IRangesList %>%
-	convert_query_to_refspace(bam.input = bam, BSgenome_name.input = yaml.config$BSgenome$BSgenome_name)
+	convert_query_to_refspace(bam.input = bam, BSgenome_name.input = BSgenome_name)
 
 #Subtract bases below filter thresholds from bam reads filter tracker, joining on run_id and zm. Set ignore.strand = TRUE so that if a position is filtered in one strand, also filter the same reference space position on the opposite strand, since that is how calls are filtered.
 bam.gr.filtertrack.indelanalysis <- bam.gr.filtertrack.indelanalysis %>%
@@ -1486,7 +1487,7 @@ calls <- calls %>%
 			select(run_id,zm,strand,max_sa.opposite_strand),
 		by = join_by(run_id,zm,strand)
 	) %>%
-	
+
 	#Calculate frac_subreads_cvg for both strands
 	mutate(
 		frac_subreads_cvg = map2(
@@ -1500,7 +1501,7 @@ calls <- calls %>%
 			function(x,y){x/y}
 		)
 	) %>%
-	
+
 	#Perform filtering. NA in any base on the opposite strand is assigned passfilter = FALSE.
 	mutate(
 		min_frac_subreads_cvg.passfilter = map2_lgl(
@@ -1528,7 +1529,7 @@ calls <- calls %>%
 			)
 		)
 	)
-	
+
 #min_frac_subreads_match
 calls <- calls %>%
 	#Calculate frac_subreads_match for both strands
@@ -1544,7 +1545,7 @@ calls <- calls %>%
 			function(x,y){x/(x+y)}
 		)
 	) %>%
-	
+
 	#Perform filtering. If any base on the call strand or opposite strand has (sm+sx) = 0, evaluate frac_subreads_match as 0. If any opposite strand base has sm or sx = NA, then assign passfilter = FALSE.
 	mutate(
 		min_frac_subreads_match.passfilter = map2_lgl(
@@ -1558,7 +1559,7 @@ calls <- calls %>%
 		)
 	) %>%
 	select(-c(frac_subreads_match,frac_subreads_match.opposite_strand))
-	
+
 rm(frac_subreads_cvg.fail.gr, num_subreads_match.fail.gr, frac_subreads_match.fail.gr)
 invisible(gc())
 
@@ -1578,7 +1579,7 @@ duplex_coverage.fail.indelanalysis.gr <- c(
 	bam.gr.filtertrack.indelanalysis %>%
 		filter(strand=="+") %>%
 		GRanges_subtract_bymcols(bam.gr.filtertrack.indelanalysis %>% filter(strand=="-"), join_mcols = c("run_id","zm"), ignore.strand = TRUE),
-	
+
 	#Minus strand only
 	bam.gr.filtertrack.indelanalysis %>%
 		filter(strand=="-") %>%
@@ -1591,7 +1592,7 @@ duplex_coverage.fail.nonindelanalysis.gr <- c(
 	bam.gr.filtertrack.nonindelanalysis %>%
 		filter(strand=="+") %>%
 		GRanges_subtract_bymcols(bam.gr.filtertrack.nonindelanalysis %>% filter(strand=="-"), join_mcols = c("run_id","zm"), ignore.strand = TRUE),
-	
+
 	#Minus strand only
 	bam.gr.filtertrack.nonindelanalysis %>%
 		filter(strand=="-") %>%
@@ -1657,28 +1658,28 @@ bam.gr.filtertrack.nonindelanalysis.except_germline_filters <- bam.gr.filtertrac
 
 #Split germline_vcf_variants by germline_vcf_file
 germline_vcf_variants <- germline_vcf_variants  %>%
-	group_by(germline_vcf_file) %>% 
+	group_by(germline_vcf_file) %>%
 	nest %>%
 	deframe
 
 for(i in names(germline_vcf_variants)){
-	
+
 	#Construct label for the newly created filter column
 	passfilter_label <- i %>%
 		basename %>%
 		str_c("germline_vcf_indel_region_filter_",.,".passfilter")
-	
+
 	#Extract germline VCF type and padding configuration
 	vcf_type <- germline_vcf_variants %>% pluck(i,"germline_vcf_type",1)
 	indel_ins_pad <- germline_vcf_types_config %>% filter(germline_vcf_type == vcf_type) %>% pull(indel_ins_pad)
 	indel_del_pad <- germline_vcf_types_config %>% filter(germline_vcf_type == vcf_type) %>% pull(indel_del_pad)
-	
+
 	#Create GRanges of insertions with configured padding
 	if(!is.na(indel_ins_pad)){
 		indel_ins_pad <- indel_ins_pad %>%
 			tibble(pad=.) %>%
 			extract(pad, into = c("m", "b"), regex = "m(\\d+)b(\\d+)", convert = TRUE)
-		
+
 		germline_vcf_ins_region_filter <- germline_vcf_variants %>%
 			pluck(i) %>%
 			filter(call_class=="indel", call_type == "insertion") %>%
@@ -1693,13 +1694,13 @@ for(i in names(germline_vcf_variants)){
 			pluck(i) %>%
 			slice(0)
 	}
-	
+
 	#Create GRanges of deletions with configured padding
 	if(!is.na(indel_del_pad)){
 		indel_del_pad <- indel_del_pad %>%
 			tibble(pad=.) %>%
 			extract(pad, into = c("m", "b"), regex = "m(\\d+)b(\\d+)", convert = TRUE)
-		
+
 		germline_vcf_del_region_filter <- germline_vcf_variants %>%
 			pluck(i) %>%
 			filter(call_class=="indel", call_type == "deletion") %>%
@@ -1714,32 +1715,32 @@ for(i in names(germline_vcf_variants)){
 			pluck(i) %>%
 			slice(0)
 	}
-	
+
 	#Combine insertion and deletion GRanges with configured padding
 	germline_vcf_indel_region_filter <- bind_rows(germline_vcf_ins_region_filter, germline_vcf_del_region_filter) %>%
 		makeGRangesFromDataFrame(
-			seqinfo=yaml.config$BSgenome$BSgenome_name %>% get %>% seqinfo
+			seqinfo=BSgenome_name %>% get %>% seqinfo
 		) %>%
 		suppressWarnings %>% #remove warnings of out of bounds regions due to resize
 		trim %>%
 		GenomicRanges::reduce(ignore.strand=TRUE)
-	
+
 	#Subtract filtered regions from filter trackers
 	bam.gr.filtertrack.indelanalysis <- bam.gr.filtertrack.indelanalysis %>%
 		GRanges_subtract(germline_vcf_indel_region_filter, ignore.strand = TRUE)
-	
+
 	bam.gr.filtertrack.nonindelanalysis <- bam.gr.filtertrack.nonindelanalysis %>%
 		GRanges_subtract(germline_vcf_indel_region_filter, ignore.strand = TRUE)
-	
+
 	genome_chromgroup.gr.filtertrack <- genome_chromgroup.gr.filtertrack %>%
 		GRanges_subtract(germline_vcf_indel_region_filter)
-	
+
 	#Annotate filtered calls. Annotates even if partial overlap (relevant for deletions).
 	calls[[passfilter_label]] <- ! overlapsAny_bymcols(
 		calls.gr, germline_vcf_indel_region_filter,
 		ignore.strand = TRUE
 	)
-	
+
 	#Record number of filtered genome bases to stats
 	region_genome_filter_stats <- region_genome_filter_stats %>%
 		bind_rows(
@@ -1782,22 +1783,22 @@ cat("DONE\n")
 cat("## Applying region-based molecule filters...")
 
 for(i in seq_len(nrow(region_read_filters_config))){
-	
+
 	#Construct label for the newly created filter column
 	passfilter_label <- region_read_filters_config %>%
 		pluck("region_filter_threshold_file",i) %>%
 		basename %>%
 		str_c("region_read_filter_",.,".passfilter")
-	
+
 	#Extract read threshold
 	read_threshold_type <- region_read_filters_config %>%
 		pluck("read_threshold",i) %>%
 		str_extract("^(gt|gte|lt|lte)")
-	
+
 	read_threshold_value <- region_read_filters_config %>%
 		pluck("read_threshold",i) %>%
 		str_extract("[0-9.]+$")
-	
+
 	#Load region read filter bigwig
 	region_read_filter <- region_read_filters_config %>%
 		pluck("region_filter_threshold_file",i) %>%
@@ -1807,7 +1808,7 @@ for(i in seq_len(nrow(region_read_filters_config))){
 			seqinfo(.) <- seqinfo(genome_chromgroup.gr)
 			.
 		} %>%
-		
+
 		#Add padding
 		resize(
 			width = width(.) + 2 * (region_read_filters_config %>% pluck("padding",i)),
@@ -1816,11 +1817,11 @@ for(i in seq_len(nrow(region_read_filters_config))){
 		suppressWarnings %>% #remove warnings of out of bounds regions due to resize
 		trim %>%
 		GenomicRanges::reduce(ignore.strand=TRUE) %>%
-		
+
 		#Create a logical TRUE/FALSE RLE of genomic bases covered so that the below binnedAverage function calculates, for each read, the fraction covered by the region_read_filter
 		coverage %>%
 		{. > 0}
-	
+
 	#Annotate which molecules pass the filter
 	bam <- bam %>%
 		left_join(
@@ -1829,12 +1830,12 @@ for(i in seq_len(nrow(region_read_filters_config))){
 				select(seqnames, start, end, strand, run_id, zm) %>%
 				makeGRangesFromDataFrame(
 					keep.extra.columns=TRUE,
-					seqinfo=yaml.config$BSgenome$BSgenome_name %>% get %>% seqinfo
+					seqinfo=BSgenome_name %>% get %>% seqinfo
 				) %>%
-				
+
 				#Calculate fraction of coverage by the region read filter
 				binnedAverage(region_read_filter,varname="frac") %>%
-				
+
 				#Annotate which molecules have a fraction of their length filtered by the above bigwig (averaged across plus and minus strands) that is either greater than (gt), greater than or equal (gte), less than (lt), or less than or equal (lte) to a read_threshold_value
 				as_tibble %>%
 				group_by(run_id, zm) %>%
@@ -1849,7 +1850,7 @@ for(i in seq_len(nrow(region_read_filters_config))){
 				),
 			by = join_by(run_id,zm)
 		)
-	
+
 	#Remove filtered molecules from bam.gr.filtertrack
 	bam.gr.filtertrack.indelanalysis <- bam.gr.filtertrack.indelanalysis[
 		!vctrs::vec_in(
@@ -1862,7 +1863,7 @@ for(i in seq_len(nrow(region_read_filters_config))){
 				distinct(run_id,zm)
 			)
 		]
-		
+
 		bam.gr.filtertrack.nonindelanalysis <- bam.gr.filtertrack.nonindelanalysis[
 			!vctrs::vec_in(
 				bam.gr.filtertrack.nonindelanalysis %>%
@@ -1874,7 +1875,7 @@ for(i in seq_len(nrow(region_read_filters_config))){
 					distinct(run_id,zm)
 			)
 		]
-		
+
 		#Remove filtered molecules from bam.gr.filtertrack.except_germline_filters only if it is a non-germline filter
 		if(region_read_filters_config %>% pluck("is_germline_filter",i) == FALSE){
 			bam.gr.filtertrack.indelanalysis.except_germline_filters <- bam.gr.filtertrack.indelanalysis.except_germline_filters[
@@ -1888,7 +1889,7 @@ for(i in seq_len(nrow(region_read_filters_config))){
 						distinct(run_id,zm)
 				)
 			]
-			
+
 			bam.gr.filtertrack.nonindelanalysis.except_germline_filters <- bam.gr.filtertrack.nonindelanalysis.except_germline_filters[
 				!vctrs::vec_in(
 					bam.gr.filtertrack.nonindelanalysis.except_germline_filters %>%
@@ -1901,7 +1902,7 @@ for(i in seq_len(nrow(region_read_filters_config))){
 				)
 			]
 		}
-		
+
 		#Update molecule stats of remaining molecules and bases after each filter is added
 		molecule_stats <- molecule_stats %>%
 			bind_rows(
@@ -1916,7 +1917,7 @@ for(i in seq_len(nrow(region_read_filters_config))){
 			)
 
 	rm(region_read_filter)
-	invisible(gc())		
+	invisible(gc())
 }
 
 #Update molecule stats of each filter applied individually regardless of any prior filters. This is possible in this case since these are molecule-level filters. Note, all_filter_suffix = NULL, because can't calculate all_filter stats from bam at this point since non-molecule filters have already been applied upstream.
@@ -1966,13 +1967,13 @@ cat("## Applying genome region filters...")
 
 #Perform filtering
 for(i in seq_len(nrow(region_genome_filters_config))){
-	
+
 	#Construct label for the newly created filter column
 	passfilter_label <- region_genome_filters_config %>%
 		pluck("region_filter_threshold_file",i) %>%
 		basename %>%
 		str_c("region_genome_filter_",.,".passfilter")
-	
+
 	#Load region read filter bigwig
 	region_genome_filter <- region_genome_filters_config %>%
 		pluck("region_filter_threshold_file",i) %>%
@@ -1982,7 +1983,7 @@ for(i in seq_len(nrow(region_genome_filters_config))){
 			seqinfo(.) <- seqinfo(genome_chromgroup.gr)
 			.
 		} %>%
-		
+
 		#Add padding
 		resize(
 			width = width(.) + 2 * (region_genome_filters_config %>% pluck("padding",i)),
@@ -1991,32 +1992,32 @@ for(i in seq_len(nrow(region_genome_filters_config))){
 		suppressWarnings %>% #remove warnings of out of bounds regions due to resize
 		trim %>%
 		GenomicRanges::reduce(ignore.strand=TRUE)
-	
+
 	#Subtract genome region filters from filter trackers
 	bam.gr.filtertrack.indelanalysis <- bam.gr.filtertrack.indelanalysis %>%
 		GRanges_subtract(region_genome_filter, ignore.strand=TRUE) #GRanges_subtract to retain run_id and zm columns
-	
+
 	bam.gr.filtertrack.nonindelanalysis <- bam.gr.filtertrack.nonindelanalysis %>%
 		GRanges_subtract(region_genome_filter, ignore.strand=TRUE)
-	
+
 	#Remove filtered regions from bam.gr.filtertrack.except_germline_filters only if it is a non-germline filter
 	if(region_genome_filters_config %>% pluck("is_germline_filter",i) == FALSE){
 		bam.gr.filtertrack.indelanalysis.except_germline_filters <- bam.gr.filtertrack.indelanalysis.except_germline_filters %>%
 			GRanges_subtract(region_genome_filter, ignore.strand=TRUE)
-		
+
 		bam.gr.filtertrack.nonindelanalysis.except_germline_filters <- bam.gr.filtertrack.nonindelanalysis.except_germline_filters %>%
 			GRanges_subtract(region_genome_filter, ignore.strand=TRUE)
 	}
-	
+
 	genome_chromgroup.gr.filtertrack <- genome_chromgroup.gr.filtertrack %>%
 		GRanges_subtract(region_genome_filter)
-	
+
 	#Annotate filtered calls. Annotates even if partial overlap (relevant for deletions).
 	calls[[passfilter_label]] <- ! overlapsAny_bymcols(
 		calls.gr, region_genome_filter,
 		ignore.strand = TRUE
 	)
-	
+
 	#Update molecule stats
 	molecule_stats <- molecule_stats %>%
 		bind_rows(
@@ -2029,7 +2030,7 @@ for(i in seq_len(nrow(region_genome_filters_config))){
 				stat_label.suffix = str_c("nonindelanalysis.",passfilter_label)
 			)
 		)
-	
+
 	#Record number of filtered genome bases to stats
 	region_genome_filter_stats <- region_genome_filter_stats %>%
 		bind_rows(
@@ -2047,7 +2048,7 @@ for(i in seq_len(nrow(region_genome_filters_config))){
 				) %>%
 				select(-c(applyto_chromgroups,applyto_filtergroups))
 		)
-	
+
 	rm(region_genome_filter)
 	invisible(gc())
 }
@@ -2085,10 +2086,10 @@ max_finalcalls_eachstrand.filter <- calls %>%
 
 #Subtract filtered molecules from bam.gr.filtertrack, creating a new bam.gr.filtertrack.bytype for each call_type x SBSindel_call_type combination being analyzed. For only bam.gr.filtertrack.bytype, also add a row for SBS/mismatch-ss (if not already there) for later calculation of SBS mutation error probability. Perform for both standard and 'except_germline_filters' filter trackers.
 bam.gr.filtertrack.bytype <- call_types_toanalyze %>%
-	
+
 	#Remove analyzein_chromgroups and MDB configuration parameters from call_types_toanalyze that are not needed here
 	select(-analyzein_chromgroups, -starts_with("MDB")) %>%
-	
+
 	#Add row for SBS/mismatch-ss
 	bind_rows(
 		tibble(
@@ -2099,7 +2100,7 @@ bam.gr.filtertrack.bytype <- call_types_toanalyze %>%
 		)
 	) %>%
 	distinct %>%
-	
+
 	mutate(
 		bam.gr.filtertrack = if_else(
 			call_class == "indel",
@@ -2116,14 +2117,14 @@ bam.gr.filtertrack.bytype <- call_types_toanalyze %>%
 						max_finalcalls_eachstrand.passfilter == FALSE
 						) %>%
 					distinct(run_id,zm)
-					
+
 				x[
 					!vctrs::vec_in(
 						x %>% mcols %>% as_tibble %>% select(run_id,zm),
 						molecules_to_filter
 					)
 				]
-				
+
 			}
 		)
 	)
@@ -2146,14 +2147,14 @@ bam.gr.filtertrack.except_germline_filters.bytype <- call_types_toanalyze %>%
 						max_finalcalls_eachstrand.passfilter == FALSE
 					) %>%
 					distinct(run_id,zm)
-				
+
 				x[
 					!vctrs::vec_in(
 						x %>% mcols %>% as_tibble %>% select(run_id,zm),
 						molecules_to_filter
 					)
 				]
-				
+
 			}
 		)
 	)
@@ -2162,7 +2163,7 @@ bam.gr.filtertrack.except_germline_filters.bytype <- call_types_toanalyze %>%
 molecule_stats <- molecule_stats %>%
 	bind_rows(
 		bam.gr.filtertrack.bytype %>%
-			#Exclude SBS/mismatch-ss row if it was only added to bam.gr.filtertrack.bytype for downstream calculation of SBS mutation error probability. 
+			#Exclude SBS/mismatch-ss row if it was only added to bam.gr.filtertrack.bytype for downstream calculation of SBS mutation error probability.
 			semi_join(
 				call_types_toanalyze,
 				by = join_by(call_type, call_class, SBSindel_call_type, filtergroup)

--- a/bin/installBSgenome.R
+++ b/bin/installBSgenome.R
@@ -10,9 +10,17 @@ cat("#### Running installBSgenome ####\n")
 ######################
 suppressPackageStartupMessages(library(optparse))
 suppressPackageStartupMessages(library(BSgenome))
+suppressPackageStartupMessages(library(BSgenomeForge))
 suppressPackageStartupMessages(library(configr))
+suppressPackageStartupMessages(library(devtools))
 suppressPackageStartupMessages(library(qs2))
 suppressPackageStartupMessages(library(tidyverse))
+suppressPackageStartupMessages(library(withr))
+
+######################
+### Load custom shared functions
+######################
+source(Sys.which("sharedFunctions.R"))
 
 ######################
 ### Load configuration
@@ -37,6 +45,8 @@ if(is.null(opt$config)){
 yaml.config <- suppressWarnings(read.config(opt$config))
 
 cache_dir <- yaml.config$cache_dir
+BSgenome_name <- get_bsgenome_name(yaml.config)
+writeLines(BSgenome_name, "BSgenome_name.txt")
 
 cat("DONE\n")
 
@@ -48,19 +58,73 @@ cat("## Installing BSgenome reference...")
 #Configure cache dir as the path for the BSgenome installation
 dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)
 
-.libPaths(cache_dir)
+.libPaths(c(cache_dir, .libPaths()))
 
-#Check if BSgenome_name is already installed or available to be installed in Bioconductor, and if not, install the genome from BSgenome_file
-if(!yaml.config$BSgenome$BSgenome_name %in% installed.genomes()){
-	if(yaml.config$BSgenome$BSgenome_name %in% available.genomes() %>% suppressMessages){
-		BiocManager::install(yaml.config$BSgenome$BSgenome_name, lib = cache_dir)
-	}else if(!is.null(yaml.config$BSgenome$BSgenome_file)){
-		install.packages(yaml.config$BSgenome$BSgenome_file, repos = NULL, lib = cache_dir)
+#Check only the configured cache. Downstream scripts load the forged package from cache_dir.
+if(length(find.package(BSgenome_name, lib.loc=cache_dir, quiet=TRUE)) == 0){
+	cat("\n")
+	cat("> BSgenome package not found in cache:", BSgenome_name, "\n")
+	cat("> Forging BSgenome package from:", yaml.config$genome_fasta, "\n")
+
+	genome_fasta_basename <- basename(yaml.config$genome_fasta)
+	genome_part <- genome_fasta_basename %>%
+		gsub(pattern = "[^0-9a-zA-Z.]", replacement = "", x = .)
+
+	circular_chromosomes <- yaml.config$circular_chromosomes
+	if(is.null(circular_chromosomes)){
+		circular_chromosomes <- character(0)
 	}else{
-		stop("ERROR: Must specify either BSgenome_name that is in available.genomes() or a BSgenome_file!", call.=FALSE)
+		circular_chromosomes <- circular_chromosomes %>%
+			unlist(use.names=FALSE) %>%
+			as.character %>%
+			paste(collapse=",") %>%
+			str_split_1(",") %>%
+			str_trim
+		circular_chromosomes <- circular_chromosomes[nzchar(circular_chromosomes)]
 	}
-	
+
+	twobit_path <- tempfile(tmpdir=getwd(), pattern=str_c(genome_part, "."), fileext=".2bit")
+	BSgenomeForge::fastaTo2bit(
+		origfile = yaml.config$genome_fasta,
+		destfile = twobit_path
+	)
+
+	pkg_dir <- BSgenomeForge::forgeBSgenomeDataPkgFromTwobitFile(
+		filepath = twobit_path,
+		organism = yaml.config$genome_organism,
+		provider = "user",
+		genome = genome_fasta_basename,
+		# BSgenomeForge requires the Maintainer field to include an email address.
+		pkg_maintainer = "HiDEF-seq <hidef-seq@example.invalid>",
+		pkg_author = "HiDEF-seq",
+		circ_seqs = circular_chromosomes,
+		destdir = getwd()
+	)
+
+	if(basename(pkg_dir) != BSgenome_name){
+		stop(str_c(
+			"ERROR: Forged BSgenome package name did not match derived package name. Expected ",
+			BSgenome_name,
+			" but got ",
+			basename(pkg_dir),
+			"."
+		), call.=FALSE)
+	}
+
+	pkg_tarball <- devtools::build(pkg_dir, path=getwd(), vignettes=FALSE, manual=FALSE, quiet=FALSE)
+	devtools::check_built(pkg_tarball, cran=FALSE, force_suggests=FALSE, manual=FALSE, error_on="error", quiet=FALSE)
+
+	withr::with_libpaths(cache_dir, action="prefix", {
+		devtools::install_local(pkg_tarball, dependencies=FALSE, upgrade="never", build=FALSE, quiet=FALSE)
+	})
+
+	if(length(find.package(BSgenome_name, lib.loc=cache_dir, quiet=TRUE)) == 0){
+		stop(str_c("ERROR: ", BSgenome_name, " was not installed into cache_dir: ", cache_dir), call.=FALSE)
+	}
+
+	suppressPackageStartupMessages(library(BSgenome_name, character.only=TRUE, lib.loc=cache_dir))
+
 	cat("DONE\n")
 }else{
-  cat("Previously installed\n")
+	cat("Previously installed\n")
 }

--- a/bin/installBSgenome.R
+++ b/bin/installBSgenome.R
@@ -15,7 +15,6 @@ suppressPackageStartupMessages(library(configr))
 suppressPackageStartupMessages(library(devtools))
 suppressPackageStartupMessages(library(qs2))
 suppressPackageStartupMessages(library(tidyverse))
-suppressPackageStartupMessages(library(withr))
 
 ######################
 ### Load custom shared functions
@@ -58,7 +57,7 @@ cat("## Installing BSgenome reference...")
 #Configure cache dir as the path for the BSgenome installation
 dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)
 
-.libPaths(c(cache_dir, .libPaths()))
+.libPaths(cache_dir)
 
 #Check only the configured cache. Downstream scripts load the forged package from cache_dir.
 if(length(find.package(BSgenome_name, lib.loc=cache_dir, quiet=TRUE)) == 0){
@@ -68,19 +67,15 @@ if(length(find.package(BSgenome_name, lib.loc=cache_dir, quiet=TRUE)) == 0){
 
 	genome_fasta_basename <- basename(yaml.config$genome_fasta)
 	genome_part <- genome_fasta_basename %>%
-		gsub(pattern = "[^0-9a-zA-Z.]", replacement = "", x = .)
+		str_replace_all(pattern = "[^0-9a-zA-Z.]", replacement = "")
 
 	circular_chromosomes <- yaml.config$circular_chromosomes
 	if(is.null(circular_chromosomes)){
 		circular_chromosomes <- character(0)
 	}else{
 		circular_chromosomes <- circular_chromosomes %>%
-			unlist(use.names=FALSE) %>%
-			as.character %>%
-			paste(collapse=",") %>%
 			str_split_1(",") %>%
 			str_trim
-		circular_chromosomes <- circular_chromosomes[nzchar(circular_chromosomes)]
 	}
 
 	twobit_path <- tempfile(tmpdir=getwd(), pattern=str_c(genome_part, "."), fileext=".2bit")
@@ -94,11 +89,9 @@ if(length(find.package(BSgenome_name, lib.loc=cache_dir, quiet=TRUE)) == 0){
 		organism = yaml.config$genome_organism,
 		provider = "user",
 		genome = genome_fasta_basename,
-		# BSgenomeForge requires the Maintainer field to include an email address.
 		pkg_maintainer = "HiDEF-seq <hidef-seq@example.invalid>",
 		pkg_author = "HiDEF-seq",
-		circ_seqs = circular_chromosomes,
-		destdir = getwd()
+		circ_seqs = circular_chromosomes
 	)
 
 	if(basename(pkg_dir) != BSgenome_name){
@@ -114,17 +107,13 @@ if(length(find.package(BSgenome_name, lib.loc=cache_dir, quiet=TRUE)) == 0){
 	pkg_tarball <- devtools::build(pkg_dir, path=getwd(), vignettes=FALSE, manual=FALSE, quiet=FALSE)
 	devtools::check_built(pkg_tarball, cran=FALSE, force_suggests=FALSE, manual=FALSE, error_on="error", quiet=FALSE)
 
-	withr::with_libpaths(cache_dir, action="prefix", {
-		devtools::install_local(pkg_tarball, dependencies=FALSE, upgrade="never", build=FALSE, quiet=FALSE)
-	})
+	devtools::install_local(pkg_tarball, dependencies=FALSE, upgrade="never", build=FALSE, quiet=FALSE)
 
 	if(length(find.package(BSgenome_name, lib.loc=cache_dir, quiet=TRUE)) == 0){
 		stop(str_c("ERROR: ", BSgenome_name, " was not installed into cache_dir: ", cache_dir), call.=FALSE)
 	}
 
-	suppressPackageStartupMessages(library(BSgenome_name, character.only=TRUE, lib.loc=cache_dir))
-
 	cat("DONE\n")
 }else{
-	cat("Previously installed\n")
+  cat("Previously installed\n")
 }

--- a/bin/installBSgenome.R
+++ b/bin/installBSgenome.R
@@ -79,10 +79,13 @@ if(length(find.package(BSgenome_name, lib.loc=cache_dir, quiet=TRUE)) == 0){
 	}
 
 	twobit_path <- tempfile(tmpdir=getwd(), pattern=str_c(genome_part, "."), fileext=".2bit")
+	# Allow fastaTo2bit to warn, rather than stop, when it replaces unsupported bases with N's.
+	options(warn=1)
 	BSgenomeForge::fastaTo2bit(
 		origfile = yaml.config$genome_fasta,
 		destfile = twobit_path
 	)
+	options(warn=2)
 
 	pkg_dir <- BSgenomeForge::forgeBSgenomeDataPkgFromTwobitFile(
 		filepath = twobit_path,

--- a/bin/installBSgenome.R
+++ b/bin/installBSgenome.R
@@ -107,9 +107,12 @@ if(length(find.package(BSgenome_name, lib.loc=cache_dir, quiet=TRUE)) == 0){
 		), call.=FALSE)
 	}
 
+	cat("> Building BSgenome package\n")
 	pkg_tarball <- devtools::build(pkg_dir, path=getwd(), vignettes=FALSE, manual=FALSE, quiet=FALSE)
+	cat("> Checking BSgenome package\n")
 	devtools::check_built(pkg_tarball, cran=FALSE, force_suggests=FALSE, manual=FALSE, error_on="error", quiet=FALSE)
 
+	cat("> Installing BSgenome package:", cache_dir, "\n")
 	devtools::install_local(pkg_tarball, dependencies=FALSE, upgrade="never", build=FALSE, quiet=FALSE)
 
 	if(length(find.package(BSgenome_name, lib.loc=cache_dir, quiet=TRUE)) == 0){

--- a/bin/outputResults.R
+++ b/bin/outputResults.R
@@ -119,10 +119,10 @@ cat(" DONE\n")
 ######################
 #Function to write vcf from finalCalls/germlineCalls
 write_vcf_from_calls <- function(calls, BSgenome_name, out_vcf){
-
+	
 	#Repair names in 'calls' so they are compatible with DataFrame objects required by VariantAnnotation (i.e. change '-' to '.' in column names)
 	names(calls) <- names(calls) %>% vctrs::vec_as_names(repair = "universal", quiet = TRUE)
-
+	
 	#Fixed fields
 	CHROM <- calls$seqnames
 	POS <- calls$start_refspace
@@ -130,7 +130,7 @@ write_vcf_from_calls <- function(calls, BSgenome_name, out_vcf){
 	ALT <- calls$alt_plus_strand %>% DNAStringSet
 	QUAL <- rep(NA_real_, nrow(calls))
 	FILTER <- rep("PASS", nrow(calls))
-
+	
 	# Row ranges
 	if(nrow(calls)>0){
 		calls.gr <- GRanges(
@@ -142,20 +142,20 @@ write_vcf_from_calls <- function(calls, BSgenome_name, out_vcf){
 	}else{
 		calls.gr <- GRanges(seqinfo = BSgenome_name %>% get %>% seqinfo)
 	}
-
+	
 	fixed <- DataFrame(REF = REF, ALT = ALT, QUAL = QUAL, FILTER = FILTER)
-
+	
 	# INFO: everything except the basic VCF columns
 	info_cols <- names(calls) %>%
 		setdiff(c("seqnames","start_refspace","ref_plus_strand","alt_plus_strand"))
-
+	
 	#Convert factor columns to character
 	info_df <- calls %>%
 		select(all_of(info_cols)) %>%
 		mutate(across(where(is.factor), as.character)) %>%
 		as.data.frame %>%
 		DataFrame
-
+	
 	#Sort by seqnames, start, end
 	calls.order <- order(
 		calls.gr %>% seqnames %>% as.integer,
@@ -165,33 +165,33 @@ write_vcf_from_calls <- function(calls, BSgenome_name, out_vcf){
 	calls.gr <- calls.gr[calls.order]
 	fixed <- fixed[calls.order, , drop=FALSE]
 	info_df <- info_df[calls.order, , drop=FALSE]
-
+	
 	#INFO header
 	number_map <- function(x){
 		if(is.logical(x)){0L}else{1L}
 	}
-
+	
 	type_map <- function(x){
 		if(is.logical(x)){return("Flag")}
 		if(is.integer(x)){return("Integer")}
 		if(is.double(x)){return("Float")}
 		"String"
 	}
-
+	
 	info_header <- DataFrame(
 		Number = vapply(info_df, number_map, integer(1)),
 		Type = vapply(info_df, type_map, character(1)),
 		Description = info_cols,
 		row.names = info_cols
 	)
-
+	
 	# Build header (fileformat/source/reference/contigs via Seqinfo)
 	hdr <- VariantAnnotation::VCFHeader()
 	info(hdr) <- info_header
 	meta(hdr)$fileformat <- DataFrame(Value = "VCFv4.3", row.names = "fileformat")
 	meta(hdr)$source <- DataFrame(Value = "HiDEF-seq", row.names = "source")
 	meta(hdr)$reference <- DataFrame(Value = BSgenome_name, row.names = "reference")
-
+	
 	vcf <- VariantAnnotation::VCF(
 		rowRanges = calls.gr,
 		fixed = fixed,
@@ -199,7 +199,7 @@ write_vcf_from_calls <- function(calls, BSgenome_name, out_vcf){
 		collapsed = FALSE
 	)
 	header(vcf) <- hdr
-
+	
 	VariantAnnotation::writeVcf(vcf, filename = out_vcf, index = TRUE)
 }
 
@@ -226,31 +226,31 @@ estimatedSBSMutationErrorProbability <- list()
 
 #Loop over all calculateBurdens
 for(i in seq_along(calculateBurdensFiles)){
-
+	
 	#Load calculateBurdensFile
 	calculateBurdensFile <- qs_read(calculateBurdensFiles[i])
-
+	
 	#Annotations to add to tables
 	sample_annotations <- list(
 		analysis_id = analysis_id %>% factor,
 		individual_id = individual_id %>% factor,
 		sample_id = sample_id_toanalyze %>% factor
 	)
-
+	
 	chromgroup_filtergroup_annotations <- list(
 		chromgroup = calculateBurdensFile$chromgroup %>%
 			factor(levels = chromgroups),
 		filtergroup = calculateBurdensFile$filtergroup %>%
 			factor(levels = filtergroups)
 	)
-
+	
 	cat(" > chromgroup:", calculateBurdensFile$chromgroup, "/", "filtergroup:", calculateBurdensFile$filtergroup, "\n")
-
+	
 	#Run metadata
 	run_metadata[[i]] <- calculateBurdensFile %>%
 		pluck("run_metadata") %>%
 		mutate(!!!sample_annotations, .before = 1)
-
+	
 	#Filtering stats
 	molecule_stats.by_run_id[[i]] <- calculateBurdensFile %>%
 		pluck("molecule_stats.by_run_id") %>%
@@ -261,7 +261,7 @@ for(i in seq_along(calculateBurdensFiles)){
 			.before = 1
 		) %>%
 		relocate(run_id, .after = filtergroup)
-
+	
 	molecule_stats.by_analysis_id[[i]] <- calculateBurdensFile %>%
 		pluck("molecule_stats.by_analysis_id") %>%
 		mutate(
@@ -270,7 +270,7 @@ for(i in seq_along(calculateBurdensFiles)){
 			filtergroup = filtergroup %>% factor(levels = filtergroups),
 			.before = 1
 		)
-
+	
 	region_genome_filter_stats[[i]] <- calculateBurdensFile %>%
 		pluck("region_genome_filter_stats") %>%
 		mutate(
@@ -278,7 +278,7 @@ for(i in seq_along(calculateBurdensFiles)){
 			!!!chromgroup_filtergroup_annotations,
 			.before = 1
 		)
-
+	
 	#Final calls
 	finalCalls[[i]] <- calculateBurdensFile %>%
 		pluck("finalCalls") %>%
@@ -287,7 +287,7 @@ for(i in seq_along(calculateBurdensFiles)){
 			!!!chromgroup_filtergroup_annotations,
 			.before = 1
 		)
-
+	
 	#finalCalls for tsv and vcf output
 	finalCalls.bytype[[i]] <- calculateBurdensFile %>%
 		pluck("finalCalls.bytype") %>%
@@ -298,7 +298,7 @@ for(i in seq_along(calculateBurdensFiles)){
 			.before = 1
 		) %>%
 		relocate(filtergroup, call_class, .after = chromgroup)
-
+	
 	#Germline variant calls
 	germlineVariantCalls[[i]] <- calculateBurdensFile %>%
 		pluck("germlineVariantCalls") %>%
@@ -307,7 +307,7 @@ for(i in seq_along(calculateBurdensFiles)){
 			!!!chromgroup_filtergroup_annotations,
 			.before = 1
 		)
-
+	
 	#Trinucleotide context counts and fractions of finalCalls
 	finalCalls.reftnc_spectra[[i]] <- calculateBurdensFile %>%
 		pluck("finalCalls.reftnc_spectra") %>%
@@ -318,7 +318,7 @@ for(i in seq_along(calculateBurdensFiles)){
 			.before = 1
 		) %>%
 		relocate(filtergroup, call_class, .after = chromgroup)
-
+	
 	#Genome coverage and trinucleotide counts, fractions, and ratio to genome
 	bam.gr.filtertrack.bytype.coverage_tnc[[i]] <- calculateBurdensFile %>%
 		pluck("bam.gr.filtertrack.bytype.coverage_tnc") %>%
@@ -329,13 +329,13 @@ for(i in seq_along(calculateBurdensFiles)){
 			.before = 1
 		) %>%
 		relocate(filtergroup, call_class, .after = chromgroup)
-
+	
 	#Whole genome trinucleotide counts and fractions
 	genome.reftnc[[i]] <- calculateBurdensFile %>%
 		pluck("genome.reftnc") %>%
 		enframe %>%
 		pivot_wider(names_from = name, values_from = value)
-
+	
 	#Genome chromgroup trinucleotide counts and fractions
 		genome_chromgroup.reftnc[[i]] <- calculateBurdensFile %>%
 			pluck("genome_chromgroup.reftnc") %>%
@@ -369,7 +369,7 @@ for(i in seq_along(calculateBurdensFiles)){
 			.before = 1
 		) %>%
 		relocate(filtergroup, call_class, .after = chromgroup)
-
+		
 	#estimated SBS mutation error probability
 	if(! calculateBurdensFile %>% pluck("estimatedSBSMutationErrorProbability") %>% is.null){
 		estimatedSBSMutationErrorProbability[[i]] <- calculateBurdensFile %>%
@@ -383,7 +383,7 @@ for(i in seq_along(calculateBurdensFiles)){
 				.before = 1
 			)
 	}
-
+	
 	#Remove temporary objects
 	rm(calculateBurdensFile)
 	invisible(gc())
@@ -445,9 +445,9 @@ germlineVariantCalls <- germlineVariantCalls %>%
 		start_refspace = start,
 		end_refspace = end
 	)
-
+	
 finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>% bind_rows
-
+	
 bam.gr.filtertrack.bytype.coverage_tnc <- bam.gr.filtertrack.bytype.coverage_tnc %>% bind_rows
 
 genome.reftnc <- genome.reftnc %>%
@@ -486,9 +486,9 @@ cat("## Outputting filtering statistics...")
 
 for(i in chromgroups){
 	for(j in filtergroups){
-
+		
 		output_basename_full <- str_c(str_c(filterStats_dir,i,"/",output_basename), i, j, sep=".")
-
+		
 		#molecule_stats.by_run_id
 		 #Outupt all_chroms and all_chromgroups stats to each output file
 		molecule_stats.by_run_id %>%
@@ -497,7 +497,7 @@ for(i in chromgroups){
 					(chromgroup == i & (filtergroup == j | is.na(filtergroup)))
 				) %>%
 			write_tsv(str_c(output_basename_full,".molecule_stats.by_run_id.tsv"))
-
+		
 		#molecule_stats.by_analysis_id
 		molecule_stats.by_analysis_id %>%
 			filter(
@@ -505,7 +505,7 @@ for(i in chromgroups){
 					(chromgroup == i & (filtergroup == j | is.na(filtergroup)))
 			) %>%
 			write_tsv(str_c(output_basename_full,".molecule_stats.by_analysis_id.tsv"))
-
+		
 		#region_genome_filter_stats
 		region_genome_filter_stats %>%
 			filter(chromgroup == i & filtergroup == j) %>%
@@ -529,7 +529,7 @@ finalCalls.bytype %>%
 	pwalk(
 		function(...){
 			x <- list(...)
-
+			
 			output_basename_full <- str_c(
 				str_c(finalCalls_dir,x$chromgroup,"/",output_basename),
 				x$chromgroup,
@@ -539,7 +539,7 @@ finalCalls.bytype %>%
 				x$SBSindel_call_type,
 				sep="."
 			)
-
+			
 			metadata <- x %>%
 				keep(
 					names(.) %in%
@@ -550,13 +550,13 @@ finalCalls.bytype %>%
 						)
 				) %>%
 				as_tibble
-
+			
 			#all calls tsv
 			metadata %>%
 				mutate(finalCalls_for_tsv = list(x$finalCalls_for_tsv)) %>%
 				unnest(finalCalls_for_tsv) %>%
 				write_tsv(str_c(output_basename_full,".finalCalls.tsv"))
-
+			
 			#unique calls tsv
 			if(!is.null(x$finalCalls_unique_for_tsv)){
 				metadata %>%
@@ -564,7 +564,7 @@ finalCalls.bytype %>%
 					unnest(finalCalls_unique_for_tsv) %>%
 					write_tsv(str_c(output_basename_full,".finalCalls_unique.tsv"))
 			}
-
+			
 			#all calls vcf
 			metadata %>%
 				mutate(finalCalls_for_vcf = list(x$finalCalls_for_vcf)) %>%
@@ -573,7 +573,7 @@ finalCalls.bytype %>%
 					BSgenome_name = BSgenome_name,
 					out_vcf = str_c(output_basename_full,".finalCalls.vcf")
 				)
-
+			
 			#unique calls vcf
 			if(!is.null(x$finalCalls_unique_for_vcf)){
 				metadata %>%
@@ -631,7 +631,7 @@ for(i in chromgroups){
 
 		#Output path
 		output_basename_full <- str_c(str_c(germlineVariantCalls_dir,i,"/",output_basename),i,j,sep=".")
-
+		
 		#Define germline filter columns to keep in the output
 		region_read_filters_cols_keep <- yaml.config$region_filters %>%
 			map("read_filters") %>%
@@ -647,7 +647,7 @@ for(i in chromgroups){
 			pull(region_filter_threshold_file) %>%
 			basename %>%
 			str_c("region_read_filter_",.,".passfilter")
-
+		
 		region_genome_filters_cols_keep <- yaml.config$region_filters %>%
 			map("genome_filters") %>%
 			flatten %>%
@@ -662,21 +662,21 @@ for(i in chromgroups){
 			pull(region_filter_threshold_file) %>%
 			basename %>%
 			str_c("region_genome_filter_",.,".passfilter")
-
+		
 		germline_filter_cols_keep <- c( #not including germline_vcf.passfilter, since FALSE for all calls, and not including germline_vcf_indel_region_filter, max_germlineBAM_VariantReads.passfilter, max_germlineBAM_VAF.passfilter, since these are not relevant annotation to output for germline calls themselves (only relevant for somatic calls that are filtered based on germline calls).
 			region_read_filters_cols_keep,
 			region_genome_filters_cols_keep,
 			"germline_vcf_types_detected", "germline_vcf_files_detected"
 		)
-
+		
 		#Create and format output tibble
 		germlineVariantCalls.out <- germlineVariantCalls %>%
 			#Remove all passfilter columns (since all true) except germline filter columns
 			select(-(contains("passfilter") & !all_of(germline_filter_cols_keep))) %>%
-
+			
 			#Select current chromgroup/filtergroup
 			filter(chromgroup == i, filtergroup == j) %>%
-
+			
 			#Reformat list columns to be comma-delimited
 			mutate(
 				across(
@@ -684,7 +684,7 @@ for(i in chromgroups){
 					function(x){x %>% map_chr(function(v){str_c(v, collapse = ",")})}
 				)
 			) %>%
-
+			
 			#Change strand levels so that new column names after pivot_wider have suffixes ref_strand_(plus/minus)_read instead of +/-.
 			mutate(
 				refstrand = refstrand %>%
@@ -693,7 +693,7 @@ for(i in chromgroups){
 						refstrand_minus_read = "-"
 					)
 			) %>%
-
+			
 			#Collapse to one row per mutation
       pivot_wider(
 	      id_cols = all_of(c(strand_identical_cols_keep, germline_filter_cols_keep)),
@@ -702,11 +702,11 @@ for(i in chromgroups){
 	      names_glue = "{.value}_{refstrand}",
 	      names_expand = TRUE
 			)
-
+		
 		#tsv
 		germlineVariantCalls.out %>%
 			write_tsv(str_c(output_basename_full,".germlineVariantCalls.tsv"))
-
+		
 		#vcf
 		germlineVariantCalls.out %>%
 			#Rename back columns for normalize_indels_for_vcf
@@ -723,10 +723,10 @@ for(i in chromgroups){
 				BSgenome_name = BSgenome_name,
 				out_vcf = str_c(output_basename_full,".germlineVariantCalls.vcf")
 			)
-
+		
 		rm(germlineVariantCalls.out)
 		invisible(gc())
-
+		
 	}
 }
 
@@ -751,7 +751,7 @@ finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>%
 				finalCalls.refindel_spectrum.sigfit,
 				finalCalls_unique.refindel_spectrum.sigfit
 			) %>%
-
+			
 			#Sum insertion and deletion matrices (not grouping by call_type)
 			group_by(analysis_id, individual_id, sample_id, chromgroup, call_class, SBSindel_call_type) %>%
 			summarize(
@@ -768,7 +768,7 @@ finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>%
 							list
 					}
 				),
-
+				
 				#Sigfit matrices, and rename rownames
 				across(
 					c(finalCalls.refindel_spectrum.sigfit, finalCalls_unique.refindel_spectrum.sigfit),
@@ -784,7 +784,7 @@ finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>%
 							)
 					}
 				),
-
+				
 				.groups = "drop"
 			)
 	)
@@ -801,15 +801,15 @@ write_col <- function(df.input, col_name.input, metadata.input, output_basename_
 plot_col <- function(df.input, col_name.input, output_basename_full.input){
 	#Output name
 	output_name <- str_c(output_basename_full.input, ".", col_name.input)
-
+	
 	#Count number of calls
 	sum_counts <- sum(df.input)
-
+	
 	#Normalize to number of calls
 	if(sum_counts > 0){
 		df.input <- df.input / sum(df.input)
 	}
-
+	
 	df.input %>%
 		plot_spectrum(
 			pdf_path = str_c(output_name, ".pdf"),
@@ -823,7 +823,7 @@ finalCalls.reftnc_spectra %>%
 	pwalk(
 		function(...){
 			x <- list(...)
-
+			
 			output_basename_full <- str_c(
 				c(
 					str_c(finalCalls.spectra_dir,x$chromgroup,"/",output_basename),
@@ -836,7 +836,7 @@ finalCalls.reftnc_spectra %>%
 					discard(is.na), #Needed because filtergroup and call_type are NA for rows of combined insertion + deletion spectra
 				collapse="."
 			)
-
+			
 			metadata <- x %>%
 				keep(
 					names(.) %in%
@@ -847,7 +847,7 @@ finalCalls.reftnc_spectra %>%
 						)
 				) %>%
 				as_tibble
-
+			
 			sbs_tables_to_output <- c(
 				"finalCalls.reftnc_pyr",
 				"finalCalls_unique.reftnc_pyr",
@@ -856,12 +856,12 @@ finalCalls.reftnc_spectra %>%
 				"finalCalls_unique.reftnc_pyr_spectrum",
 				"finalCalls.reftnc_template_strand_spectrum"
 			)
-
+			
 			indel_tables_to_output <- c(
 				"finalCalls.refindel_spectrum.sigfit",
 				"finalCalls_unique.refindel_spectrum.sigfit"
 			)
-
+			
 			plots_to_output <- c(
 				"finalCalls.reftnc_pyr_spectrum.sigfit",
 				"finalCalls.reftnc_pyr_spectrum.corrected_to_genome.sigfit",
@@ -875,7 +875,7 @@ finalCalls.reftnc_spectra %>%
 				"finalCalls.refindel_spectrum.sigfit",
 				"finalCalls_unique.refindel_spectrum.sigfit"
 			)
-
+			
 			sbs_tables_to_output %>%
 				walk(function(y){
 					if(!is.null(x[[y]])){
@@ -885,7 +885,7 @@ finalCalls.reftnc_spectra %>%
 						)
 					}
 				})
-
+			
 			indel_tables_to_output %>%
 				walk(function(y){
 					if(!is.null(x[[y]])){
@@ -898,7 +898,7 @@ finalCalls.reftnc_spectra %>%
 						)
 					}
 				})
-
+			
 			plots_to_output %>%
 				walk(function(y){
 					if(!is.null(x[[y]])){
@@ -908,7 +908,7 @@ finalCalls.reftnc_spectra %>%
 						)
 					}
 				})
-
+			
 		}
 	)
 
@@ -917,7 +917,7 @@ bam.gr.filtertrack.bytype.coverage_tnc %>%
 	pwalk(
 		function(...){
 			x <- list(...)
-
+			
 			output_basename_full <- str_c(
 				str_c(interrogatedBases.spectra_dir,x$chromgroup,"/",output_basename),
 				x$chromgroup,
@@ -927,7 +927,7 @@ bam.gr.filtertrack.bytype.coverage_tnc %>%
 				x$SBSindel_call_type,
 				sep="."
 			)
-
+			
 			metadata <- x %>%
 				keep(
 					names(.) %in%
@@ -938,12 +938,12 @@ bam.gr.filtertrack.bytype.coverage_tnc %>%
 						)
 				) %>%
 				as_tibble
-
+			
 			sbs_tables_to_output <- c(
 				"bam.gr.filtertrack.reftnc_pyr",
 				"bam.gr.filtertrack.reftnc_both_strands"
 			)
-
+			
 			sbs_tables_to_output %>%
 				walk(function(y){
 					write_col(
@@ -951,7 +951,7 @@ bam.gr.filtertrack.bytype.coverage_tnc %>%
 						col_name.input = y, metadata.input = metadata, output_basename_full.input = output_basename_full
 					)
 				})
-
+			
 		}
 	)
 
@@ -961,18 +961,18 @@ for(i in chromgroups){
 		select(reftnc_pyr) %>%
 		unnest(reftnc_pyr) %>%
 		write_tsv(str_c(genome.spectra_dir,i,"/","genome.reftnc_pyr.tsv"))
-
+	
 	genome_chromgroup.reftnc %>%
 		filter(chromgroup == i) %>%
 		select(chromgroup, reftnc_pyr) %>%
 		unnest(reftnc_pyr) %>%
 		write_tsv(str_c(genome.spectra_dir,i,"/",i,".genome_chromgroup.reftnc_pyr.tsv"))
-
+		
 	genome.reftnc %>%
 		select(reftnc_both_strands) %>%
 		unnest(reftnc_both_strands) %>%
 		write_tsv(str_c(genome.spectra_dir,i,"/","genome.reftnc_both_strands.tsv"))
-
+	
 	genome_chromgroup.reftnc %>%
 		filter(chromgroup == i) %>%
 		select(chromgroup, reftnc_both_strands) %>%
@@ -996,17 +996,17 @@ sensitivity <- sensitivity %>%
 			first(sensitivity[sensitivity_source == "calculated"], default = NA),
 			sensitivity
 		),
-
+		
 		sensitivity_source = case_when(
 			sensitivity_source == "other_chromgroup" & is.na(sensitivity.new) ~ "default_other_chromgroup",
 			sensitivity_source == "other_chromgroup" & !is.na(sensitivity.new) ~ "calculated_other_chromgroup",
 			.default = sensitivity_source
 		),
-
+		
 		sensitivity = sensitivity.new %>% replace_na(1)
 	) %>%
 	relocate(sensitivity, sensitivity_source, .after = last_col()) %>%
-	ungroup %>%
+	ungroup %>% 
 	select(-sensitivity.new)
 
 #Output as tsv
@@ -1015,7 +1015,7 @@ sensitivity %>%
 	pwalk(
 		function(...){
 			x <- list(...)
-
+			
 			output_basename_full <- str_c(
 				str_c(sensitivity_dir, x$chromgroup, "/", output_basename),
 				x$chromgroup,
@@ -1025,9 +1025,9 @@ sensitivity %>%
 				x$SBSindel_call_type,
 				sep="."
 			)
-
+			
 			x$data %>% write_tsv(str_c(output_basename_full, ".sensitivity.tsv"))
-
+			
 		}
 	)
 
@@ -1081,7 +1081,7 @@ finalCalls.burdens %>%
 	pwalk(
 		function(...){
 			x <- list(...)
-
+			
 			output_basename_full <- str_c(
 				str_c(finalCalls.burdens_dir, x$chromgroup, "/", output_basename),
 				x$chromgroup,
@@ -1091,9 +1091,9 @@ finalCalls.burdens %>%
 				x$SBSindel_call_type,
 				sep="."
 			)
-
+			
 			x$data %>% write_tsv(str_c(output_basename_full, ".finalCalls.burdens.tsv"))
-
+			
 		}
 	)
 
@@ -1109,7 +1109,7 @@ estimatedSBSMutationErrorProbability %>%
 	pwalk(
 		function(...){
 			x <- list(...)
-
+			
 			output_basename_full <- str_c(
 				str_c(estimatedSBSMutationErrorProbability_dir, x$chromgroup, "/", output_basename),
 				x$chromgroup,
@@ -1119,7 +1119,7 @@ estimatedSBSMutationErrorProbability %>%
 				x$SBSindel_call_type,
 				sep="."
 			)
-
+			
 			metadata <- x %>%
 				keep(
 					names(.) %in%
@@ -1129,13 +1129,13 @@ estimatedSBSMutationErrorProbability %>%
 						)
 				) %>%
 				as_tibble
-
+			
 			#by_channel_pyr error probability tsv
 			metadata %>%
 				mutate(by_channel_pyr = list(x$by_channel_pyr)) %>%
 				unnest(by_channel_pyr) %>%
 				write_tsv(str_c(output_basename_full, ".estimatedSBSMutationErrorProbability.by_channel_pyr.tsv"))
-
+			
 			#total error probability tsv
 			metadata %>%
 				mutate(

--- a/bin/outputResults.R
+++ b/bin/outputResults.R
@@ -22,6 +22,11 @@ suppressPackageStartupMessages(library(qs2))
 suppressPackageStartupMessages(library(tidyverse))
 
 ######################
+### Load custom shared functions
+######################
+source(Sys.which("sharedFunctions.R"))
+
+######################
 ### Load configuration
 ######################
 cat("## Loading configuration...\n")
@@ -51,9 +56,10 @@ yaml.config <- suppressWarnings(read.config(opt$config))
 sample_id_toanalyze <- opt$sample_id_toanalyze
 calculateBurdensFiles <- opt$files %>% str_split_1(",") %>% str_trim
 output_basename <- opt$output_basename
+BSgenome_name <- get_bsgenome_name(yaml.config)
 
 #Load the BSgenome reference
-suppressPackageStartupMessages(library(yaml.config$BSgenome$BSgenome_name,character.only=TRUE,lib.loc=yaml.config$cache_dir))
+suppressPackageStartupMessages(library(BSgenome_name,character.only=TRUE,lib.loc=yaml.config$cache_dir))
 
 #Load miscellaneous configuration parameters
  #analysis_id
@@ -109,19 +115,14 @@ cat("    sample_id:",sample_id_toanalyze,"\n")
 cat(" DONE\n")
 
 ######################
-### Load custom shared functions
-######################
-source(Sys.which("sharedFunctions.R"))
-
-######################
 ### Define custom functions
 ######################
 #Function to write vcf from finalCalls/germlineCalls
 write_vcf_from_calls <- function(calls, BSgenome_name, out_vcf){
-	
+
 	#Repair names in 'calls' so they are compatible with DataFrame objects required by VariantAnnotation (i.e. change '-' to '.' in column names)
 	names(calls) <- names(calls) %>% vctrs::vec_as_names(repair = "universal", quiet = TRUE)
-	
+
 	#Fixed fields
 	CHROM <- calls$seqnames
 	POS <- calls$start_refspace
@@ -129,7 +130,7 @@ write_vcf_from_calls <- function(calls, BSgenome_name, out_vcf){
 	ALT <- calls$alt_plus_strand %>% DNAStringSet
 	QUAL <- rep(NA_real_, nrow(calls))
 	FILTER <- rep("PASS", nrow(calls))
-	
+
 	# Row ranges
 	if(nrow(calls)>0){
 		calls.gr <- GRanges(
@@ -141,20 +142,20 @@ write_vcf_from_calls <- function(calls, BSgenome_name, out_vcf){
 	}else{
 		calls.gr <- GRanges(seqinfo = BSgenome_name %>% get %>% seqinfo)
 	}
-	
+
 	fixed <- DataFrame(REF = REF, ALT = ALT, QUAL = QUAL, FILTER = FILTER)
-	
+
 	# INFO: everything except the basic VCF columns
 	info_cols <- names(calls) %>%
 		setdiff(c("seqnames","start_refspace","ref_plus_strand","alt_plus_strand"))
-	
+
 	#Convert factor columns to character
 	info_df <- calls %>%
 		select(all_of(info_cols)) %>%
 		mutate(across(where(is.factor), as.character)) %>%
 		as.data.frame %>%
 		DataFrame
-	
+
 	#Sort by seqnames, start, end
 	calls.order <- order(
 		calls.gr %>% seqnames %>% as.integer,
@@ -164,33 +165,33 @@ write_vcf_from_calls <- function(calls, BSgenome_name, out_vcf){
 	calls.gr <- calls.gr[calls.order]
 	fixed <- fixed[calls.order, , drop=FALSE]
 	info_df <- info_df[calls.order, , drop=FALSE]
-	
+
 	#INFO header
 	number_map <- function(x){
 		if(is.logical(x)){0L}else{1L}
 	}
-	
+
 	type_map <- function(x){
 		if(is.logical(x)){return("Flag")}
 		if(is.integer(x)){return("Integer")}
 		if(is.double(x)){return("Float")}
 		"String"
 	}
-	
+
 	info_header <- DataFrame(
 		Number = vapply(info_df, number_map, integer(1)),
 		Type = vapply(info_df, type_map, character(1)),
 		Description = info_cols,
 		row.names = info_cols
 	)
-	
+
 	# Build header (fileformat/source/reference/contigs via Seqinfo)
 	hdr <- VariantAnnotation::VCFHeader()
 	info(hdr) <- info_header
 	meta(hdr)$fileformat <- DataFrame(Value = "VCFv4.3", row.names = "fileformat")
 	meta(hdr)$source <- DataFrame(Value = "HiDEF-seq", row.names = "source")
 	meta(hdr)$reference <- DataFrame(Value = BSgenome_name, row.names = "reference")
-	
+
 	vcf <- VariantAnnotation::VCF(
 		rowRanges = calls.gr,
 		fixed = fixed,
@@ -198,7 +199,7 @@ write_vcf_from_calls <- function(calls, BSgenome_name, out_vcf){
 		collapsed = FALSE
 	)
 	header(vcf) <- hdr
-	
+
 	VariantAnnotation::writeVcf(vcf, filename = out_vcf, index = TRUE)
 }
 
@@ -225,31 +226,31 @@ estimatedSBSMutationErrorProbability <- list()
 
 #Loop over all calculateBurdens
 for(i in seq_along(calculateBurdensFiles)){
-	
+
 	#Load calculateBurdensFile
 	calculateBurdensFile <- qs_read(calculateBurdensFiles[i])
-	
+
 	#Annotations to add to tables
 	sample_annotations <- list(
 		analysis_id = analysis_id %>% factor,
 		individual_id = individual_id %>% factor,
 		sample_id = sample_id_toanalyze %>% factor
 	)
-	
+
 	chromgroup_filtergroup_annotations <- list(
 		chromgroup = calculateBurdensFile$chromgroup %>%
 			factor(levels = chromgroups),
 		filtergroup = calculateBurdensFile$filtergroup %>%
 			factor(levels = filtergroups)
 	)
-	
+
 	cat(" > chromgroup:", calculateBurdensFile$chromgroup, "/", "filtergroup:", calculateBurdensFile$filtergroup, "\n")
-	
+
 	#Run metadata
 	run_metadata[[i]] <- calculateBurdensFile %>%
 		pluck("run_metadata") %>%
 		mutate(!!!sample_annotations, .before = 1)
-	
+
 	#Filtering stats
 	molecule_stats.by_run_id[[i]] <- calculateBurdensFile %>%
 		pluck("molecule_stats.by_run_id") %>%
@@ -260,7 +261,7 @@ for(i in seq_along(calculateBurdensFiles)){
 			.before = 1
 		) %>%
 		relocate(run_id, .after = filtergroup)
-	
+
 	molecule_stats.by_analysis_id[[i]] <- calculateBurdensFile %>%
 		pluck("molecule_stats.by_analysis_id") %>%
 		mutate(
@@ -269,7 +270,7 @@ for(i in seq_along(calculateBurdensFiles)){
 			filtergroup = filtergroup %>% factor(levels = filtergroups),
 			.before = 1
 		)
-	
+
 	region_genome_filter_stats[[i]] <- calculateBurdensFile %>%
 		pluck("region_genome_filter_stats") %>%
 		mutate(
@@ -277,7 +278,7 @@ for(i in seq_along(calculateBurdensFiles)){
 			!!!chromgroup_filtergroup_annotations,
 			.before = 1
 		)
-	
+
 	#Final calls
 	finalCalls[[i]] <- calculateBurdensFile %>%
 		pluck("finalCalls") %>%
@@ -286,7 +287,7 @@ for(i in seq_along(calculateBurdensFiles)){
 			!!!chromgroup_filtergroup_annotations,
 			.before = 1
 		)
-	
+
 	#finalCalls for tsv and vcf output
 	finalCalls.bytype[[i]] <- calculateBurdensFile %>%
 		pluck("finalCalls.bytype") %>%
@@ -297,7 +298,7 @@ for(i in seq_along(calculateBurdensFiles)){
 			.before = 1
 		) %>%
 		relocate(filtergroup, call_class, .after = chromgroup)
-	
+
 	#Germline variant calls
 	germlineVariantCalls[[i]] <- calculateBurdensFile %>%
 		pluck("germlineVariantCalls") %>%
@@ -306,7 +307,7 @@ for(i in seq_along(calculateBurdensFiles)){
 			!!!chromgroup_filtergroup_annotations,
 			.before = 1
 		)
-	
+
 	#Trinucleotide context counts and fractions of finalCalls
 	finalCalls.reftnc_spectra[[i]] <- calculateBurdensFile %>%
 		pluck("finalCalls.reftnc_spectra") %>%
@@ -317,7 +318,7 @@ for(i in seq_along(calculateBurdensFiles)){
 			.before = 1
 		) %>%
 		relocate(filtergroup, call_class, .after = chromgroup)
-	
+
 	#Genome coverage and trinucleotide counts, fractions, and ratio to genome
 	bam.gr.filtertrack.bytype.coverage_tnc[[i]] <- calculateBurdensFile %>%
 		pluck("bam.gr.filtertrack.bytype.coverage_tnc") %>%
@@ -328,13 +329,13 @@ for(i in seq_along(calculateBurdensFiles)){
 			.before = 1
 		) %>%
 		relocate(filtergroup, call_class, .after = chromgroup)
-	
+
 	#Whole genome trinucleotide counts and fractions
 	genome.reftnc[[i]] <- calculateBurdensFile %>%
 		pluck("genome.reftnc") %>%
 		enframe %>%
 		pivot_wider(names_from = name, values_from = value)
-	
+
 	#Genome chromgroup trinucleotide counts and fractions
 		genome_chromgroup.reftnc[[i]] <- calculateBurdensFile %>%
 			pluck("genome_chromgroup.reftnc") %>%
@@ -368,7 +369,7 @@ for(i in seq_along(calculateBurdensFiles)){
 			.before = 1
 		) %>%
 		relocate(filtergroup, call_class, .after = chromgroup)
-		
+
 	#estimated SBS mutation error probability
 	if(! calculateBurdensFile %>% pluck("estimatedSBSMutationErrorProbability") %>% is.null){
 		estimatedSBSMutationErrorProbability[[i]] <- calculateBurdensFile %>%
@@ -382,7 +383,7 @@ for(i in seq_along(calculateBurdensFiles)){
 				.before = 1
 			)
 	}
-	
+
 	#Remove temporary objects
 	rm(calculateBurdensFile)
 	invisible(gc())
@@ -444,9 +445,9 @@ germlineVariantCalls <- germlineVariantCalls %>%
 		start_refspace = start,
 		end_refspace = end
 	)
-	
+
 finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>% bind_rows
-	
+
 bam.gr.filtertrack.bytype.coverage_tnc <- bam.gr.filtertrack.bytype.coverage_tnc %>% bind_rows
 
 genome.reftnc <- genome.reftnc %>%
@@ -485,9 +486,9 @@ cat("## Outputting filtering statistics...")
 
 for(i in chromgroups){
 	for(j in filtergroups){
-		
+
 		output_basename_full <- str_c(str_c(filterStats_dir,i,"/",output_basename), i, j, sep=".")
-		
+
 		#molecule_stats.by_run_id
 		 #Outupt all_chroms and all_chromgroups stats to each output file
 		molecule_stats.by_run_id %>%
@@ -496,7 +497,7 @@ for(i in chromgroups){
 					(chromgroup == i & (filtergroup == j | is.na(filtergroup)))
 				) %>%
 			write_tsv(str_c(output_basename_full,".molecule_stats.by_run_id.tsv"))
-		
+
 		#molecule_stats.by_analysis_id
 		molecule_stats.by_analysis_id %>%
 			filter(
@@ -504,7 +505,7 @@ for(i in chromgroups){
 					(chromgroup == i & (filtergroup == j | is.na(filtergroup)))
 			) %>%
 			write_tsv(str_c(output_basename_full,".molecule_stats.by_analysis_id.tsv"))
-		
+
 		#region_genome_filter_stats
 		region_genome_filter_stats %>%
 			filter(chromgroup == i & filtergroup == j) %>%
@@ -528,7 +529,7 @@ finalCalls.bytype %>%
 	pwalk(
 		function(...){
 			x <- list(...)
-			
+
 			output_basename_full <- str_c(
 				str_c(finalCalls_dir,x$chromgroup,"/",output_basename),
 				x$chromgroup,
@@ -538,7 +539,7 @@ finalCalls.bytype %>%
 				x$SBSindel_call_type,
 				sep="."
 			)
-			
+
 			metadata <- x %>%
 				keep(
 					names(.) %in%
@@ -549,13 +550,13 @@ finalCalls.bytype %>%
 						)
 				) %>%
 				as_tibble
-			
+
 			#all calls tsv
 			metadata %>%
 				mutate(finalCalls_for_tsv = list(x$finalCalls_for_tsv)) %>%
 				unnest(finalCalls_for_tsv) %>%
 				write_tsv(str_c(output_basename_full,".finalCalls.tsv"))
-			
+
 			#unique calls tsv
 			if(!is.null(x$finalCalls_unique_for_tsv)){
 				metadata %>%
@@ -563,23 +564,23 @@ finalCalls.bytype %>%
 					unnest(finalCalls_unique_for_tsv) %>%
 					write_tsv(str_c(output_basename_full,".finalCalls_unique.tsv"))
 			}
-			
+
 			#all calls vcf
 			metadata %>%
 				mutate(finalCalls_for_vcf = list(x$finalCalls_for_vcf)) %>%
 				unnest(finalCalls_for_vcf) %>%
 				write_vcf_from_calls(
-					BSgenome_name = yaml.config$BSgenome$BSgenome_name,
+					BSgenome_name = BSgenome_name,
 					out_vcf = str_c(output_basename_full,".finalCalls.vcf")
 				)
-			
+
 			#unique calls vcf
 			if(!is.null(x$finalCalls_unique_for_vcf)){
 				metadata %>%
 					mutate(finalCalls_unique_for_vcf = list(x$finalCalls_unique_for_vcf)) %>%
 					unnest(finalCalls_unique_for_vcf) %>%
 					write_vcf_from_calls(
-						BSgenome_name = yaml.config$BSgenome$BSgenome_name,
+						BSgenome_name = BSgenome_name,
 						out_vcf = str_c(output_basename_full,".finalCalls_unique.vcf")
 					)
 			}
@@ -630,7 +631,7 @@ for(i in chromgroups){
 
 		#Output path
 		output_basename_full <- str_c(str_c(germlineVariantCalls_dir,i,"/",output_basename),i,j,sep=".")
-		
+
 		#Define germline filter columns to keep in the output
 		region_read_filters_cols_keep <- yaml.config$region_filters %>%
 			map("read_filters") %>%
@@ -646,7 +647,7 @@ for(i in chromgroups){
 			pull(region_filter_threshold_file) %>%
 			basename %>%
 			str_c("region_read_filter_",.,".passfilter")
-		
+
 		region_genome_filters_cols_keep <- yaml.config$region_filters %>%
 			map("genome_filters") %>%
 			flatten %>%
@@ -661,21 +662,21 @@ for(i in chromgroups){
 			pull(region_filter_threshold_file) %>%
 			basename %>%
 			str_c("region_genome_filter_",.,".passfilter")
-		
+
 		germline_filter_cols_keep <- c( #not including germline_vcf.passfilter, since FALSE for all calls, and not including germline_vcf_indel_region_filter, max_germlineBAM_VariantReads.passfilter, max_germlineBAM_VAF.passfilter, since these are not relevant annotation to output for germline calls themselves (only relevant for somatic calls that are filtered based on germline calls).
 			region_read_filters_cols_keep,
 			region_genome_filters_cols_keep,
 			"germline_vcf_types_detected", "germline_vcf_files_detected"
 		)
-		
+
 		#Create and format output tibble
 		germlineVariantCalls.out <- germlineVariantCalls %>%
 			#Remove all passfilter columns (since all true) except germline filter columns
 			select(-(contains("passfilter") & !all_of(germline_filter_cols_keep))) %>%
-			
+
 			#Select current chromgroup/filtergroup
 			filter(chromgroup == i, filtergroup == j) %>%
-			
+
 			#Reformat list columns to be comma-delimited
 			mutate(
 				across(
@@ -683,7 +684,7 @@ for(i in chromgroups){
 					function(x){x %>% map_chr(function(v){str_c(v, collapse = ",")})}
 				)
 			) %>%
-			
+
 			#Change strand levels so that new column names after pivot_wider have suffixes ref_strand_(plus/minus)_read instead of +/-.
 			mutate(
 				refstrand = refstrand %>%
@@ -692,7 +693,7 @@ for(i in chromgroups){
 						refstrand_minus_read = "-"
 					)
 			) %>%
-			
+
 			#Collapse to one row per mutation
       pivot_wider(
 	      id_cols = all_of(c(strand_identical_cols_keep, germline_filter_cols_keep)),
@@ -701,11 +702,11 @@ for(i in chromgroups){
 	      names_glue = "{.value}_{refstrand}",
 	      names_expand = TRUE
 			)
-		
+
 		#tsv
 		germlineVariantCalls.out %>%
 			write_tsv(str_c(output_basename_full,".germlineVariantCalls.tsv"))
-		
+
 		#vcf
 		germlineVariantCalls.out %>%
 			#Rename back columns for normalize_indels_for_vcf
@@ -714,18 +715,18 @@ for(i in chromgroups){
 				end = end_refspace
 			) %>%
 			normalize_indels_for_vcf(
-				BSgenome_name = yaml.config$BSgenome$BSgenome_name
+				BSgenome_name = BSgenome_name
 			) %>%
 			#Rename back columns for greater clarity in final output
 			rename(start_refspace = start) %>%
 			write_vcf_from_calls(
-				BSgenome_name = yaml.config$BSgenome$BSgenome_name,
+				BSgenome_name = BSgenome_name,
 				out_vcf = str_c(output_basename_full,".germlineVariantCalls.vcf")
 			)
-		
+
 		rm(germlineVariantCalls.out)
 		invisible(gc())
-		
+
 	}
 }
 
@@ -750,7 +751,7 @@ finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>%
 				finalCalls.refindel_spectrum.sigfit,
 				finalCalls_unique.refindel_spectrum.sigfit
 			) %>%
-			
+
 			#Sum insertion and deletion matrices (not grouping by call_type)
 			group_by(analysis_id, individual_id, sample_id, chromgroup, call_class, SBSindel_call_type) %>%
 			summarize(
@@ -767,7 +768,7 @@ finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>%
 							list
 					}
 				),
-				
+
 				#Sigfit matrices, and rename rownames
 				across(
 					c(finalCalls.refindel_spectrum.sigfit, finalCalls_unique.refindel_spectrum.sigfit),
@@ -783,7 +784,7 @@ finalCalls.reftnc_spectra <- finalCalls.reftnc_spectra %>%
 							)
 					}
 				),
-				
+
 				.groups = "drop"
 			)
 	)
@@ -800,15 +801,15 @@ write_col <- function(df.input, col_name.input, metadata.input, output_basename_
 plot_col <- function(df.input, col_name.input, output_basename_full.input){
 	#Output name
 	output_name <- str_c(output_basename_full.input, ".", col_name.input)
-	
+
 	#Count number of calls
 	sum_counts <- sum(df.input)
-	
+
 	#Normalize to number of calls
 	if(sum_counts > 0){
 		df.input <- df.input / sum(df.input)
 	}
-	
+
 	df.input %>%
 		plot_spectrum(
 			pdf_path = str_c(output_name, ".pdf"),
@@ -822,7 +823,7 @@ finalCalls.reftnc_spectra %>%
 	pwalk(
 		function(...){
 			x <- list(...)
-			
+
 			output_basename_full <- str_c(
 				c(
 					str_c(finalCalls.spectra_dir,x$chromgroup,"/",output_basename),
@@ -835,7 +836,7 @@ finalCalls.reftnc_spectra %>%
 					discard(is.na), #Needed because filtergroup and call_type are NA for rows of combined insertion + deletion spectra
 				collapse="."
 			)
-			
+
 			metadata <- x %>%
 				keep(
 					names(.) %in%
@@ -846,7 +847,7 @@ finalCalls.reftnc_spectra %>%
 						)
 				) %>%
 				as_tibble
-			
+
 			sbs_tables_to_output <- c(
 				"finalCalls.reftnc_pyr",
 				"finalCalls_unique.reftnc_pyr",
@@ -855,12 +856,12 @@ finalCalls.reftnc_spectra %>%
 				"finalCalls_unique.reftnc_pyr_spectrum",
 				"finalCalls.reftnc_template_strand_spectrum"
 			)
-			
+
 			indel_tables_to_output <- c(
 				"finalCalls.refindel_spectrum.sigfit",
 				"finalCalls_unique.refindel_spectrum.sigfit"
 			)
-			
+
 			plots_to_output <- c(
 				"finalCalls.reftnc_pyr_spectrum.sigfit",
 				"finalCalls.reftnc_pyr_spectrum.corrected_to_genome.sigfit",
@@ -874,7 +875,7 @@ finalCalls.reftnc_spectra %>%
 				"finalCalls.refindel_spectrum.sigfit",
 				"finalCalls_unique.refindel_spectrum.sigfit"
 			)
-			
+
 			sbs_tables_to_output %>%
 				walk(function(y){
 					if(!is.null(x[[y]])){
@@ -884,7 +885,7 @@ finalCalls.reftnc_spectra %>%
 						)
 					}
 				})
-			
+
 			indel_tables_to_output %>%
 				walk(function(y){
 					if(!is.null(x[[y]])){
@@ -897,7 +898,7 @@ finalCalls.reftnc_spectra %>%
 						)
 					}
 				})
-			
+
 			plots_to_output %>%
 				walk(function(y){
 					if(!is.null(x[[y]])){
@@ -907,7 +908,7 @@ finalCalls.reftnc_spectra %>%
 						)
 					}
 				})
-			
+
 		}
 	)
 
@@ -916,7 +917,7 @@ bam.gr.filtertrack.bytype.coverage_tnc %>%
 	pwalk(
 		function(...){
 			x <- list(...)
-			
+
 			output_basename_full <- str_c(
 				str_c(interrogatedBases.spectra_dir,x$chromgroup,"/",output_basename),
 				x$chromgroup,
@@ -926,7 +927,7 @@ bam.gr.filtertrack.bytype.coverage_tnc %>%
 				x$SBSindel_call_type,
 				sep="."
 			)
-			
+
 			metadata <- x %>%
 				keep(
 					names(.) %in%
@@ -937,12 +938,12 @@ bam.gr.filtertrack.bytype.coverage_tnc %>%
 						)
 				) %>%
 				as_tibble
-			
+
 			sbs_tables_to_output <- c(
 				"bam.gr.filtertrack.reftnc_pyr",
 				"bam.gr.filtertrack.reftnc_both_strands"
 			)
-			
+
 			sbs_tables_to_output %>%
 				walk(function(y){
 					write_col(
@@ -950,7 +951,7 @@ bam.gr.filtertrack.bytype.coverage_tnc %>%
 						col_name.input = y, metadata.input = metadata, output_basename_full.input = output_basename_full
 					)
 				})
-			
+
 		}
 	)
 
@@ -960,18 +961,18 @@ for(i in chromgroups){
 		select(reftnc_pyr) %>%
 		unnest(reftnc_pyr) %>%
 		write_tsv(str_c(genome.spectra_dir,i,"/","genome.reftnc_pyr.tsv"))
-	
+
 	genome_chromgroup.reftnc %>%
 		filter(chromgroup == i) %>%
 		select(chromgroup, reftnc_pyr) %>%
 		unnest(reftnc_pyr) %>%
 		write_tsv(str_c(genome.spectra_dir,i,"/",i,".genome_chromgroup.reftnc_pyr.tsv"))
-		
+
 	genome.reftnc %>%
 		select(reftnc_both_strands) %>%
 		unnest(reftnc_both_strands) %>%
 		write_tsv(str_c(genome.spectra_dir,i,"/","genome.reftnc_both_strands.tsv"))
-	
+
 	genome_chromgroup.reftnc %>%
 		filter(chromgroup == i) %>%
 		select(chromgroup, reftnc_both_strands) %>%
@@ -995,17 +996,17 @@ sensitivity <- sensitivity %>%
 			first(sensitivity[sensitivity_source == "calculated"], default = NA),
 			sensitivity
 		),
-		
+
 		sensitivity_source = case_when(
 			sensitivity_source == "other_chromgroup" & is.na(sensitivity.new) ~ "default_other_chromgroup",
 			sensitivity_source == "other_chromgroup" & !is.na(sensitivity.new) ~ "calculated_other_chromgroup",
 			.default = sensitivity_source
 		),
-		
+
 		sensitivity = sensitivity.new %>% replace_na(1)
 	) %>%
 	relocate(sensitivity, sensitivity_source, .after = last_col()) %>%
-	ungroup %>% 
+	ungroup %>%
 	select(-sensitivity.new)
 
 #Output as tsv
@@ -1014,7 +1015,7 @@ sensitivity %>%
 	pwalk(
 		function(...){
 			x <- list(...)
-			
+
 			output_basename_full <- str_c(
 				str_c(sensitivity_dir, x$chromgroup, "/", output_basename),
 				x$chromgroup,
@@ -1024,9 +1025,9 @@ sensitivity %>%
 				x$SBSindel_call_type,
 				sep="."
 			)
-			
+
 			x$data %>% write_tsv(str_c(output_basename_full, ".sensitivity.tsv"))
-			
+
 		}
 	)
 
@@ -1080,7 +1081,7 @@ finalCalls.burdens %>%
 	pwalk(
 		function(...){
 			x <- list(...)
-			
+
 			output_basename_full <- str_c(
 				str_c(finalCalls.burdens_dir, x$chromgroup, "/", output_basename),
 				x$chromgroup,
@@ -1090,9 +1091,9 @@ finalCalls.burdens %>%
 				x$SBSindel_call_type,
 				sep="."
 			)
-			
+
 			x$data %>% write_tsv(str_c(output_basename_full, ".finalCalls.burdens.tsv"))
-			
+
 		}
 	)
 
@@ -1108,7 +1109,7 @@ estimatedSBSMutationErrorProbability %>%
 	pwalk(
 		function(...){
 			x <- list(...)
-			
+
 			output_basename_full <- str_c(
 				str_c(estimatedSBSMutationErrorProbability_dir, x$chromgroup, "/", output_basename),
 				x$chromgroup,
@@ -1118,7 +1119,7 @@ estimatedSBSMutationErrorProbability %>%
 				x$SBSindel_call_type,
 				sep="."
 			)
-			
+
 			metadata <- x %>%
 				keep(
 					names(.) %in%
@@ -1128,13 +1129,13 @@ estimatedSBSMutationErrorProbability %>%
 						)
 				) %>%
 				as_tibble
-			
+
 			#by_channel_pyr error probability tsv
 			metadata %>%
 				mutate(by_channel_pyr = list(x$by_channel_pyr)) %>%
 				unnest(by_channel_pyr) %>%
 				write_tsv(str_c(output_basename_full, ".estimatedSBSMutationErrorProbability.by_channel_pyr.tsv"))
-			
+
 			#total error probability tsv
 			metadata %>%
 				mutate(

--- a/bin/processGermlineVCFs.R
+++ b/bin/processGermlineVCFs.R
@@ -37,7 +37,7 @@ option_list = list(
   make_option(c("-i", "--individual_id"), type = "character", default=NULL,
               help="individual_id to process"),
   make_option(c("-o", "--output"), type = "character", default=NULL,
-  						help="output qs2 file")
+						help="output qs2 file")
 )
 
 opt <- parse_args(OptionParser(option_list=option_list))
@@ -52,9 +52,10 @@ individual_id_toprocess <- opt$individual_id
 outputFile <- opt$output
 
 cache_dir <- yaml.config$cache_dir
+BSgenome_name <- get_bsgenome_name(yaml.config)
 
 #Load the BSgenome reference
-suppressPackageStartupMessages(library(yaml.config$BSgenome$BSgenome_name,character.only=TRUE,lib.loc=yaml.config$cache_dir))
+suppressPackageStartupMessages(library(BSgenome_name,character.only=TRUE,lib.loc=yaml.config$cache_dir))
 
 cat("DONE\n")
 
@@ -79,22 +80,22 @@ germline_vcf_variants <- list()
 vcf_files_individual <- vcf_files %>% filter(individual_id == individual_id_toprocess)
 
 for(i in 1:nrow(vcf_files_individual)){
-	
+
 	germline_vcf_file <- vcf_files_individual %>% pluck("germline_vcf_file",i)
 	germline_vcf_type <- vcf_files_individual %>% pluck("germline_vcf_type",i)
 
   cat(">> Processing VCF file:",germline_vcf_file,"...")
-  
+
   germline_vcf_variants[[i]] <- load_vcf(
-	  	vcf_file = germline_vcf_file,
-	  	genome_fasta = yaml.config$genome_fasta,
-	  	BSgenome_name = yaml.config$BSgenome$BSgenome_name,
-	  	bcftools_bin = yaml.config$bcftools_bin
-  	) %>%
-  	mutate(
-  		germline_vcf_file = factor(!!germline_vcf_file),
-  		germline_vcf_type = factor(!!germline_vcf_type)
-  	)
+		vcf_file = germline_vcf_file,
+		genome_fasta = yaml.config$genome_fasta,
+		BSgenome_name = BSgenome_name,
+		bcftools_bin = yaml.config$bcftools_bin
+	) %>%
+	mutate(
+		germline_vcf_file = factor(!!germline_vcf_file),
+		germline_vcf_type = factor(!!germline_vcf_type)
+	)
 
   cat("DONE\n")
 }

--- a/bin/processGermlineVCFs.R
+++ b/bin/processGermlineVCFs.R
@@ -37,7 +37,7 @@ option_list = list(
   make_option(c("-i", "--individual_id"), type = "character", default=NULL,
               help="individual_id to process"),
   make_option(c("-o", "--output"), type = "character", default=NULL,
-						help="output qs2 file")
+  						help="output qs2 file")
 )
 
 opt <- parse_args(OptionParser(option_list=option_list))
@@ -80,22 +80,22 @@ germline_vcf_variants <- list()
 vcf_files_individual <- vcf_files %>% filter(individual_id == individual_id_toprocess)
 
 for(i in 1:nrow(vcf_files_individual)){
-
+	
 	germline_vcf_file <- vcf_files_individual %>% pluck("germline_vcf_file",i)
 	germline_vcf_type <- vcf_files_individual %>% pluck("germline_vcf_type",i)
 
   cat(">> Processing VCF file:",germline_vcf_file,"...")
-
+  
   germline_vcf_variants[[i]] <- load_vcf(
-		vcf_file = germline_vcf_file,
-		genome_fasta = yaml.config$genome_fasta,
-		BSgenome_name = BSgenome_name,
-		bcftools_bin = yaml.config$bcftools_bin
-	) %>%
-	mutate(
-		germline_vcf_file = factor(!!germline_vcf_file),
-		germline_vcf_type = factor(!!germline_vcf_type)
-	)
+	  	vcf_file = germline_vcf_file,
+	  	genome_fasta = yaml.config$genome_fasta,
+	  	BSgenome_name = BSgenome_name,
+	  	bcftools_bin = yaml.config$bcftools_bin
+  	) %>%
+  	mutate(
+  		germline_vcf_file = factor(!!germline_vcf_file),
+  		germline_vcf_type = factor(!!germline_vcf_type)
+  	)
 
   cat("DONE\n")
 }

--- a/bin/sharedFunctions.R
+++ b/bin/sharedFunctions.R
@@ -2,66 +2,13 @@
 ### Custom shared functions
 ######################
 
-#Function to derive the BSgenome package name forged from the configured FASTA
-format_bsgenome_organism <- function(genome_organism){
-	if(is.null(genome_organism) || length(genome_organism) != 1 || is.na(genome_organism) || !nzchar(genome_organism)){
-		stop("ERROR: genome_organism must be specified!", call.=FALSE)
-	}
-
-	genome_organism <- genome_organism %>%
-		as.character %>%
-		gsub(pattern = "^\\s*|\\s*$", replacement = "", x = .) %>%
-		gsub(pattern = "\\s+", replacement = " ", x = .)
-
-	if(!nzchar(genome_organism)){
-		stop("ERROR: genome_organism must be specified!", call.=FALSE)
-	}
-
-	paste0(
-		toupper(substring(genome_organism, 1, 1)),
-		tolower(substring(genome_organism, 2))
-	)
-}
-
-abbreviate_bsgenome_organism <- function(genome_organism){
-	genome_organism <- format_bsgenome_organism(genome_organism)
-	suffix <- sub("^.*[^0-9\\s]([0-9\\s]*)$", "\\1", genome_organism, perl=TRUE)
-	prefix <- substr(genome_organism, 1, nchar(genome_organism) - nchar(suffix))
-	parts <- strsplit(prefix, "\\s+")[[1]]
-	if(length(parts) == 0 || !nzchar(parts[1])){
-		stop("ERROR: genome_organism must contain a non-numeric organism name.", call.=FALSE)
-	}
-
-	if(length(parts) <= 1){
-		abbr_organism <- parts
-	}else{
-		abbr_organism <- paste0(substr(head(parts, 1), 1, 1), tail(parts, 1))
-	}
-
-	paste0(abbr_organism, gsub("\\s", "", suffix))
-}
-
+#Function to derive the BSgenome package name created from the configured FASTA
 get_bsgenome_name <- function(yaml.config){
-	if(is.null(yaml.config$genome_fasta) || length(yaml.config$genome_fasta) != 1 || is.na(yaml.config$genome_fasta) || !nzchar(yaml.config$genome_fasta)){
-		stop("ERROR: genome_fasta must be specified!", call.=FALSE)
-	}
-
-	genome_part <- yaml.config$genome_fasta %>%
-		as.character %>%
+	genome_suffix <- yaml.config$genome_fasta %>%
 		basename %>%
-		gsub(pattern = "[^0-9a-zA-Z.]", replacement = "", x = .)
+		str_replace_all(pattern = "[^0-9a-zA-Z.]", replacement = "")
 
-	if(!nzchar(genome_part)){
-		stop("ERROR: genome_fasta basename must contain at least one letter, number, or dot!", call.=FALSE)
-	}
-
-	bsgenome_name <- paste("BSgenome", abbreviate_bsgenome_organism(yaml.config$genome_organism), "user", genome_part, sep=".")
-
-	if(!grepl("^[A-Za-z][A-Za-z0-9.]*[A-Za-z0-9]$", bsgenome_name)){
-		stop(str_c("ERROR: Derived BSgenome package name is not a valid R package name: ", bsgenome_name), call.=FALSE)
-	}
-
-	bsgenome_name
+	str_c("BSgenome", yaml.config$genome_organism, "user", genome_suffix, sep=".")
 }
 
 #Function to load and format VCF
@@ -82,14 +29,14 @@ load_vcf <- function(vcf_file, regions = NULL, genome_fasta, BSgenome_name, bcft
 		"grep '^##FORMAT=<ID=GT' | wc -l"
 		)
 	 )), intern=TRUE) != "0"
-
+	
 	GQ_exists <- system(paste("/bin/bash -c",shQuote(paste(
 		bcftools_bin,"view -h",
 		vcf_file,"|",
 		"grep '^##FORMAT=<ID=GQ' | wc -l"
 	)
 	)), intern=TRUE) != "0"
-
+	
 	if(!is.null(regions) && nrow(regions) == 0){
 		return(
 			GRanges(
@@ -109,7 +56,7 @@ load_vcf <- function(vcf_file, regions = NULL, genome_fasta, BSgenome_name, bcft
 			)
 		)
 	}
-
+	
 	#Create regions files if specified
 	if(!is.null(regions)){
 		tmpregions <- tempfile(tmpdir=getwd(),pattern=".")
@@ -118,10 +65,10 @@ load_vcf <- function(vcf_file, regions = NULL, genome_fasta, BSgenome_name, bcft
 			distinct %>%
 			write_tsv(tmpregions, col_names=FALSE)
 	}
-
+	
 	#Atomize and split multi-allelic sites (bcftools norm -a -f [fastaref] | bcftools norm -m -both -f [fastaref]), and filter for records containing ALT alleles.
   tmpvcf <- tempfile(tmpdir=getwd(),pattern=".")
-
+  
   system(paste("/bin/bash -c",shQuote(paste(
     bcftools_bin,"view",
     if(!is.null(regions)){paste("-R",tmpregions)},
@@ -133,7 +80,7 @@ load_vcf <- function(vcf_file, regions = NULL, genome_fasta, BSgenome_name, bcft
     tmpvcf
     )
    )))
-
+  
   if(!is.null(regions)){
   	file.remove(tmpregions) %>% invisible
   }
@@ -146,10 +93,10 @@ load_vcf <- function(vcf_file, regions = NULL, genome_fasta, BSgenome_name, bcft
    #For deletions, change to: REF = deleted bases and ALT = "". For insertions, change to: REF = "" and ALT = inserted bases
    #Keep only columns CHROM, POS, REF, ALT, QUAL, FILTER, GT (if exists), GQ (if exists).
    #Convert to GRanges
-
+  
   vcf <- read.vcfR(tmpvcf,convertNA=FALSE,verbose=FALSE)
   file.remove(tmpvcf) %>% invisible
-
+  
   vcf <- vcf@fix %>%
   	as_tibble %>%
   	mutate(
@@ -233,7 +180,7 @@ GRanges_subtract <- function(x, y, ignore.strand=FALSE){
 	mcols(unlisted_ans) <- extractROWS(mcols(x),Rle(seq_along(ans), lengths(ans)))
 	unlist(setNames(relist(unlisted_ans, ans), names(x)))
 }
-
+	
 # Function to subtract two granges (x and y) from each other, if they match on join_mcols (character vector of all columns to match), without reducing overlaps in the final output.
 GRanges_subtract_bymcols <- function(x, y, join_mcols, ignore.strand = FALSE){
   #Encode join keys as a factor
@@ -242,49 +189,49 @@ GRanges_subtract_bymcols <- function(x, y, join_mcols, ignore.strand = FALSE){
     select(all_of(join_mcols)) %>%
     as.list %>%
     interaction(drop = TRUE)
-
+  
   key_y <- y %>%
     as_tibble %>%
     select(all_of(join_mcols)) %>%
     as.list %>%
     interaction(drop = TRUE)
-
+  
   keys_all <- factor(c(key_x,key_y))
   id_x <- as.integer(keys_all)[seq_along(x)]
   id_y <- as.integer(keys_all)[length(x) + seq_along(y)]
-
+  
   #Change seqnames to contain key
   x2 <- GRanges(
   	seqnames = str_c(as.character(seqnames(x)), "|", id_x),
   	ranges = ranges(x),
   	strand = strand(x)
   )
-
+  
   y2 <- GRanges(
   	seqnames = str_c(as.character(seqnames(y)), "|", id_y),
   	ranges = ranges(y),
   	strand = strand(y)
   ) %>%
   	GNCList
-
+  
   #Find all overlaps
   hits <- findOverlaps(x2, y2, ignore.strand = ignore.strand) %>%
   	suppressWarnings #Hide warning about unshared seqlevels between x2 and y2
-
+  
   if(length(hits) == 0){return(x)}
-
+  
   #Obtain intersecting segments for matched hits
   qh <- queryHits(hits)
   sh <- subjectHits(hits)
-
+  
   segs_to_remove <- pintersect(x[qh], y[sh], ignore.strand = ignore.strand)
-
+  
   #Split segs_to_remove by the index of x
   rem_list <- split(segs_to_remove, factor(qh, levels = seq_along(x)), drop = FALSE)
-
+  
   #Subtract for each range in x (x_list) the ranges in y (rem_list) that intersect it
   out_list <- psetdiff(x, rem_list, ignore.strand = ignore.strand)
-
+  
   #Flatten result and restore all metadata from the original x
    #How many fragments came from each original x[i]
   nfrags <- elementNROWS(out_list)
@@ -294,7 +241,7 @@ GRanges_subtract_bymcols <- function(x, y, join_mcols, ignore.strand = FALSE){
   src_idx  <- rep(seq_along(nfrags), times = nfrags)
    #Re‐attach metadata columns
   mcols(out) <- mcols(x)[src_idx, , drop = FALSE]
-
+  
   return(out)
 }
 
@@ -331,43 +278,43 @@ trinucleotides_64to32 <- function(x, tri_column, count_column){
 
 #Function to re-anchor indels from HiDEF-seq calls to the style of VCF format so that ref_plus_strand and alt_plus_strand contain the base preceding the indel
 normalize_indels_for_vcf <- function(df, BSgenome_name){
-
+	
 	#Identify deletions and insertions
 	# insertions: ref_plus_strand == ""; alt_plus_strand = inserted bases
 	# deletions: ref_plus_strand = deleted bases; alt_plus_strand == ""
 	ins <- !nzchar(df$ref_plus_strand) & nzchar(df$alt_plus_strand)
 	del <- nzchar(df$ref_plus_strand) & !nzchar(df$alt_plus_strand)
 	ins_or_del <- ins | del
-
+	
 	#Normalize start position of insertions and deletions to start = start - 1, and extract sequence of the new start position
 	if(any(ins_or_del)){
 		df$start[ins_or_del] <- df$start[ins_or_del] - 1
-
+		
 		gr <- GRanges(
 			df$seqnames[ins_or_del],
 			IRanges(df$start[ins_or_del],	width = 1),
 			seqinfo = BSgenome_name %>% get %>% seqinfo
 		)
-
+		
 		start_base_ref <- df %>% nrow %>% character
 		start_base_ref[ins_or_del] <- getSeq(BSgenome_name %>% get, gr) %>% as.character
 	}
-
+	
 	#Normalize insertion sequences: ref_plus_strand = new start position base; alt_plus_strand = new start position base + inserted bases
 	if(any(ins)){
 		df$ref_plus_strand[ins] <- start_base_ref[ins]
 		df$alt_plus_strand[ins] <- str_c(start_base_ref[ins], df$alt_plus_strand[ins])
 	}
-
+	
 	#Normalize deletion sequences: ref_plus_strand = new start position base + deleted bases; alt_plus_strand = new start position base
 	if(any(del)){
 		df$ref_plus_strand[del] <- str_c(start_base_ref[del], df$ref_plus_strand[del])
 		df$alt_plus_strand[del] <- start_base_ref[del]
 	}
-
+	
 	#Remove 'end' column that is not needed for vcf, to avoid confusion
 	df$end <- NULL
-
+	
 	return(df)
 }
 
@@ -375,53 +322,53 @@ normalize_indels_for_vcf <- function(df, BSgenome_name){
 ## Max Stammnitz; maxrupsta@gmail.com; University of Cambridge  ##
 ## Citation: The evolution of two transmissible cancers in Tasmanian devils (Stammnitz et al. 2023, Science 380:6642)
 indel.spectrum <- function(x, reference, context_bp = 1000){
-
+	
 	# context_bp: total number of bp extracted around ≥5 bp events (flank on each side ~ context_bp/2)
 	.flank <- as.integer(context_bp / 2L)  # symmetric flank size used in ≥5 bp sections
-
+	
 	## 1. split VCF indels into:
 	# (i) 1-bp deletions
 	dels.1bp <- x[nchar(as.character(x[,'ALT'])) == nchar(as.character(x[,'REF']))-1,,drop=F]
-
+	
 	# (ii) 1-bp insertions
 	ins.1bp <- x[nchar(as.character(x[,'REF'])) == nchar(as.character(x[,'ALT']))-1,,drop=F]
-
+	
 	# (iii) >1 bp deletions
-
+	
 	## 2
 	dels.2bp <- x[nchar(as.character(x[,'ALT'])) == nchar(as.character(x[,'REF']))-2,,drop=F]
-
+	
 	## 3
 	dels.3bp <- x[nchar(as.character(x[,'ALT'])) == nchar(as.character(x[,'REF']))-3,,drop=F]
-
+	
 	## 4
 	dels.4bp <- x[nchar(as.character(x[,'ALT'])) == nchar(as.character(x[,'REF']))-4,,drop=F]
-
+	
 	## 5+
 	dels.5bp <- x[nchar(as.character(x[,'ALT'])) <= nchar(as.character(x[,'REF']))-5,,drop=F]
-
+	
 	# (iv) >1 bp insertions
-
+	
 	## 2
 	ins.2bp <- x[nchar(as.character(x[,'REF'])) == nchar(as.character(x[,'ALT']))-2,,drop=F]
-
+	
 	## 3
 	ins.3bp <- x[nchar(as.character(x[,'REF'])) == nchar(as.character(x[,'ALT']))-3,,drop=F]
-
+	
 	## 4
 	ins.4bp <- x[nchar(as.character(x[,'REF'])) == nchar(as.character(x[,'ALT']))-4,,drop=F]
-
+	
 	## 5+
 	ins.5bp <- x[nchar(as.character(x[,'REF'])) <= nchar(as.character(x[,'ALT']))-5,,drop=F]
-
+	
 	## 2. classify 1 bp events into:
-
+	
 	# (i) 1 bp deletions at homopolymers (length 1 == "no neighbouring homopolymers")
 	if(nrow(dels.1bp) > 0){
-
+		
 		## extract 10 bp upstream/downstream sequence context from reference
-		dels.1bp.context <- as.character(subseq(x = reference[as.character(dels.1bp[,'CHROM'])],
-																						start = as.numeric(dels.1bp[,'POS']) - 9,
+		dels.1bp.context <- as.character(subseq(x = reference[as.character(dels.1bp[,'CHROM'])], 
+																						start = as.numeric(dels.1bp[,'POS']) - 9, 
 																						end = as.numeric(dels.1bp[,'POS']) + 11))
 		dels.1bp.context.middle <- paste0('[', str_split_fixed(dels.1bp.context, '', 21)[,11,drop=F], ']')
 		dels.1bp.context.start <- str_split_fixed(dels.1bp.context, '', 11)[,1:10,drop=F]
@@ -431,11 +378,11 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 																		dels.1bp.context.start[,10], sep = '')
 		dels.1bp.context.end <- str_split_fixed(dels.1bp.context, '', 12)[,12,drop=F]
 		dels.1bp[,'TRIPLET'] <- paste(dels.1bp.context.start, dels.1bp.context.middle, dels.1bp.context.end, sep = '')
-		colnames(dels.1bp)[5] <- 'CONTEXT FW'
-
+		colnames(dels.1bp)[5] <- 'CONTEXT FW' 
+		
 		## need the central base to be pyrimidine-centred, i.e. C or T, hence also run reverseComplements on full contexts
-		dels.1bp.context.rc <- as.character(reverseComplement(subseq(x = reference[as.character(dels.1bp[,'CHROM'])],
-																																 start = as.numeric(dels.1bp[,'POS']) - 9,
+		dels.1bp.context.rc <- as.character(reverseComplement(subseq(x = reference[as.character(dels.1bp[,'CHROM'])], 
+																																 start = as.numeric(dels.1bp[,'POS']) - 9, 
 																																 end = as.numeric(dels.1bp[,'POS']) + 11)))
 		dels.1bp.context.rc.middle <- paste0('[', str_split_fixed(dels.1bp.context.rc, '', 21)[,11,drop=F], ']')
 		dels.1bp.context.rc.start <- str_split_fixed(dels.1bp.context.rc, '', 11)[,1:10,drop=F]
@@ -446,7 +393,7 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 		dels.1bp.context.rc.end <- str_split_fixed(dels.1bp.context.rc, '', 12)[,12,drop=F]
 		dels.1bp <- cbind(dels.1bp[,1:5,drop=F], paste(dels.1bp.context.rc.start, dels.1bp.context.rc.middle, dels.1bp.context.rc.end, sep = ''))
 		colnames(dels.1bp)[6] <- 'CONTEXT RC'
-
+		
 		## summarise 1 bp deletions in matrix format
 		dels.1bp.summary <- matrix(0, ncol = 2, nrow = 6)
 		colnames(dels.1bp.summary) <- c('C', 'T') ## pyrimidine-centred deleted base
@@ -455,181 +402,181 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 		rc <- str_split_fixed(str_split_fixed(dels.1bp[,'CONTEXT RC'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		fw.if <- fw == 'C' | fw == 'T'
 		for (i in 1:nrow(dels.1bp)){
-
+			
 			if(fw.if[i] == T){
-
+				
 				## look at forward context
 				upstream.tmp <- str_split_fixed(str_split_fixed(as.character(dels.1bp[i,'CONTEXT FW']), '\\[', 2)[,1], '', 10)
 				upstream.tmp <- which(upstream.tmp == fw[i])
-
+				
 				### check all 6 categories for upstream bases
 				if(any(upstream.tmp %in% 10)){
-
+					
 					if(any(upstream.tmp %in% 9)){
-
+						
 						if(any(upstream.tmp %in% 8)){
-
+							
 							if(any(upstream.tmp %in% 7)){
-
+								
 								if(any(upstream.tmp %in% 6)){
-
+									
 									upstream.tmp <- 6
-
+									
 								}else{
 									upstream.tmp <- 5
 								}
-
+								
 							}else{
 								upstream.tmp <- 4
 							}
-
+							
 						}else{
 							upstream.tmp <- 3
 						}
-
+						
 					}else{
 						upstream.tmp <- 2
 					}
-
+					
 				}else{
 					upstream.tmp <- 1
 				}
-
+				
 				downstream.tmp <- str_split_fixed(str_split_fixed(as.character(dels.1bp[i,'CONTEXT FW']), '\\]', 2)[,2], '', 10)
 				downstream.tmp <- which(downstream.tmp == fw[i])
-
+				
 				### check all 6 categories for downstream bases
 				if(any(downstream.tmp %in% 1)){
-
+					
 					if(any(downstream.tmp %in% 2)){
-
+						
 						if(any(downstream.tmp %in% 3)){
-
+							
 							if(any(downstream.tmp %in% 4)){
-
+								
 								if(any(downstream.tmp %in% 5)){
-
+									
 									downstream.tmp <- 6
-
+									
 								}else{
 									downstream.tmp <- 5
 								}
-
+								
 							}else{
 								downstream.tmp <- 4
 							}
-
+							
 						}else{
 							downstream.tmp <- 3
 						}
-
+						
 					}else{
 						downstream.tmp <- 2
 					}
-
+					
 				}else{
 					downstream.tmp <- 1
 				}
-
+				
 				## summarise, which homopolymer (upstream vs. downstream context) is longer
 				dels.1bp.summary[max(c(upstream.tmp, downstream.tmp)),fw[i]] <- dels.1bp.summary[max(c(upstream.tmp, downstream.tmp)),fw[i]] + 1
-
+				
 			} else {
-
+				
 				## look at reverse complement context
 				upstream.tmp <- str_split_fixed(str_split_fixed(as.character(dels.1bp[i,'CONTEXT RC']), '\\[', 2)[,1], '', 10)
 				upstream.tmp <- which(upstream.tmp == rc[i])
-
+				
 				### check all 6 categories for upstream bases
 				if(any(upstream.tmp %in% 10)){
-
+					
 					if(any(upstream.tmp %in% 9)){
-
+						
 						if(any(upstream.tmp %in% 8)){
-
+							
 							if(any(upstream.tmp %in% 7)){
-
+								
 								if(any(upstream.tmp %in% 6)){
-
+									
 									upstream.tmp <- 6
-
+									
 								}else{
 									upstream.tmp <- 5
 								}
-
+								
 							}else{
 								upstream.tmp <- 4
 							}
-
+							
 						}else{
 							upstream.tmp <- 3
 						}
-
+						
 					}else{
 						upstream.tmp <- 2
 					}
-
+					
 				}else{
 					upstream.tmp <- 1
 				}
-
+				
 				downstream.tmp <- str_split_fixed(str_split_fixed(as.character(dels.1bp[i,'CONTEXT RC']), '\\]', 2)[,2], '', 10)
 				downstream.tmp <- which(downstream.tmp == rc[i])
-
+				
 				### check all 6 categories for downstream bases
 				if(any(downstream.tmp %in% 1)){
-
+					
 					if(any(downstream.tmp %in% 2)){
-
+						
 						if(any(downstream.tmp %in% 3)){
-
+							
 							if(any(downstream.tmp %in% 4)){
-
+								
 								if(any(downstream.tmp %in% 5)){
-
+									
 									downstream.tmp <- 6
-
+									
 								}else{
 									downstream.tmp <- 5
 								}
-
+								
 							}else{
 								downstream.tmp <- 4
 							}
-
+							
 						}else{
 							downstream.tmp <- 3
 						}
-
+						
 					}else{
 						downstream.tmp <- 2
 					}
-
+					
 				}else{
 					downstream.tmp <- 1
 				}
-
+				
 				## summarise, which homopolymer (upstream vs. downstream context) is longer
 				dels.1bp.summary[max(c(upstream.tmp, downstream.tmp)),rc[i]] <- dels.1bp.summary[max(c(upstream.tmp, downstream.tmp)),rc[i]] + 1
 			}
-
+			
 		}
-
+		
 	}else{
-
+		
 		## summarise 1 bp deletions in matrix format
 		dels.1bp.summary <- matrix(0, ncol = 2, nrow = 6)
 		colnames(dels.1bp.summary) <- c('C', 'T') ## pyrimidine-centred deleted base
 		rownames(dels.1bp.summary) <- c('0 bp', '1 bp', '2 bp', '3 bp', '4 bp', '5+ bp') ## contextual homopolymer-length
-
+		
 	}
-
+	
 	# (ii) 1 bp insertions at homopolymers (length 0 == "no neighbouring homopolymers")
 	if(nrow(ins.1bp) > 0){
-
+		
 		## extract 10 bp upstream/downstream sequence context from reference
-		ins.1bp.context <- as.character(subseq(x = reference[as.character(ins.1bp[,'CHROM'])],
-																					 start = as.numeric(ins.1bp[,'POS']) - 9,
+		ins.1bp.context <- as.character(subseq(x = reference[as.character(ins.1bp[,'CHROM'])], 
+																					 start = as.numeric(ins.1bp[,'POS']) - 9, 
 																					 end = as.numeric(ins.1bp[,'POS']) + 10))
 		## insertion after base pos. 10
 		ins.1bp.context.middle <- paste0('[', str_split_fixed(as.character(ins.1bp[,'ALT']), '', 2)[,2,drop=F], ']')
@@ -641,10 +588,10 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 		ins.1bp.context.end <- str_split_fixed(ins.1bp.context, '', 11)[,11,drop=F]
 		ins.1bp[,'TRIPLET'] <- paste(ins.1bp.context.start, ins.1bp.context.middle, ins.1bp.context.end, sep = '')
 		colnames(ins.1bp)[5] <- 'CONTEXT FW'
-
+		
 		## need the central base to be pyrimidine-centred, i.e. C or T, hence also run reverseComplements on full contexts
-		ins.1bp.context.rc <- as.character(reverseComplement(subseq(x = reference[as.character(ins.1bp[,'CHROM'])],
-																																start = as.numeric(ins.1bp[,'POS']) - 9,
+		ins.1bp.context.rc <- as.character(reverseComplement(subseq(x = reference[as.character(ins.1bp[,'CHROM'])], 
+																																start = as.numeric(ins.1bp[,'POS']) - 9, 
 																																end = as.numeric(ins.1bp[,'POS']) + 10)))
 		ins.1bp.context.rc.middle <- paste0('[', as.character(reverseComplement(DNAStringSet(str_split_fixed(as.character(ins.1bp[,'ALT']), '', 2)[,2,drop=F]))), ']')
 		ins.1bp.context.rc.start <- str_split_fixed(ins.1bp.context.rc, '', 11)[,1:10,drop=F]
@@ -655,7 +602,7 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 		ins.1bp.context.rc.end <- str_split_fixed(ins.1bp.context.rc, '', 11)[,11,drop=F]
 		ins.1bp <- cbind(ins.1bp[,1:5,drop=F], paste(ins.1bp.context.rc.start, ins.1bp.context.rc.middle, ins.1bp.context.rc.end, sep = ''))
 		colnames(ins.1bp)[6] <- 'CONTEXT RC'
-
+		
 		## summarise 1 bp insertions in matrix format
 		ins.1bp.summary <- matrix(0, ncol = 2, nrow = 6)
 		colnames(ins.1bp.summary) <- c('C', 'T') ## pyrimidine-centred inserted base
@@ -664,183 +611,183 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 		rc <- str_split_fixed(str_split_fixed(ins.1bp[,'CONTEXT RC'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		fw.if <- fw == 'C' | fw == 'T'
 		for (i in 1:nrow(ins.1bp)){
-
+			
 			if(fw.if[i] == T){
-
+				
 				## look at forward context
 				upstream.tmp <- str_split_fixed(str_split_fixed(as.character(ins.1bp[i,'CONTEXT FW']), '\\[', 2)[,1], '', 10)
 				upstream.tmp <- which(upstream.tmp == fw[i])
-
+				
 				### check all 6 categories for upstream bases
 				if(any(upstream.tmp %in% 10)){
-
+					
 					if(any(upstream.tmp %in% 9)){
-
+						
 						if(any(upstream.tmp %in% 8)){
-
+							
 							if(any(upstream.tmp %in% 7)){
-
+								
 								if(any(upstream.tmp %in% 6)){
-
+									
 									upstream.tmp <- 6
-
+									
 								}else{
 									upstream.tmp <- 5
 								}
-
+								
 							}else{
 								upstream.tmp <- 4
 							}
-
+							
 						}else{
 							upstream.tmp <- 3
 						}
-
+						
 					}else{
 						upstream.tmp <- 2
 					}
-
+					
 				}else{
 					upstream.tmp <- 1
 				}
-
+				
 				downstream.tmp <- str_split_fixed(str_split_fixed(as.character(ins.1bp[i,'CONTEXT FW']), '\\]', 2)[,2], '', 10)
 				downstream.tmp <- which(downstream.tmp == fw[i])
-
+				
 				### check all 6 categories for downstream bases
 				if(any(downstream.tmp %in% 1)){
-
+					
 					if(any(downstream.tmp %in% 2)){
-
+						
 						if(any(downstream.tmp %in% 3)){
-
+							
 							if(any(downstream.tmp %in% 4)){
-
+								
 								if(any(downstream.tmp %in% 5)){
-
+									
 									downstream.tmp <- 6
-
+									
 								}else{
 									downstream.tmp <- 5
 								}
-
+								
 							}else{
 								downstream.tmp <- 4
 							}
-
+							
 						}else{
 							downstream.tmp <- 3
 						}
-
+						
 					}else{
 						downstream.tmp <- 2
 					}
-
+					
 				}else{
 					downstream.tmp <- 1
 				}
-
+				
 				## summarise, which homopolymer is longer
 				ins.1bp.summary[max(c(upstream.tmp, downstream.tmp)),fw[i]] <- ins.1bp.summary[max(c(upstream.tmp, downstream.tmp)),fw[i]] + 1
-
+				
 			} else {
-
+				
 				## look at reverse complement context
 				upstream.tmp <- str_split_fixed(str_split_fixed(as.character(ins.1bp[i,'CONTEXT RC']), '\\[', 2)[,1], '', 10)
 				upstream.tmp <- which(upstream.tmp == rc[i])
-
+				
 				### check all 6 categories for upstream bases
 				if(any(upstream.tmp %in% 10)){
-
+					
 					if(any(upstream.tmp %in% 9)){
-
+						
 						if(any(upstream.tmp %in% 8)){
-
+							
 							if(any(upstream.tmp %in% 7)){
-
+								
 								if(any(upstream.tmp %in% 6)){
-
+									
 									upstream.tmp <- 6
-
+									
 								}else{
 									upstream.tmp <- 5
 								}
-
+								
 							}else{
 								upstream.tmp <- 4
 							}
-
+							
 						}else{
 							upstream.tmp <- 3
 						}
-
+						
 					}else{
 						upstream.tmp <- 2
 					}
-
+					
 				}else{
 					upstream.tmp <- 1
 				}
-
+				
 				downstream.tmp <- str_split_fixed(str_split_fixed(as.character(ins.1bp[i,'CONTEXT RC']), '\\]', 2)[,2], '', 10)
 				downstream.tmp <- which(downstream.tmp == rc[i])
-
+				
 				### check all 6 categories for downstream bases
 				if(any(downstream.tmp %in% 1)){
-
+					
 					if(any(downstream.tmp %in% 2)){
-
+						
 						if(any(downstream.tmp %in% 3)){
-
+							
 							if(any(downstream.tmp %in% 4)){
-
+								
 								if(any(downstream.tmp %in% 5)){
-
+									
 									downstream.tmp <- 6
-
+									
 								}else{
 									downstream.tmp <- 5
 								}
-
+								
 							}else{
 								downstream.tmp <- 4
 							}
-
+							
 						}else{
 							downstream.tmp <- 3
 						}
-
+						
 					}else{
 						downstream.tmp <- 2
 					}
-
+					
 				}else{
 					downstream.tmp <- 1
 				}
-
+				
 				## summarise, which homopolymer is longer
 				ins.1bp.summary[max(c(upstream.tmp, downstream.tmp)),rc[i]] <- ins.1bp.summary[max(c(upstream.tmp, downstream.tmp)),rc[i]] + 1
 			}
-
-		}
-
+			
+		} 
+		
 	}else{
-
+		
 		## summarise 1 bp insertions in matrix format
 		ins.1bp.summary <- matrix(0, ncol = 2, nrow = 6)
 		colnames(ins.1bp.summary) <- c('C', 'T') ## pyrimidine-centred inserted base
 		rownames(ins.1bp.summary) <- c('0 bp', '1 bp', '2 bp', '3 bp', '4 bp', '5+ bp') ## contextual homopolymer-length
-
+		
 	}
-
+	
 	## 3. classify >=2 bp deletions into:
-
+	
 	# (i) 2 bp deletions at simple repeats (length 1 == "no neighbouring simple repeat")
 	if(nrow(dels.2bp) > 0){
-
+		
 		## extract 5 x 2 bp upstream/downstream sequence context from reference
-		dels.2bp.context <- as.character(subseq(x = reference[as.character(dels.2bp[,'CHROM'])],
-																						start = as.numeric(dels.2bp[,'POS']) - 9,
+		dels.2bp.context <- as.character(subseq(x = reference[as.character(dels.2bp[,'CHROM'])], 
+																						start = as.numeric(dels.2bp[,'POS']) - 9, 
 																						end = as.numeric(dels.2bp[,'POS']) + 2 + 10))
 		dels.2bp.context.middle <- str_split_fixed(dels.2bp.context, '', 22)[,11:12,drop=F]
 		dels.2bp.context.middle <- paste0('[', dels.2bp.context.middle[,1], dels.2bp.context.middle[,2], ']')
@@ -851,16 +798,16 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 																		dels.2bp.context.start[,10], sep = '')
 		dels.2bp.context.end <- str_split_fixed(dels.2bp.context, '', 13)[,13,drop=F]
 		dels.2bp[,'TRIPLET'] <- paste(dels.2bp.context.start, dels.2bp.context.middle, dels.2bp.context.end, sep = '')
-		colnames(dels.2bp)[5] <- 'CONTEXT'
-
+		colnames(dels.2bp)[5] <- 'CONTEXT' 
+		
 	}
-
+	
 	# (ii) 3 bp deletions at simple repeats (length 1 == "no neighbouring simple repeat")
 	if(nrow(dels.3bp) > 0){
-
+		
 		## extract 5 x 3 bp upstream/downstream sequence context from reference
-		dels.3bp.context <- as.character(subseq(x = reference[as.character(dels.3bp[,'CHROM'])],
-																						start = as.numeric(dels.3bp[,'POS']) - 14,
+		dels.3bp.context <- as.character(subseq(x = reference[as.character(dels.3bp[,'CHROM'])], 
+																						start = as.numeric(dels.3bp[,'POS']) - 14, 
 																						end = as.numeric(dels.3bp[,'POS']) + 3 + 15))
 		dels.3bp.context.middle <- str_split_fixed(dels.3bp.context, '', 33)[,16:18,drop=F]
 		dels.3bp.context.middle <- paste0('[', dels.3bp.context.middle[,1], dels.3bp.context.middle[,2], dels.3bp.context.middle[,3], ']')
@@ -868,46 +815,46 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 		dels.3bp.context.start <- paste(dels.3bp.context.start[,1], dels.3bp.context.start[,2], dels.3bp.context.start[,3],
 																		dels.3bp.context.start[,4], dels.3bp.context.start[,5], dels.3bp.context.start[,6],
 																		dels.3bp.context.start[,7], dels.3bp.context.start[,8], dels.3bp.context.start[,9],
-																		dels.3bp.context.start[,10], dels.3bp.context.start[,11], dels.3bp.context.start[,12],
+																		dels.3bp.context.start[,10], dels.3bp.context.start[,11], dels.3bp.context.start[,12], 
 																		dels.3bp.context.start[,13], dels.3bp.context.start[,14], dels.3bp.context.start[,15], sep = '')
 		dels.3bp.context.end <- str_split_fixed(dels.3bp.context, '', 19)[,19,drop=F]
 		dels.3bp[,'TRIPLET'] <- paste(dels.3bp.context.start, dels.3bp.context.middle, dels.3bp.context.end, sep = '')
-		colnames(dels.3bp)[5] <- 'CONTEXT'
-
+		colnames(dels.3bp)[5] <- 'CONTEXT' 
+		
 	}
-
+	
 	# (iii) 4 bp deletions at simple repeats (length 1 == "no neighbouring simple repeat")
 	if(nrow(dels.4bp) > 0){
-
+		
 		## extract 5 x 4 bp upstream/downstream sequence context from reference
-		dels.4bp.context <- as.character(subseq(x = reference[as.character(dels.4bp[,'CHROM'])],
-																						start = as.numeric(dels.4bp[,'POS']) - 19,
+		dels.4bp.context <- as.character(subseq(x = reference[as.character(dels.4bp[,'CHROM'])], 
+																						start = as.numeric(dels.4bp[,'POS']) - 19, 
 																						end = as.numeric(dels.4bp[,'POS']) + 4 + 20))
 		dels.4bp.context.middle <- str_split_fixed(dels.4bp.context, '', 41)[,21:24,drop=F]
-		dels.4bp.context.middle <- paste0('[', dels.4bp.context.middle[,1],
-																			dels.4bp.context.middle[,2],
-																			dels.4bp.context.middle[,3],
+		dels.4bp.context.middle <- paste0('[', dels.4bp.context.middle[,1], 
+																			dels.4bp.context.middle[,2], 
+																			dels.4bp.context.middle[,3], 
 																			dels.4bp.context.middle[,4], ']')
 		dels.4bp.context.start <- str_split_fixed(dels.4bp.context, '', 21)[,1:20,drop=F]
 		dels.4bp.context.start <- paste(dels.4bp.context.start[,1], dels.4bp.context.start[,2], dels.4bp.context.start[,3],
 																		dels.4bp.context.start[,4], dels.4bp.context.start[,5], dels.4bp.context.start[,6],
 																		dels.4bp.context.start[,7], dels.4bp.context.start[,8], dels.4bp.context.start[,9],
-																		dels.4bp.context.start[,10], dels.4bp.context.start[,11], dels.4bp.context.start[,12],
-																		dels.4bp.context.start[,13], dels.4bp.context.start[,14], dels.4bp.context.start[,15],
-																		dels.4bp.context.start[,16], dels.4bp.context.start[,17], dels.4bp.context.start[,18],
+																		dels.4bp.context.start[,10], dels.4bp.context.start[,11], dels.4bp.context.start[,12], 
+																		dels.4bp.context.start[,13], dels.4bp.context.start[,14], dels.4bp.context.start[,15], 
+																		dels.4bp.context.start[,16], dels.4bp.context.start[,17], dels.4bp.context.start[,18], 
 																		dels.4bp.context.start[,19], dels.4bp.context.start[,20], sep = '')
 		dels.4bp.context.end <- str_split_fixed(dels.4bp.context, '', 25)[,25,drop=F]
 		dels.4bp[,'TRIPLET'] <- paste(dels.4bp.context.start, dels.4bp.context.middle, dels.4bp.context.end, sep = '')
-		colnames(dels.4bp)[5] <- 'CONTEXT'
-
+		colnames(dels.4bp)[5] <- 'CONTEXT' 
+		
 	}
-
+	
 	# (iv) 5+ bp deletions at simple repeats (length 1 == "no neighbouring simple repeat")
 	if(nrow(dels.5bp) > 0){
-
+		
 		# lengths of the deleted segments
 		dels.5bp.context.middle.lengths <- nchar(as.character(dels.5bp[,'REF'])) - 1
-
+		
 		# extract symmetric upstream/downstream flanks sized by context_bp and extend end by deletion length
 		dels.5bp.context <- as.character(
 			subseq(
@@ -916,12 +863,12 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 				end = as.numeric(dels.5bp[,'POS']) + dels.5bp.context.middle.lengths + .flank
 				)
 			)
-
+		
 		# build [deleted] middle
 		dels.5bp.context.middle <- as.character(dels.5bp[,'REF'])
 		dels.5bp.context.middle <- str_split_fixed(dels.5bp.context.middle, '', 2)[,2,drop=F]
 		dels.5bp.context.middle <- paste0('[', dels.5bp.context.middle, ']')
-
+		
 		#upstream
 		dels.5bp.context.start <- rep(NA, nrow(dels.5bp))
 		for (i in 1:length(dels.5bp.context.start)){
@@ -932,7 +879,7 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 			i2 <- .flank # end index (upstream flank end)
 			dels.5bp.context.start[i] <- paste(s[, i1:i2, drop=FALSE], collapse='')
 		}
-
+		
 		#downstream
 		dels.5bp.context.end <- rep(NA, nrow(dels.5bp))
 		for (i in 1:length(dels.5bp.context.end)){
@@ -943,306 +890,306 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 			i2 <- min(.flank + (6*l), nC) # clamp to available sequence
 			dels.5bp.context.end[i] <- paste(s[, i1:i2, drop=FALSE], collapse='')
 		}
-
+		
 		dels.5bp[,'TRIPLET'] <- paste(dels.5bp.context.start, dels.5bp.context.middle, dels.5bp.context.end, sep = '')
 		colnames(dels.5bp)[5] <- 'CONTEXT'
-
+		
 	}
-
+	
 	## summarise >=2 bp deletions at simple repeats in matrix format
 	## also create sub-tables for repeat length = 1 hits, to later assess these for microhomologies
 	dels.greater.2bp.summary <- matrix(0, ncol = 4, nrow = 6)
 	colnames(dels.greater.2bp.summary) <- c('2 bp', '3 bp', '4 bp', '5+ bp') ## deletion size
 	rownames(dels.greater.2bp.summary) <- c('1 or MH', '2', '3', '4', '5', '6+') ## number of repeats
-
+	
 	## 2 bp
 	if(nrow(dels.2bp) > 0){
-
+		
 		repeat.nts <- str_split_fixed(str_split_fixed(dels.2bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		downstream.context <- str_split_fixed(str_split_fixed(dels.2bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 		dels.2bp.pot.MH.ind <- c()
 		for (i in 1:nrow(dels.2bp)){
-
+			
 			## look at repeat
 			tmp.repeat.nts <- repeat.nts[i]
 			tmp.repeat.length <- nchar(tmp.repeat.nts)
-
+			
 			## how often does it match consecutively in the immediate downstream context?
 			tmp.downstream.context <- downstream.context[i]
 			tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]]
-
+			
 			## group
 			tmp.downstream.context <- c(paste(tmp.downstream.context[c(tmp.repeat.length-c(tmp.repeat.length - 1)):tmp.repeat.length], collapse = ''),
 																	paste(tmp.downstream.context[c(2*tmp.repeat.length-c(tmp.repeat.length - 1)):c(2*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(3*tmp.repeat.length-c(tmp.repeat.length - 1)):c(3*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(4*tmp.repeat.length-c(tmp.repeat.length - 1)):c(4*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(5*tmp.repeat.length-c(tmp.repeat.length - 1)):c(5*tmp.repeat.length)], collapse = ''))
-
+			
 			### check all 6 categories for upstream bases
 			if(tmp.downstream.context[1] %in% tmp.repeat.nts){
-
+				
 				if(tmp.downstream.context[2] %in% tmp.repeat.nts){
-
+					
 					if(tmp.downstream.context[3] %in% tmp.repeat.nts){
-
+						
 						if(tmp.downstream.context[4] %in% tmp.repeat.nts){
-
+							
 							if(tmp.downstream.context[5] %in% tmp.repeat.nts){
-
+								
 								dels.greater.2bp.summary['6+', '2 bp'] <- dels.greater.2bp.summary['6+', '2 bp'] + 1
-
+								
 							} else{
-
+								
 								dels.greater.2bp.summary['5', '2 bp'] <- dels.greater.2bp.summary['5', '2 bp'] + 1
-
+								
 							}
-
+							
 						}else{
-
+							
 							dels.greater.2bp.summary['4', '2 bp'] <- dels.greater.2bp.summary['4', '2 bp'] + 1
-
+							
 						}
-
+						
 					}else{
-
+						
 						dels.greater.2bp.summary['3', '2 bp'] <- dels.greater.2bp.summary['3', '2 bp'] + 1
-
+						
 					}
-
+					
 				}else{
-
+					
 					dels.greater.2bp.summary['2', '2 bp'] <- dels.greater.2bp.summary['2', '2 bp'] + 1
-
+					
 				}
-
+				
 			}else{
-
+				
 				dels.greater.2bp.summary['1 or MH', '2 bp'] <- dels.greater.2bp.summary['1 or MH', '2 bp'] + 1
 				dels.2bp.pot.MH.ind <- c(dels.2bp.pot.MH.ind, i)
-
+				
 			}
-
+			
 		}
-		dels.2bp.pot.MH <- dels.2bp[dels.2bp.pot.MH.ind,,drop=F]
-
+		dels.2bp.pot.MH <- dels.2bp[dels.2bp.pot.MH.ind,,drop=F] 
+		
 	}
-
+	
 	## 3 bp
 	if(nrow(dels.3bp) > 0){
-
+		
 		repeat.nts <- str_split_fixed(str_split_fixed(dels.3bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		downstream.context <- str_split_fixed(str_split_fixed(dels.3bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 		dels.3bp.pot.MH.ind <- c()
 		for (i in 1:nrow(dels.3bp)){
-
+			
 			## look at repeat
 			tmp.repeat.nts <- repeat.nts[i]
 			tmp.repeat.length <- nchar(tmp.repeat.nts)
-
+			
 			## how often does it match consecutively in the immediate downstream context?
 			tmp.downstream.context <- downstream.context[i]
 			tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]]
-
+			
 			## group
 			tmp.downstream.context <- c(paste(tmp.downstream.context[c(tmp.repeat.length-c(tmp.repeat.length - 1)):tmp.repeat.length], collapse = ''),
 																	paste(tmp.downstream.context[c(2*tmp.repeat.length-c(tmp.repeat.length - 1)):c(2*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(3*tmp.repeat.length-c(tmp.repeat.length - 1)):c(3*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(4*tmp.repeat.length-c(tmp.repeat.length - 1)):c(4*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(5*tmp.repeat.length-c(tmp.repeat.length - 1)):c(5*tmp.repeat.length)], collapse = ''))
-
+			
 			### check all 6 categories for upstream bases
 			if(tmp.downstream.context[1] %in% tmp.repeat.nts){
-
+				
 				if(tmp.downstream.context[2] %in% tmp.repeat.nts){
-
+					
 					if(tmp.downstream.context[3] %in% tmp.repeat.nts){
-
+						
 						if(tmp.downstream.context[4] %in% tmp.repeat.nts){
-
+							
 							if(tmp.downstream.context[5] %in% tmp.repeat.nts){
-
+								
 								dels.greater.2bp.summary['6+', '3 bp'] <- dels.greater.2bp.summary['6+', '3 bp'] + 1
-
+								
 							} else{
-
+								
 								dels.greater.2bp.summary['5', '3 bp'] <- dels.greater.2bp.summary['5', '3 bp'] + 1
-
+								
 							}
-
+							
 						}else{
-
+							
 							dels.greater.2bp.summary['4', '3 bp'] <- dels.greater.2bp.summary['4', '3 bp'] + 1
-
+							
 						}
-
+						
 					}else{
-
+						
 						dels.greater.2bp.summary['3', '3 bp'] <- dels.greater.2bp.summary['3', '3 bp'] + 1
-
+						
 					}
-
+					
 				}else{
-
+					
 					dels.greater.2bp.summary['2', '3 bp'] <- dels.greater.2bp.summary['2', '3 bp'] + 1
-
+					
 				}
-
+				
 			}else{
-
+				
 				dels.greater.2bp.summary['1 or MH', '3 bp'] <- dels.greater.2bp.summary['1 or MH', '3 bp'] + 1
 				dels.3bp.pot.MH.ind <- c(dels.3bp.pot.MH.ind, i)
-
+				
 			}
-
+			
 		}
-		dels.3bp.pot.MH <- dels.3bp[dels.3bp.pot.MH.ind,,drop=F]
-
+		dels.3bp.pot.MH <- dels.3bp[dels.3bp.pot.MH.ind,,drop=F] 
+		
 	}
-
+	
 	## 4 bp
 	if(nrow(dels.4bp) > 0){
-
+		
 		repeat.nts <- str_split_fixed(str_split_fixed(dels.4bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		downstream.context <- str_split_fixed(str_split_fixed(dels.4bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 		dels.4bp.pot.MH.ind <- c()
 		for (i in 1:nrow(dels.4bp)){
-
+			
 			## look at repeat
 			tmp.repeat.nts <- repeat.nts[i]
 			tmp.repeat.length <- nchar(tmp.repeat.nts)
-
+			
 			## how often does it match consecutively in the immediate downstream context?
 			tmp.downstream.context <- downstream.context[i]
 			tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]]
-
+			
 			## group
 			tmp.downstream.context <- c(paste(tmp.downstream.context[c(tmp.repeat.length-c(tmp.repeat.length - 1)):tmp.repeat.length], collapse = ''),
 																	paste(tmp.downstream.context[c(2*tmp.repeat.length-c(tmp.repeat.length - 1)):c(2*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(3*tmp.repeat.length-c(tmp.repeat.length - 1)):c(3*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(4*tmp.repeat.length-c(tmp.repeat.length - 1)):c(4*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(5*tmp.repeat.length-c(tmp.repeat.length - 1)):c(5*tmp.repeat.length)], collapse = ''))
-
+			
 			### check all 6 categories for upstream bases
 			if(tmp.downstream.context[1] %in% tmp.repeat.nts){
-
+				
 				if(tmp.downstream.context[2] %in% tmp.repeat.nts){
-
+					
 					if(tmp.downstream.context[3] %in% tmp.repeat.nts){
-
+						
 						if(tmp.downstream.context[4] %in% tmp.repeat.nts){
-
+							
 							if(tmp.downstream.context[5] %in% tmp.repeat.nts){
-
+								
 								dels.greater.2bp.summary['6+', '4 bp'] <- dels.greater.2bp.summary['6+', '4 bp'] + 1
-
+								
 							} else{
-
+								
 								dels.greater.2bp.summary['5', '4 bp'] <- dels.greater.2bp.summary['5', '4 bp'] + 1
-
+								
 							}
-
+							
 						}else{
-
+							
 							dels.greater.2bp.summary['4', '4 bp'] <- dels.greater.2bp.summary['4', '4 bp'] + 1
-
+							
 						}
-
+						
 					}else{
-
+						
 						dels.greater.2bp.summary['3', '4 bp'] <- dels.greater.2bp.summary['3', '4 bp'] + 1
-
+						
 					}
-
+					
 				}else{
-
+					
 					dels.greater.2bp.summary['2', '4 bp'] <- dels.greater.2bp.summary['2', '4 bp'] + 1
-
+					
 				}
-
+				
 			}else{
-
+				
 				dels.greater.2bp.summary['1 or MH', '4 bp'] <- dels.greater.2bp.summary['1 or MH', '4 bp'] + 1
 				dels.4bp.pot.MH.ind <- c(dels.4bp.pot.MH.ind, i)
-
+				
 			}
-
+			
 		}
 		dels.4bp.pot.MH <- dels.4bp[dels.4bp.pot.MH.ind,,drop=F]
-
+		
 	}
-
+	
 	## 5+ bp
 	if(nrow(dels.5bp) > 0){
-
+		
 		repeat.nts <- str_split_fixed(str_split_fixed(dels.5bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		downstream.context <- str_split_fixed(str_split_fixed(dels.5bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 		dels.5bp.pot.MH.ind <- c()
 		for (i in 1:nrow(dels.5bp)){
-
+			
 			## look at repeat
 			tmp.repeat.nts <- repeat.nts[i]
 			tmp.repeat.length <- nchar(tmp.repeat.nts)
-
+			
 			## how often does it match consecutively in the immediate downstream context?
 			tmp.downstream.context <- downstream.context[i]
 			tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]]
-
+			
 			## group
 			tmp.downstream.context <- c(paste(tmp.downstream.context[c(tmp.repeat.length-c(tmp.repeat.length - 1)):tmp.repeat.length], collapse = ''),
 																	paste(tmp.downstream.context[c(2*tmp.repeat.length-c(tmp.repeat.length - 1)):c(2*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(3*tmp.repeat.length-c(tmp.repeat.length - 1)):c(3*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(4*tmp.repeat.length-c(tmp.repeat.length - 1)):c(4*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(5*tmp.repeat.length-c(tmp.repeat.length - 1)):c(5*tmp.repeat.length)], collapse = ''))
-
+			
 			### check all 6 categories for upstream bases
 			if(tmp.downstream.context[1] %in% tmp.repeat.nts){
-
+				
 				if(tmp.downstream.context[2] %in% tmp.repeat.nts){
-
+					
 					if(tmp.downstream.context[3] %in% tmp.repeat.nts){
-
+						
 						if(tmp.downstream.context[4] %in% tmp.repeat.nts){
-
+							
 							if(tmp.downstream.context[5] %in% tmp.repeat.nts){
-
+								
 								dels.greater.2bp.summary['6+', '5+ bp'] <- dels.greater.2bp.summary['6+', '5+ bp'] + 1
-
+								
 							} else{
-
+								
 								dels.greater.2bp.summary['5', '5+ bp'] <- dels.greater.2bp.summary['5', '5+ bp'] + 1
-
+								
 							}
-
+							
 						}else{
-
+							
 							dels.greater.2bp.summary['4', '5+ bp'] <- dels.greater.2bp.summary['4', '5+ bp'] + 1
-
+							
 						}
-
+						
 					}else{
-
+						
 						dels.greater.2bp.summary['3', '5+ bp'] <- dels.greater.2bp.summary['3', '5+ bp'] + 1
-
+						
 					}
-
+					
 				}else{
-
+					
 					dels.greater.2bp.summary['2', '5+ bp'] <- dels.greater.2bp.summary['2', '5+ bp'] + 1
-
+					
 				}
-
+				
 			}else{
-
+				
 				dels.greater.2bp.summary['1 or MH', '5+ bp'] <- dels.greater.2bp.summary['1 or MH', '5+ bp'] + 1
 				dels.5bp.pot.MH.ind <- c(dels.5bp.pot.MH.ind, i)
-
+				
 			}
-
+			
 		}
-		dels.5bp.pot.MH <- dels.5bp[dels.5bp.pot.MH.ind,,drop=F]
-
+		dels.5bp.pot.MH <- dels.5bp[dels.5bp.pot.MH.ind,,drop=F] 
+		
 	}
-
+	
 	# (v) >=2 bp deletions at microhomologies
 	## go directly into in matrix format, thereby also re-classify repeat length = 1 deletions
 	dels.greater.2bp.MH.summary <- matrix(0, ncol = 4, nrow = 5)
@@ -1251,234 +1198,234 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 	dels.greater.2bp.MH.summary[2:5, '2 bp'] <- NA
 	dels.greater.2bp.MH.summary[3:5, '3 bp'] <- NA
 	dels.greater.2bp.MH.summary[4:5, '4 bp'] <- NA
-
+	
 	## 2 bp
 	if(nrow(dels.2bp) > 0){
-
+		
 		if(nrow(dels.2bp.pot.MH) > 0){
-
+			
 			repeat.nts <- str_split_fixed(str_split_fixed(dels.2bp.pot.MH[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 			upstream.context <- str_split_fixed(dels.2bp.pot.MH[,'CONTEXT'], '\\[', 2)[,1,drop=F]
 			downstream.context <- str_split_fixed(str_split_fixed(dels.2bp.pot.MH[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 			for (i in 1:nrow(dels.2bp.pot.MH)){
-
+				
 				## look at repeat
 				tmp.repeat.nts <- repeat.nts[i]
-
+				
 				## isolate first nucleotide in the immediate upstream context
 				tmp.upstream.context <- upstream.context[i]
 				tmp.upstream.context <- strsplit(tmp.upstream.context, '')[[1]][length(strsplit(tmp.upstream.context, '')[[1]])]
-
+				
 				## isolate first nucleotide in the immediate downstream context
 				tmp.downstream.context <- downstream.context[i]
 				tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]][1]
-
+				
 				if(strsplit(tmp.repeat.nts, '')[[1]][2] == tmp.upstream.context | strsplit(tmp.repeat.nts, '')[[1]][1] == tmp.downstream.context){
-
+					
 					dels.greater.2bp.MH.summary['1 bp MH', '2 bp'] <- dels.greater.2bp.MH.summary['1 bp MH', '2 bp'] + 1
 					dels.greater.2bp.summary['1 or MH', '2 bp'] <- dels.greater.2bp.summary['1 or MH', '2 bp'] - 1
-
+					
 				}
-			}
-
+			} 
+			
 		}
-
+		
 	}
-
+	
 	## 3 bp
 	if(nrow(dels.3bp) > 0){
-
+		
 		if(nrow(dels.3bp.pot.MH) > 0){
-
+			
 			repeat.nts <- str_split_fixed(str_split_fixed(dels.3bp.pot.MH[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 			upstream.context <- str_split_fixed(dels.3bp.pot.MH[,'CONTEXT'], '\\[', 2)[,1,drop=F]
 			downstream.context <- str_split_fixed(str_split_fixed(dels.3bp.pot.MH[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 			for (i in 1:nrow(dels.3bp.pot.MH)){
-
+				
 				## look at repeat
 				tmp.repeat.nts <- repeat.nts[i]
-
+				
 				## isolate first two nucleotides in the immediate upstream context
 				tmp.upstream.context <- upstream.context[i]
 				tmp.upstream.context <- strsplit(tmp.upstream.context, '')[[1]][c(length(strsplit(tmp.upstream.context, '')[[1]]) - 1):length(strsplit(tmp.upstream.context, '')[[1]])]
-
+				
 				## isolate first two nucleotides in the immediate downstream context
 				tmp.downstream.context <- downstream.context[i]
 				tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]][1:2]
-
+				
 				### MH length = 2 (important to start with the highest possible MH length)
-
+				
 				if(all(c(strsplit(tmp.repeat.nts, '')[[1]][2:3] == tmp.upstream.context) == T) | all(c(strsplit(tmp.repeat.nts, '')[[1]][1:2] == tmp.downstream.context) == T)){
-
+					
 					dels.greater.2bp.MH.summary['2 bp MH', '3 bp'] <- dels.greater.2bp.MH.summary['2 bp MH', '3 bp'] + 1
 					dels.greater.2bp.summary['1 or MH', '3 bp'] <- dels.greater.2bp.summary['1 or MH', '3 bp'] - 1
-
+					
 				}else{
-
+					
 					### MH length = 1
-
+					
 					if(strsplit(tmp.repeat.nts, '')[[1]][3] == tmp.upstream.context[2] | strsplit(tmp.repeat.nts, '')[[1]][1] == tmp.downstream.context[1]){
-
+						
 						dels.greater.2bp.MH.summary['1 bp MH', '3 bp'] <- dels.greater.2bp.MH.summary['1 bp MH', '3 bp'] + 1
 						dels.greater.2bp.summary['1 or MH', '3 bp'] <- dels.greater.2bp.summary['1 or MH', '3 bp'] - 1
-
+						
 					}
-
+					
 				}
-
-			}
-
+				
+			} 
+			
 		}
-
+		
 	}
-
+	
 	## 4 bp
 	if(nrow(dels.4bp) > 0){
-
+		
 		if(nrow(dels.4bp.pot.MH) > 0){
-
+			
 			repeat.nts <- str_split_fixed(str_split_fixed(dels.4bp.pot.MH[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 			upstream.context <- str_split_fixed(dels.4bp.pot.MH[,'CONTEXT'], '\\[', 2)[,1,drop=F]
 			downstream.context <- str_split_fixed(str_split_fixed(dels.4bp.pot.MH[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 			for (i in 1:nrow(dels.4bp.pot.MH)){
-
+				
 				## look at repeat
 				tmp.repeat.nts <- repeat.nts[i]
-
+				
 				## isolate first three nucleotides in the immediate upstream context
 				tmp.upstream.context <- upstream.context[i]
 				tmp.upstream.context <- strsplit(tmp.upstream.context, '')[[1]][c(length(strsplit(tmp.upstream.context, '')[[1]]) - 2):length(strsplit(tmp.upstream.context, '')[[1]])]
-
+				
 				## isolate first three nucleotides in the immediate downstream context
 				tmp.downstream.context <- downstream.context[i]
 				tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]][1:3]
-
+				
 				### MH length = 3 (important to start with the highest possible MH length)
-
+				
 				if(all(c(strsplit(tmp.repeat.nts, '')[[1]][2:4] == tmp.upstream.context) == T) | all(c(strsplit(tmp.repeat.nts, '')[[1]][1:3] == tmp.downstream.context) == T)){
-
+					
 					dels.greater.2bp.MH.summary['3 bp MH', '4 bp'] <- dels.greater.2bp.MH.summary['3 bp MH', '4 bp'] + 1
 					dels.greater.2bp.summary['1 or MH', '4 bp'] <- dels.greater.2bp.summary['1 or MH', '4 bp'] - 1
-
+					
 				}else{
-
+					
 					### MH length = 2
-
+					
 					if(all(c(strsplit(tmp.repeat.nts, '')[[1]][3:4] == tmp.upstream.context[2:3]) ==T) | all(c(strsplit(tmp.repeat.nts, '')[[1]][1:2] == tmp.downstream.context[1:2]) == T)){
-
+						
 						dels.greater.2bp.MH.summary['2 bp MH', '4 bp'] <- dels.greater.2bp.MH.summary['2 bp MH', '4 bp'] + 1
 						dels.greater.2bp.summary['1 or MH', '4 bp'] <- dels.greater.2bp.summary['1 or MH', '4 bp'] - 1
-
+						
 					}else{
-
+						
 						### MH length = 1
-
+						
 						if(strsplit(tmp.repeat.nts, '')[[1]][4] == tmp.upstream.context[3] | strsplit(tmp.repeat.nts, '')[[1]][1] == tmp.downstream.context[1]){
-
+							
 							dels.greater.2bp.MH.summary['1 bp MH', '4 bp'] <- dels.greater.2bp.MH.summary['1 bp MH', '4 bp'] + 1
 							dels.greater.2bp.summary['1 or MH', '4 bp'] <- dels.greater.2bp.summary['1 or MH', '4 bp'] - 1
-
+							
 						}
-
+						
 					}
-
+					
 				}
-
-			}
-
+				
+			} 
+			
 		}
-
+		
 	}
-
+	
 	## 5+ bp
 	if(nrow(dels.5bp) > 0){
-
+		
 		if(nrow(dels.5bp.pot.MH) > 0){
-
+			
 			repeat.nts <- str_split_fixed(str_split_fixed(dels.5bp.pot.MH[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 			upstream.context <- str_split_fixed(dels.5bp.pot.MH[,'CONTEXT'], '\\[', 2)[,1,drop=F]
 			downstream.context <- str_split_fixed(str_split_fixed(dels.5bp.pot.MH[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 			for (i in 1:nrow(dels.5bp.pot.MH)){
-
+				
 				## look at repeat
 				tmp.repeat.nts <- repeat.nts[i]
 				tmp.repeat.length <- nchar(tmp.repeat.nts)
-
+				
 				## isolate first X (= repeat length - 1) nucleotides in the immediate upstream context
 				tmp.upstream.context <- upstream.context[i]
 				tmp.upstream.context <- strsplit(tmp.upstream.context, '')[[1]][c(length(strsplit(tmp.upstream.context, '')[[1]]) - 4):length(strsplit(tmp.upstream.context, '')[[1]])]
-
+				
 				## isolate first X (= repeat length - 1) nucleotides in the immediate downstream context
 				tmp.downstream.context <- downstream.context[i]
 				tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]][1:5]
-
+				
 				### MH length = 5+ (important to start with the highest possible MH length); only need to look at first 5 up/downstream NTs
-
+				
 				if(all(c(strsplit(tmp.repeat.nts, '')[[1]][c(tmp.repeat.length-4):tmp.repeat.length] == tmp.upstream.context[c(length(tmp.upstream.context) - 4):length(tmp.upstream.context)]) == T) | all(c(strsplit(tmp.repeat.nts, '')[[1]][1:5] == tmp.downstream.context[1:5]) == T)){
-
+					
 					dels.greater.2bp.MH.summary['5+ bp MH', '5+ bp'] <- dels.greater.2bp.MH.summary['5+ bp MH', '5+ bp'] + 1
 					dels.greater.2bp.summary['1 or MH', '5+ bp'] <- dels.greater.2bp.summary['1 or MH', '5+ bp'] - 1
-
+					
 				}else{
-
+					
 					### MH length = 4
-
+					
 					if(all(c(strsplit(tmp.repeat.nts, '')[[1]][c(tmp.repeat.length-3):tmp.repeat.length] == tmp.upstream.context[c(length(tmp.upstream.context) - 3):length(tmp.upstream.context)]) == T) | all(c(strsplit(tmp.repeat.nts, '')[[1]][1:4] == tmp.downstream.context[1:4]) == T)){
-
+						
 						dels.greater.2bp.MH.summary['4 bp MH', '5+ bp'] <- dels.greater.2bp.MH.summary['4 bp MH', '5+ bp'] + 1
 						dels.greater.2bp.summary['1 or MH', '5+ bp'] <- dels.greater.2bp.summary['1 or MH', '5+ bp'] - 1
-
+						
 					}else{
-
+						
 						### MH length = 3
-
+						
 						if(all(c(strsplit(tmp.repeat.nts, '')[[1]][c(tmp.repeat.length-2):tmp.repeat.length] == tmp.upstream.context[c(length(tmp.upstream.context) - 2):length(tmp.upstream.context)]) == T) | all(c(strsplit(tmp.repeat.nts, '')[[1]][1:3] == tmp.downstream.context[1:3]) == T)){
-
+							
 							dels.greater.2bp.MH.summary['3 bp MH', '5+ bp'] <- dels.greater.2bp.MH.summary['3 bp MH', '5+ bp'] + 1
 							dels.greater.2bp.summary['1 or MH', '5+ bp'] <- dels.greater.2bp.summary['1 or MH', '5+ bp'] - 1
-
+							
 						}else{
-
+							
 							### MH length = 2
-
+							
 							if(all(c(strsplit(tmp.repeat.nts, '')[[1]][c(tmp.repeat.length-1):tmp.repeat.length] == tmp.upstream.context[c(length(tmp.upstream.context) - 1):length(tmp.upstream.context)]) == T) | all(c(strsplit(tmp.repeat.nts, '')[[1]][1:2] == tmp.downstream.context[1:2]) == T)){
-
+								
 								dels.greater.2bp.MH.summary['2 bp MH', '5+ bp'] <- dels.greater.2bp.MH.summary['2 bp MH', '5+ bp'] + 1
 								dels.greater.2bp.summary['1 or MH', '5+ bp'] <- dels.greater.2bp.summary['1 or MH', '5+ bp'] - 1
-
+								
 							}else{
-
+								
 								if(strsplit(tmp.repeat.nts, '')[[1]][tmp.repeat.length] == tmp.upstream.context[length(tmp.upstream.context)] | strsplit(tmp.repeat.nts, '')[[1]][1] == tmp.downstream.context[1]){
-
+									
 									dels.greater.2bp.MH.summary['1 bp MH', '5+ bp'] <- dels.greater.2bp.MH.summary['1 bp MH', '5+ bp'] + 1
 									dels.greater.2bp.summary['1 or MH', '5+ bp'] <- dels.greater.2bp.summary['1 or MH', '5+ bp'] - 1
-
+									
 								}
-
+								
 							}
-
+							
 						}
-
+						
 					}
-
+					
 				}
-
-			}
-
+				
+			} 
+			
 		}
-
+		
 	}
-
+	
 	## after MH cases have been taken out, rename row of deletions at 1-unit repeats in original table
 	rownames(dels.greater.2bp.summary)[1] <- '1'
-
+	
 	## 4. classify >=2 bp insertions into:
-
+	
 	# (i) 2 bp insertions at simple repeats (length 0 == "no neighbouring simple repeat")
 	if(nrow(ins.2bp) > 0){
-
-		ins.2bp.context <- as.character(subseq(x = reference[as.character(ins.2bp[,'CHROM'])],
-																					 start = as.numeric(ins.2bp[,'POS']) - 9,
+		
+		ins.2bp.context <- as.character(subseq(x = reference[as.character(ins.2bp[,'CHROM'])], 
+																					 start = as.numeric(ins.2bp[,'POS']) - 9, 
 																					 end = as.numeric(ins.2bp[,'POS']) + 10))
 		ins.2bp.context.middle <- as.character(ins.2bp[,'ALT'])
 		ins.2bp.context.middle <- paste0('[', str_split_fixed(ins.2bp.context.middle, '', 2)[,2,drop=F], ']')
@@ -1489,15 +1436,15 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 																	 ins.2bp.context.start[,10], sep = '')
 		ins.2bp.context.end <- str_split_fixed(ins.2bp.context, '', 11)[,11,drop=F]
 		ins.2bp[,'TRIPLET'] <- paste(ins.2bp.context.start, ins.2bp.context.middle, ins.2bp.context.end, sep = '')
-		colnames(ins.2bp)[5] <- 'CONTEXT'
-
+		colnames(ins.2bp)[5] <- 'CONTEXT' 
+		
 	}
-
+	
 	# (ii) 3 bp insertions at simple repeats (length 0 == "no neighbouring simple repeat")
 	if(nrow(ins.3bp) > 0){
-
-		ins.3bp.context <- as.character(subseq(x = reference[as.character(ins.3bp[,'CHROM'])],
-																					 start = as.numeric(ins.3bp[,'POS']) - 14,
+		
+		ins.3bp.context <- as.character(subseq(x = reference[as.character(ins.3bp[,'CHROM'])], 
+																					 start = as.numeric(ins.3bp[,'POS']) - 14, 
 																					 end = as.numeric(ins.3bp[,'POS']) + 15))
 		ins.3bp.context.middle <- as.character(ins.3bp[,'ALT'])
 		ins.3bp.context.middle <- paste0('[', str_split_fixed(ins.3bp.context.middle, '', 2)[,2,drop=F], ']')
@@ -1505,19 +1452,19 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 		ins.3bp.context.start <- paste(ins.3bp.context.start[,1], ins.3bp.context.start[,2], ins.3bp.context.start[,3],
 																	 ins.3bp.context.start[,4], ins.3bp.context.start[,5], ins.3bp.context.start[,6],
 																	 ins.3bp.context.start[,7], ins.3bp.context.start[,8], ins.3bp.context.start[,9],
-																	 ins.3bp.context.start[,10], ins.3bp.context.start[,11], ins.3bp.context.start[,12],
+																	 ins.3bp.context.start[,10], ins.3bp.context.start[,11], ins.3bp.context.start[,12], 
 																	 ins.3bp.context.start[,13], ins.3bp.context.start[,14], ins.3bp.context.start[,15], sep = '')
 		ins.3bp.context.end <- str_split_fixed(ins.3bp.context, '', 16)[,16,drop=F]
 		ins.3bp[,'TRIPLET'] <- paste(ins.3bp.context.start, ins.3bp.context.middle, ins.3bp.context.end, sep = '')
-		colnames(ins.3bp)[5] <- 'CONTEXT'
-
+		colnames(ins.3bp)[5] <- 'CONTEXT' 
+		
 	}
-
+	
 	# (iii) 4 bp insertions at simple repeats (length 0 == "no neighbouring simple repeat")
 	if(nrow(ins.4bp) > 0){
-
-		ins.4bp.context <- as.character(subseq(x = reference[as.character(ins.4bp[,'CHROM'])],
-																					 start = as.numeric(ins.4bp[,'POS']) - 19,
+		
+		ins.4bp.context <- as.character(subseq(x = reference[as.character(ins.4bp[,'CHROM'])], 
+																					 start = as.numeric(ins.4bp[,'POS']) - 19, 
 																					 end = as.numeric(ins.4bp[,'POS']) + 20))
 		ins.4bp.context.middle <- as.character(ins.4bp[,'ALT'])
 		ins.4bp.context.middle <- paste0('[', str_split_fixed(ins.4bp.context.middle, '', 2)[,2,drop=F], ']')
@@ -1525,19 +1472,19 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 		ins.4bp.context.start <- paste(ins.4bp.context.start[,1], ins.4bp.context.start[,2], ins.4bp.context.start[,3],
 																	 ins.4bp.context.start[,4], ins.4bp.context.start[,5], ins.4bp.context.start[,6],
 																	 ins.4bp.context.start[,7], ins.4bp.context.start[,8], ins.4bp.context.start[,9],
-																	 ins.4bp.context.start[,10], ins.4bp.context.start[,11], ins.4bp.context.start[,12],
-																	 ins.4bp.context.start[,13], ins.4bp.context.start[,14], ins.4bp.context.start[,15],
-																	 ins.4bp.context.start[,16], ins.4bp.context.start[,17], ins.4bp.context.start[,18],
+																	 ins.4bp.context.start[,10], ins.4bp.context.start[,11], ins.4bp.context.start[,12], 
+																	 ins.4bp.context.start[,13], ins.4bp.context.start[,14], ins.4bp.context.start[,15], 
+																	 ins.4bp.context.start[,16], ins.4bp.context.start[,17], ins.4bp.context.start[,18], 
 																	 ins.4bp.context.start[,19], ins.4bp.context.start[,20], sep = '')
 		ins.4bp.context.end <- str_split_fixed(ins.4bp.context, '', 21)[,21,drop=F]
 		ins.4bp[,'TRIPLET'] <- paste(ins.4bp.context.start, ins.4bp.context.middle, ins.4bp.context.end, sep = '')
-		colnames(ins.4bp)[5] <- 'CONTEXT'
-
+		colnames(ins.4bp)[5] <- 'CONTEXT' 
+		
 	}
-
+	
 	# (iv) 5+ bp insertions at simple repeats (length 0 == "no neighbouring simple repeat")
 	if(nrow(ins.5bp) > 0){
-
+		
 		ins.5bp.context <- as.character(
 			subseq(
 				x = reference[as.character(ins.5bp[,'CHROM'])],
@@ -1545,7 +1492,7 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 				end = as.numeric(ins.5bp[,'POS']) + .flank
 			)
 		)
-
+		
 		# inserted segment and its length
 		ins.5bp.context.middle <- as.character(ins.5bp[,'ALT'])
 		ins.5bp.context.middle <- str_split_fixed(ins.5bp.context.middle, '', 2)[,2,drop=F]
@@ -1561,7 +1508,7 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 			i2 <- .flank
 			ins.5bp.context.start[i] <- paste(s[, i1:i2, drop=FALSE], collapse='')
 		}
-
+		
 		# downstream: take up to 6×repeat-length starting immediately after POS
 		ins.5bp.context.end <- rep(NA, nrow(ins.5bp))
 		for (i in 1:length(ins.5bp.context.end)){
@@ -1571,293 +1518,293 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 			i2 <- min(.flank + (6 * l), 2*.flank) # clamp to available sequence
 			ins.5bp.context.end[i] <- paste(s[, i1:i2, drop=FALSE], collapse='')
 		}
-
+		
 		ins.5bp[,'TRIPLET'] <- paste(ins.5bp.context.start, ins.5bp.context.middle, ins.5bp.context.end, sep = '')
 		colnames(ins.5bp)[5] <- 'CONTEXT'
-
+		
 	}
-
+	
 	## summarise >=2 bp insertions at simple repeats in matrix format
 	ins.greater.2bp.summary <- matrix(0, ncol = 4, nrow = 6)
 	colnames(ins.greater.2bp.summary) <- c('2 bp', '3 bp', '4 bp', '5+ bp') ## insertion size
 	rownames(ins.greater.2bp.summary) <- c('0', '1', '2', '3', '4', '5+') ## number of repeats
-
+	
 	## 2 bp
 	if(nrow(ins.2bp) > 0){
-
+		
 		repeat.nts <- str_split_fixed(str_split_fixed(ins.2bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		downstream.context <- str_split_fixed(str_split_fixed(ins.2bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 		for (i in 1:nrow(ins.2bp)){
-
+			
 			## look at repeat
 			tmp.repeat.nts <- repeat.nts[i]
 			tmp.repeat.length <- nchar(tmp.repeat.nts)
-
+			
 			## how often does it match consecutively in the immediate downstream context?
 			tmp.downstream.context <- downstream.context[i]
 			tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]]
-
+			
 			## group
 			tmp.downstream.context <- c(paste(tmp.downstream.context[c(tmp.repeat.length-c(tmp.repeat.length - 1)):tmp.repeat.length], collapse = ''),
 																	paste(tmp.downstream.context[c(2*tmp.repeat.length-c(tmp.repeat.length - 1)):c(2*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(3*tmp.repeat.length-c(tmp.repeat.length - 1)):c(3*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(4*tmp.repeat.length-c(tmp.repeat.length - 1)):c(4*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(5*tmp.repeat.length-c(tmp.repeat.length - 1)):c(5*tmp.repeat.length)], collapse = ''))
-
+			
 			### check all 6 categories for upstream bases
 			if(tmp.downstream.context[1] %in% tmp.repeat.nts){
-
+				
 				if(tmp.downstream.context[2] %in% tmp.repeat.nts){
-
+					
 					if(tmp.downstream.context[3] %in% tmp.repeat.nts){
-
+						
 						if(tmp.downstream.context[4] %in% tmp.repeat.nts){
-
+							
 							if(tmp.downstream.context[5] %in% tmp.repeat.nts){
-
+								
 								ins.greater.2bp.summary['5+', '2 bp'] <- ins.greater.2bp.summary['5+', '2 bp'] + 1
-
+								
 							} else{
-
+								
 								ins.greater.2bp.summary['4', '2 bp'] <- ins.greater.2bp.summary['4', '2 bp'] + 1
-
+								
 							}
-
+							
 						}else{
-
+							
 							ins.greater.2bp.summary['3', '2 bp'] <- ins.greater.2bp.summary['3', '2 bp'] + 1
-
+							
 						}
-
+						
 					}else{
-
+						
 						ins.greater.2bp.summary['2', '2 bp'] <- ins.greater.2bp.summary['2', '2 bp'] + 1
-
+						
 					}
-
+					
 				}else{
-
+					
 					ins.greater.2bp.summary['1', '2 bp'] <- ins.greater.2bp.summary['1', '2 bp'] + 1
-
+					
 				}
-
+				
 			}else{
-
+				
 				ins.greater.2bp.summary['0', '2 bp'] <- ins.greater.2bp.summary['0', '2 bp'] + 1
-
+				
 			}
-
+			
 		}
-
+		
 	}
-
+	
 	## 3 bp
 	if(nrow(ins.3bp) > 0){
-
+		
 		repeat.nts <- str_split_fixed(str_split_fixed(ins.3bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		downstream.context <- str_split_fixed(str_split_fixed(ins.3bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 		for (i in 1:nrow(ins.3bp)){
-
+			
 			## look at repeat
 			tmp.repeat.nts <- repeat.nts[i]
 			tmp.repeat.length <- nchar(tmp.repeat.nts)
-
+			
 			## how often does it match consecutively in the immediate downstream context?
 			tmp.downstream.context <- downstream.context[i]
 			tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]]
-
+			
 			## group
 			tmp.downstream.context <- c(paste(tmp.downstream.context[c(tmp.repeat.length-c(tmp.repeat.length - 1)):tmp.repeat.length], collapse = ''),
 																	paste(tmp.downstream.context[c(2*tmp.repeat.length-c(tmp.repeat.length - 1)):c(2*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(3*tmp.repeat.length-c(tmp.repeat.length - 1)):c(3*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(4*tmp.repeat.length-c(tmp.repeat.length - 1)):c(4*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(5*tmp.repeat.length-c(tmp.repeat.length - 1)):c(5*tmp.repeat.length)], collapse = ''))
-
+			
 			### check all 6 categories for upstream bases
 			if(tmp.downstream.context[1] %in% tmp.repeat.nts){
-
+				
 				if(tmp.downstream.context[2] %in% tmp.repeat.nts){
-
+					
 					if(tmp.downstream.context[3] %in% tmp.repeat.nts){
-
+						
 						if(tmp.downstream.context[4] %in% tmp.repeat.nts){
-
+							
 							if(tmp.downstream.context[5] %in% tmp.repeat.nts){
-
+								
 								ins.greater.2bp.summary['5+', '3 bp'] <- ins.greater.2bp.summary['5+', '3 bp'] + 1
-
+								
 							} else{
-
+								
 								ins.greater.2bp.summary['4', '3 bp'] <- ins.greater.2bp.summary['4', '3 bp'] + 1
-
+								
 							}
-
+							
 						}else{
-
+							
 							ins.greater.2bp.summary['3', '3 bp'] <- ins.greater.2bp.summary['3', '3 bp'] + 1
-
+							
 						}
-
+						
 					}else{
-
+						
 						ins.greater.2bp.summary['2', '3 bp'] <- ins.greater.2bp.summary['2', '3 bp'] + 1
-
+						
 					}
-
+					
 				}else{
-
+					
 					ins.greater.2bp.summary['1', '3 bp'] <- ins.greater.2bp.summary['1', '3 bp'] + 1
-
+					
 				}
-
+				
 			}else{
-
+				
 				ins.greater.2bp.summary['0', '3 bp'] <- ins.greater.2bp.summary['0', '3 bp'] + 1
-
+				
 			}
-
-		}
-
+			
+		} 
+		
 	}
-
+	
 	## 4 bp
 	if(nrow(ins.4bp) > 0){
-
+		
 		repeat.nts <- str_split_fixed(str_split_fixed(ins.4bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		downstream.context <- str_split_fixed(str_split_fixed(ins.4bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 		for (i in 1:nrow(ins.4bp)){
-
+			
 			## look at repeat
 			tmp.repeat.nts <- repeat.nts[i]
 			tmp.repeat.length <- nchar(tmp.repeat.nts)
-
+			
 			## how often does it match consecutively in the immediate downstream context?
 			tmp.downstream.context <- downstream.context[i]
 			tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]]
-
+			
 			## group
 			tmp.downstream.context <- c(paste(tmp.downstream.context[c(tmp.repeat.length-c(tmp.repeat.length - 1)):tmp.repeat.length], collapse = ''),
 																	paste(tmp.downstream.context[c(2*tmp.repeat.length-c(tmp.repeat.length - 1)):c(2*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(3*tmp.repeat.length-c(tmp.repeat.length - 1)):c(3*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(4*tmp.repeat.length-c(tmp.repeat.length - 1)):c(4*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(5*tmp.repeat.length-c(tmp.repeat.length - 1)):c(5*tmp.repeat.length)], collapse = ''))
-
+			
 			### check all 6 categories for upstream bases
 			if(tmp.downstream.context[1] %in% tmp.repeat.nts){
-
+				
 				if(tmp.downstream.context[2] %in% tmp.repeat.nts){
-
+					
 					if(tmp.downstream.context[3] %in% tmp.repeat.nts){
-
+						
 						if(tmp.downstream.context[4] %in% tmp.repeat.nts){
-
+							
 							if(tmp.downstream.context[5] %in% tmp.repeat.nts){
-
+								
 								ins.greater.2bp.summary['5+', '4 bp'] <- ins.greater.2bp.summary['5+', '4 bp'] + 1
-
+								
 							} else{
-
+								
 								ins.greater.2bp.summary['4', '4 bp'] <- ins.greater.2bp.summary['4', '4 bp'] + 1
-
+								
 							}
-
+							
 						}else{
-
+							
 							ins.greater.2bp.summary['3', '4 bp'] <- ins.greater.2bp.summary['3', '4 bp'] + 1
-
+							
 						}
-
+						
 					}else{
-
+						
 						ins.greater.2bp.summary['2', '4 bp'] <- ins.greater.2bp.summary['2', '4 bp'] + 1
-
+						
 					}
-
+					
 				}else{
-
+					
 					ins.greater.2bp.summary['1', '4 bp'] <- ins.greater.2bp.summary['1', '4 bp'] + 1
-
+					
 				}
-
+				
 			}else{
-
+				
 				ins.greater.2bp.summary['0', '4 bp'] <- ins.greater.2bp.summary['0', '4 bp'] + 1
-
+				
 			}
-
-		}
-
+			
+		} 
+		
 	}
-
+	
 	## 5+ bp
 	if(nrow(ins.5bp) > 0){
-
+		
 		repeat.nts <- str_split_fixed(str_split_fixed(ins.5bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		downstream.context <- str_split_fixed(str_split_fixed(ins.5bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 		for (i in 1:nrow(ins.5bp)){
-
+			
 			## look at repeat
 			tmp.repeat.nts <- repeat.nts[i]
 			tmp.repeat.length <- nchar(tmp.repeat.nts)
-
+			
 			## how often does it match consecutively in the immediate downstream context?
 			tmp.downstream.context <- downstream.context[i]
 			tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]]
-
+			
 			## group
 			tmp.downstream.context <- c(paste(tmp.downstream.context[c(tmp.repeat.length-c(tmp.repeat.length - 1)):tmp.repeat.length], collapse = ''),
 																	paste(tmp.downstream.context[c(2*tmp.repeat.length-c(tmp.repeat.length - 1)):c(2*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(3*tmp.repeat.length-c(tmp.repeat.length - 1)):c(3*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(4*tmp.repeat.length-c(tmp.repeat.length - 1)):c(4*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(5*tmp.repeat.length-c(tmp.repeat.length - 1)):c(5*tmp.repeat.length)], collapse = ''))
-
+			
 			### check all 6 categories for upstream bases
 			if(tmp.downstream.context[1] %in% tmp.repeat.nts){
-
+				
 				if(tmp.downstream.context[2] %in% tmp.repeat.nts){
-
+					
 					if(tmp.downstream.context[3] %in% tmp.repeat.nts){
-
+						
 						if(tmp.downstream.context[4] %in% tmp.repeat.nts){
-
+							
 							if(tmp.downstream.context[5] %in% tmp.repeat.nts){
-
+								
 								ins.greater.2bp.summary['5+', '5+ bp'] <- ins.greater.2bp.summary['5+', '5+ bp'] + 1
-
+								
 							} else{
-
+								
 								ins.greater.2bp.summary['4', '5+ bp'] <- ins.greater.2bp.summary['4', '5+ bp'] + 1
-
+								
 							}
-
+							
 						}else{
-
+							
 							ins.greater.2bp.summary['3', '5+ bp'] <- ins.greater.2bp.summary['3', '5+ bp'] + 1
-
+							
 						}
-
+						
 					}else{
-
+						
 						ins.greater.2bp.summary['2', '5+ bp'] <- ins.greater.2bp.summary['2', '5+ bp'] + 1
-
+						
 					}
-
+					
 				}else{
-
+					
 					ins.greater.2bp.summary['1', '5+ bp'] <- ins.greater.2bp.summary['1', '5+ bp'] + 1
-
+					
 				}
-
+				
 			}else{
-
+				
 				ins.greater.2bp.summary['0', '5+ bp'] <- ins.greater.2bp.summary['0', '5+ bp'] + 1
-
+				
 			}
-
-		}
-
+			
+		} 
+		
 	}
-
+	
 	## 5. summarise outputs as five lists, each featuring one table per major ID category
 	out <- list('1bp del' = dels.1bp.summary,
 							'1bp ins' = ins.1bp.summary,
@@ -1865,33 +1812,33 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 							'>2bp ins' = ins.greater.2bp.summary,
 							'MH dels' = dels.greater.2bp.MH.summary)
 	return(out)
-
+	
 }
 
 #Function to convert indel spectrum produced by indel.spectrum() to sigfit format
 indelspectrum.to.sigfit <- function(indelspectrum){
-
+	
 	#Helpers to convert from indelwald to sigfit labels
 	map_1bp_rep  <- function(x){
 		case_match(x, "0 bp" ~ "0", "1 bp" ~ "1", "2 bp" ~ "2", "3 bp" ~ "3", "4 bp" ~ "4", "5+ bp" ~ "5")
 	}
-
+	
 	map_sz <- function(x){
 		case_match(x, "2 bp" ~ "2", "3 bp" ~ "3", "4 bp" ~ "4", "5+ bp" ~ "5")
 	}
-
+	
 	map_R_del <- function(x){
 		case_match(x, "1" ~ "0", "2" ~ "1", "3" ~ "2", "4" ~ "3", "5" ~ "4", "6+" ~ "5")
 	}
-
+	
 	map_R_ins <- function(x){
 		case_match(x,"0" ~ "0", "1" ~ "1", "2" ~ "2", "3" ~ "3", "4" ~ "4", "5+" ~ "5")
 	}
-
+	
 	map_MH_len <- function(x){
 		case_match(x,"1 bp MH" ~ "1", "2 bp MH" ~ "2", "3 bp MH" ~ "3", "4 bp MH" ~ "4", "5+ bp MH" ~ "5")
 	}
-
+	
 	indelspectrum %>%
 		imap_dfr(function(mat, grp){
 			mat %>%

--- a/bin/sharedFunctions.R
+++ b/bin/sharedFunctions.R
@@ -2,6 +2,68 @@
 ### Custom shared functions
 ######################
 
+#Function to derive the BSgenome package name forged from the configured FASTA
+format_bsgenome_organism <- function(genome_organism){
+	if(is.null(genome_organism) || length(genome_organism) != 1 || is.na(genome_organism) || !nzchar(genome_organism)){
+		stop("ERROR: genome_organism must be specified!", call.=FALSE)
+	}
+
+	genome_organism <- genome_organism %>%
+		as.character %>%
+		gsub(pattern = "^\\s*|\\s*$", replacement = "", x = .) %>%
+		gsub(pattern = "\\s+", replacement = " ", x = .)
+
+	if(!nzchar(genome_organism)){
+		stop("ERROR: genome_organism must be specified!", call.=FALSE)
+	}
+
+	paste0(
+		toupper(substring(genome_organism, 1, 1)),
+		tolower(substring(genome_organism, 2))
+	)
+}
+
+abbreviate_bsgenome_organism <- function(genome_organism){
+	genome_organism <- format_bsgenome_organism(genome_organism)
+	suffix <- sub("^.*[^0-9\\s]([0-9\\s]*)$", "\\1", genome_organism, perl=TRUE)
+	prefix <- substr(genome_organism, 1, nchar(genome_organism) - nchar(suffix))
+	parts <- strsplit(prefix, "\\s+")[[1]]
+	if(length(parts) == 0 || !nzchar(parts[1])){
+		stop("ERROR: genome_organism must contain a non-numeric organism name.", call.=FALSE)
+	}
+
+	if(length(parts) <= 1){
+		abbr_organism <- parts
+	}else{
+		abbr_organism <- paste0(substr(head(parts, 1), 1, 1), tail(parts, 1))
+	}
+
+	paste0(abbr_organism, gsub("\\s", "", suffix))
+}
+
+get_bsgenome_name <- function(yaml.config){
+	if(is.null(yaml.config$genome_fasta) || length(yaml.config$genome_fasta) != 1 || is.na(yaml.config$genome_fasta) || !nzchar(yaml.config$genome_fasta)){
+		stop("ERROR: genome_fasta must be specified!", call.=FALSE)
+	}
+
+	genome_part <- yaml.config$genome_fasta %>%
+		as.character %>%
+		basename %>%
+		gsub(pattern = "[^0-9a-zA-Z.]", replacement = "", x = .)
+
+	if(!nzchar(genome_part)){
+		stop("ERROR: genome_fasta basename must contain at least one letter, number, or dot!", call.=FALSE)
+	}
+
+	bsgenome_name <- paste("BSgenome", abbreviate_bsgenome_organism(yaml.config$genome_organism), "user", genome_part, sep=".")
+
+	if(!grepl("^[A-Za-z][A-Za-z0-9.]*[A-Za-z0-9]$", bsgenome_name)){
+		stop(str_c("ERROR: Derived BSgenome package name is not a valid R package name: ", bsgenome_name), call.=FALSE)
+	}
+
+	bsgenome_name
+}
+
 #Function to load and format VCF
 # regions: optional tibble with columns: seqnames start_refspace end_refspace
 load_vcf <- function(vcf_file, regions = NULL, genome_fasta, BSgenome_name, bcftools_bin){
@@ -20,14 +82,14 @@ load_vcf <- function(vcf_file, regions = NULL, genome_fasta, BSgenome_name, bcft
 		"grep '^##FORMAT=<ID=GT' | wc -l"
 		)
 	 )), intern=TRUE) != "0"
-	
+
 	GQ_exists <- system(paste("/bin/bash -c",shQuote(paste(
 		bcftools_bin,"view -h",
 		vcf_file,"|",
 		"grep '^##FORMAT=<ID=GQ' | wc -l"
 	)
 	)), intern=TRUE) != "0"
-	
+
 	if(!is.null(regions) && nrow(regions) == 0){
 		return(
 			GRanges(
@@ -47,7 +109,7 @@ load_vcf <- function(vcf_file, regions = NULL, genome_fasta, BSgenome_name, bcft
 			)
 		)
 	}
-	
+
 	#Create regions files if specified
 	if(!is.null(regions)){
 		tmpregions <- tempfile(tmpdir=getwd(),pattern=".")
@@ -56,10 +118,10 @@ load_vcf <- function(vcf_file, regions = NULL, genome_fasta, BSgenome_name, bcft
 			distinct %>%
 			write_tsv(tmpregions, col_names=FALSE)
 	}
-	
+
 	#Atomize and split multi-allelic sites (bcftools norm -a -f [fastaref] | bcftools norm -m -both -f [fastaref]), and filter for records containing ALT alleles.
   tmpvcf <- tempfile(tmpdir=getwd(),pattern=".")
-  
+
   system(paste("/bin/bash -c",shQuote(paste(
     bcftools_bin,"view",
     if(!is.null(regions)){paste("-R",tmpregions)},
@@ -71,7 +133,7 @@ load_vcf <- function(vcf_file, regions = NULL, genome_fasta, BSgenome_name, bcft
     tmpvcf
     )
    )))
-  
+
   if(!is.null(regions)){
   	file.remove(tmpregions) %>% invisible
   }
@@ -84,10 +146,10 @@ load_vcf <- function(vcf_file, regions = NULL, genome_fasta, BSgenome_name, bcft
    #For deletions, change to: REF = deleted bases and ALT = "". For insertions, change to: REF = "" and ALT = inserted bases
    #Keep only columns CHROM, POS, REF, ALT, QUAL, FILTER, GT (if exists), GQ (if exists).
    #Convert to GRanges
-  
+
   vcf <- read.vcfR(tmpvcf,convertNA=FALSE,verbose=FALSE)
   file.remove(tmpvcf) %>% invisible
-  
+
   vcf <- vcf@fix %>%
   	as_tibble %>%
   	mutate(
@@ -171,7 +233,7 @@ GRanges_subtract <- function(x, y, ignore.strand=FALSE){
 	mcols(unlisted_ans) <- extractROWS(mcols(x),Rle(seq_along(ans), lengths(ans)))
 	unlist(setNames(relist(unlisted_ans, ans), names(x)))
 }
-	
+
 # Function to subtract two granges (x and y) from each other, if they match on join_mcols (character vector of all columns to match), without reducing overlaps in the final output.
 GRanges_subtract_bymcols <- function(x, y, join_mcols, ignore.strand = FALSE){
   #Encode join keys as a factor
@@ -180,49 +242,49 @@ GRanges_subtract_bymcols <- function(x, y, join_mcols, ignore.strand = FALSE){
     select(all_of(join_mcols)) %>%
     as.list %>%
     interaction(drop = TRUE)
-  
+
   key_y <- y %>%
     as_tibble %>%
     select(all_of(join_mcols)) %>%
     as.list %>%
     interaction(drop = TRUE)
-  
+
   keys_all <- factor(c(key_x,key_y))
   id_x <- as.integer(keys_all)[seq_along(x)]
   id_y <- as.integer(keys_all)[length(x) + seq_along(y)]
-  
+
   #Change seqnames to contain key
   x2 <- GRanges(
   	seqnames = str_c(as.character(seqnames(x)), "|", id_x),
   	ranges = ranges(x),
   	strand = strand(x)
   )
-  
+
   y2 <- GRanges(
   	seqnames = str_c(as.character(seqnames(y)), "|", id_y),
   	ranges = ranges(y),
   	strand = strand(y)
   ) %>%
   	GNCList
-  
+
   #Find all overlaps
   hits <- findOverlaps(x2, y2, ignore.strand = ignore.strand) %>%
   	suppressWarnings #Hide warning about unshared seqlevels between x2 and y2
-  
+
   if(length(hits) == 0){return(x)}
-  
+
   #Obtain intersecting segments for matched hits
   qh <- queryHits(hits)
   sh <- subjectHits(hits)
-  
+
   segs_to_remove <- pintersect(x[qh], y[sh], ignore.strand = ignore.strand)
-  
+
   #Split segs_to_remove by the index of x
   rem_list <- split(segs_to_remove, factor(qh, levels = seq_along(x)), drop = FALSE)
-  
+
   #Subtract for each range in x (x_list) the ranges in y (rem_list) that intersect it
   out_list <- psetdiff(x, rem_list, ignore.strand = ignore.strand)
-  
+
   #Flatten result and restore all metadata from the original x
    #How many fragments came from each original x[i]
   nfrags <- elementNROWS(out_list)
@@ -232,7 +294,7 @@ GRanges_subtract_bymcols <- function(x, y, join_mcols, ignore.strand = FALSE){
   src_idx  <- rep(seq_along(nfrags), times = nfrags)
    #Re‐attach metadata columns
   mcols(out) <- mcols(x)[src_idx, , drop = FALSE]
-  
+
   return(out)
 }
 
@@ -269,43 +331,43 @@ trinucleotides_64to32 <- function(x, tri_column, count_column){
 
 #Function to re-anchor indels from HiDEF-seq calls to the style of VCF format so that ref_plus_strand and alt_plus_strand contain the base preceding the indel
 normalize_indels_for_vcf <- function(df, BSgenome_name){
-	
+
 	#Identify deletions and insertions
 	# insertions: ref_plus_strand == ""; alt_plus_strand = inserted bases
 	# deletions: ref_plus_strand = deleted bases; alt_plus_strand == ""
 	ins <- !nzchar(df$ref_plus_strand) & nzchar(df$alt_plus_strand)
 	del <- nzchar(df$ref_plus_strand) & !nzchar(df$alt_plus_strand)
 	ins_or_del <- ins | del
-	
+
 	#Normalize start position of insertions and deletions to start = start - 1, and extract sequence of the new start position
 	if(any(ins_or_del)){
 		df$start[ins_or_del] <- df$start[ins_or_del] - 1
-		
+
 		gr <- GRanges(
 			df$seqnames[ins_or_del],
 			IRanges(df$start[ins_or_del],	width = 1),
 			seqinfo = BSgenome_name %>% get %>% seqinfo
 		)
-		
+
 		start_base_ref <- df %>% nrow %>% character
 		start_base_ref[ins_or_del] <- getSeq(BSgenome_name %>% get, gr) %>% as.character
 	}
-	
+
 	#Normalize insertion sequences: ref_plus_strand = new start position base; alt_plus_strand = new start position base + inserted bases
 	if(any(ins)){
 		df$ref_plus_strand[ins] <- start_base_ref[ins]
 		df$alt_plus_strand[ins] <- str_c(start_base_ref[ins], df$alt_plus_strand[ins])
 	}
-	
+
 	#Normalize deletion sequences: ref_plus_strand = new start position base + deleted bases; alt_plus_strand = new start position base
 	if(any(del)){
 		df$ref_plus_strand[del] <- str_c(start_base_ref[del], df$ref_plus_strand[del])
 		df$alt_plus_strand[del] <- start_base_ref[del]
 	}
-	
+
 	#Remove 'end' column that is not needed for vcf, to avoid confusion
 	df$end <- NULL
-	
+
 	return(df)
 }
 
@@ -313,53 +375,53 @@ normalize_indels_for_vcf <- function(df, BSgenome_name){
 ## Max Stammnitz; maxrupsta@gmail.com; University of Cambridge  ##
 ## Citation: The evolution of two transmissible cancers in Tasmanian devils (Stammnitz et al. 2023, Science 380:6642)
 indel.spectrum <- function(x, reference, context_bp = 1000){
-	
+
 	# context_bp: total number of bp extracted around ≥5 bp events (flank on each side ~ context_bp/2)
 	.flank <- as.integer(context_bp / 2L)  # symmetric flank size used in ≥5 bp sections
-	
+
 	## 1. split VCF indels into:
 	# (i) 1-bp deletions
 	dels.1bp <- x[nchar(as.character(x[,'ALT'])) == nchar(as.character(x[,'REF']))-1,,drop=F]
-	
+
 	# (ii) 1-bp insertions
 	ins.1bp <- x[nchar(as.character(x[,'REF'])) == nchar(as.character(x[,'ALT']))-1,,drop=F]
-	
+
 	# (iii) >1 bp deletions
-	
+
 	## 2
 	dels.2bp <- x[nchar(as.character(x[,'ALT'])) == nchar(as.character(x[,'REF']))-2,,drop=F]
-	
+
 	## 3
 	dels.3bp <- x[nchar(as.character(x[,'ALT'])) == nchar(as.character(x[,'REF']))-3,,drop=F]
-	
+
 	## 4
 	dels.4bp <- x[nchar(as.character(x[,'ALT'])) == nchar(as.character(x[,'REF']))-4,,drop=F]
-	
+
 	## 5+
 	dels.5bp <- x[nchar(as.character(x[,'ALT'])) <= nchar(as.character(x[,'REF']))-5,,drop=F]
-	
+
 	# (iv) >1 bp insertions
-	
+
 	## 2
 	ins.2bp <- x[nchar(as.character(x[,'REF'])) == nchar(as.character(x[,'ALT']))-2,,drop=F]
-	
+
 	## 3
 	ins.3bp <- x[nchar(as.character(x[,'REF'])) == nchar(as.character(x[,'ALT']))-3,,drop=F]
-	
+
 	## 4
 	ins.4bp <- x[nchar(as.character(x[,'REF'])) == nchar(as.character(x[,'ALT']))-4,,drop=F]
-	
+
 	## 5+
 	ins.5bp <- x[nchar(as.character(x[,'REF'])) <= nchar(as.character(x[,'ALT']))-5,,drop=F]
-	
+
 	## 2. classify 1 bp events into:
-	
+
 	# (i) 1 bp deletions at homopolymers (length 1 == "no neighbouring homopolymers")
 	if(nrow(dels.1bp) > 0){
-		
+
 		## extract 10 bp upstream/downstream sequence context from reference
-		dels.1bp.context <- as.character(subseq(x = reference[as.character(dels.1bp[,'CHROM'])], 
-																						start = as.numeric(dels.1bp[,'POS']) - 9, 
+		dels.1bp.context <- as.character(subseq(x = reference[as.character(dels.1bp[,'CHROM'])],
+																						start = as.numeric(dels.1bp[,'POS']) - 9,
 																						end = as.numeric(dels.1bp[,'POS']) + 11))
 		dels.1bp.context.middle <- paste0('[', str_split_fixed(dels.1bp.context, '', 21)[,11,drop=F], ']')
 		dels.1bp.context.start <- str_split_fixed(dels.1bp.context, '', 11)[,1:10,drop=F]
@@ -369,11 +431,11 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 																		dels.1bp.context.start[,10], sep = '')
 		dels.1bp.context.end <- str_split_fixed(dels.1bp.context, '', 12)[,12,drop=F]
 		dels.1bp[,'TRIPLET'] <- paste(dels.1bp.context.start, dels.1bp.context.middle, dels.1bp.context.end, sep = '')
-		colnames(dels.1bp)[5] <- 'CONTEXT FW' 
-		
+		colnames(dels.1bp)[5] <- 'CONTEXT FW'
+
 		## need the central base to be pyrimidine-centred, i.e. C or T, hence also run reverseComplements on full contexts
-		dels.1bp.context.rc <- as.character(reverseComplement(subseq(x = reference[as.character(dels.1bp[,'CHROM'])], 
-																																 start = as.numeric(dels.1bp[,'POS']) - 9, 
+		dels.1bp.context.rc <- as.character(reverseComplement(subseq(x = reference[as.character(dels.1bp[,'CHROM'])],
+																																 start = as.numeric(dels.1bp[,'POS']) - 9,
 																																 end = as.numeric(dels.1bp[,'POS']) + 11)))
 		dels.1bp.context.rc.middle <- paste0('[', str_split_fixed(dels.1bp.context.rc, '', 21)[,11,drop=F], ']')
 		dels.1bp.context.rc.start <- str_split_fixed(dels.1bp.context.rc, '', 11)[,1:10,drop=F]
@@ -384,7 +446,7 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 		dels.1bp.context.rc.end <- str_split_fixed(dels.1bp.context.rc, '', 12)[,12,drop=F]
 		dels.1bp <- cbind(dels.1bp[,1:5,drop=F], paste(dels.1bp.context.rc.start, dels.1bp.context.rc.middle, dels.1bp.context.rc.end, sep = ''))
 		colnames(dels.1bp)[6] <- 'CONTEXT RC'
-		
+
 		## summarise 1 bp deletions in matrix format
 		dels.1bp.summary <- matrix(0, ncol = 2, nrow = 6)
 		colnames(dels.1bp.summary) <- c('C', 'T') ## pyrimidine-centred deleted base
@@ -393,181 +455,181 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 		rc <- str_split_fixed(str_split_fixed(dels.1bp[,'CONTEXT RC'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		fw.if <- fw == 'C' | fw == 'T'
 		for (i in 1:nrow(dels.1bp)){
-			
+
 			if(fw.if[i] == T){
-				
+
 				## look at forward context
 				upstream.tmp <- str_split_fixed(str_split_fixed(as.character(dels.1bp[i,'CONTEXT FW']), '\\[', 2)[,1], '', 10)
 				upstream.tmp <- which(upstream.tmp == fw[i])
-				
+
 				### check all 6 categories for upstream bases
 				if(any(upstream.tmp %in% 10)){
-					
+
 					if(any(upstream.tmp %in% 9)){
-						
+
 						if(any(upstream.tmp %in% 8)){
-							
+
 							if(any(upstream.tmp %in% 7)){
-								
+
 								if(any(upstream.tmp %in% 6)){
-									
+
 									upstream.tmp <- 6
-									
+
 								}else{
 									upstream.tmp <- 5
 								}
-								
+
 							}else{
 								upstream.tmp <- 4
 							}
-							
+
 						}else{
 							upstream.tmp <- 3
 						}
-						
+
 					}else{
 						upstream.tmp <- 2
 					}
-					
+
 				}else{
 					upstream.tmp <- 1
 				}
-				
+
 				downstream.tmp <- str_split_fixed(str_split_fixed(as.character(dels.1bp[i,'CONTEXT FW']), '\\]', 2)[,2], '', 10)
 				downstream.tmp <- which(downstream.tmp == fw[i])
-				
+
 				### check all 6 categories for downstream bases
 				if(any(downstream.tmp %in% 1)){
-					
+
 					if(any(downstream.tmp %in% 2)){
-						
+
 						if(any(downstream.tmp %in% 3)){
-							
+
 							if(any(downstream.tmp %in% 4)){
-								
+
 								if(any(downstream.tmp %in% 5)){
-									
+
 									downstream.tmp <- 6
-									
+
 								}else{
 									downstream.tmp <- 5
 								}
-								
+
 							}else{
 								downstream.tmp <- 4
 							}
-							
+
 						}else{
 							downstream.tmp <- 3
 						}
-						
+
 					}else{
 						downstream.tmp <- 2
 					}
-					
+
 				}else{
 					downstream.tmp <- 1
 				}
-				
+
 				## summarise, which homopolymer (upstream vs. downstream context) is longer
 				dels.1bp.summary[max(c(upstream.tmp, downstream.tmp)),fw[i]] <- dels.1bp.summary[max(c(upstream.tmp, downstream.tmp)),fw[i]] + 1
-				
+
 			} else {
-				
+
 				## look at reverse complement context
 				upstream.tmp <- str_split_fixed(str_split_fixed(as.character(dels.1bp[i,'CONTEXT RC']), '\\[', 2)[,1], '', 10)
 				upstream.tmp <- which(upstream.tmp == rc[i])
-				
+
 				### check all 6 categories for upstream bases
 				if(any(upstream.tmp %in% 10)){
-					
+
 					if(any(upstream.tmp %in% 9)){
-						
+
 						if(any(upstream.tmp %in% 8)){
-							
+
 							if(any(upstream.tmp %in% 7)){
-								
+
 								if(any(upstream.tmp %in% 6)){
-									
+
 									upstream.tmp <- 6
-									
+
 								}else{
 									upstream.tmp <- 5
 								}
-								
+
 							}else{
 								upstream.tmp <- 4
 							}
-							
+
 						}else{
 							upstream.tmp <- 3
 						}
-						
+
 					}else{
 						upstream.tmp <- 2
 					}
-					
+
 				}else{
 					upstream.tmp <- 1
 				}
-				
+
 				downstream.tmp <- str_split_fixed(str_split_fixed(as.character(dels.1bp[i,'CONTEXT RC']), '\\]', 2)[,2], '', 10)
 				downstream.tmp <- which(downstream.tmp == rc[i])
-				
+
 				### check all 6 categories for downstream bases
 				if(any(downstream.tmp %in% 1)){
-					
+
 					if(any(downstream.tmp %in% 2)){
-						
+
 						if(any(downstream.tmp %in% 3)){
-							
+
 							if(any(downstream.tmp %in% 4)){
-								
+
 								if(any(downstream.tmp %in% 5)){
-									
+
 									downstream.tmp <- 6
-									
+
 								}else{
 									downstream.tmp <- 5
 								}
-								
+
 							}else{
 								downstream.tmp <- 4
 							}
-							
+
 						}else{
 							downstream.tmp <- 3
 						}
-						
+
 					}else{
 						downstream.tmp <- 2
 					}
-					
+
 				}else{
 					downstream.tmp <- 1
 				}
-				
+
 				## summarise, which homopolymer (upstream vs. downstream context) is longer
 				dels.1bp.summary[max(c(upstream.tmp, downstream.tmp)),rc[i]] <- dels.1bp.summary[max(c(upstream.tmp, downstream.tmp)),rc[i]] + 1
 			}
-			
+
 		}
-		
+
 	}else{
-		
+
 		## summarise 1 bp deletions in matrix format
 		dels.1bp.summary <- matrix(0, ncol = 2, nrow = 6)
 		colnames(dels.1bp.summary) <- c('C', 'T') ## pyrimidine-centred deleted base
 		rownames(dels.1bp.summary) <- c('0 bp', '1 bp', '2 bp', '3 bp', '4 bp', '5+ bp') ## contextual homopolymer-length
-		
+
 	}
-	
+
 	# (ii) 1 bp insertions at homopolymers (length 0 == "no neighbouring homopolymers")
 	if(nrow(ins.1bp) > 0){
-		
+
 		## extract 10 bp upstream/downstream sequence context from reference
-		ins.1bp.context <- as.character(subseq(x = reference[as.character(ins.1bp[,'CHROM'])], 
-																					 start = as.numeric(ins.1bp[,'POS']) - 9, 
+		ins.1bp.context <- as.character(subseq(x = reference[as.character(ins.1bp[,'CHROM'])],
+																					 start = as.numeric(ins.1bp[,'POS']) - 9,
 																					 end = as.numeric(ins.1bp[,'POS']) + 10))
 		## insertion after base pos. 10
 		ins.1bp.context.middle <- paste0('[', str_split_fixed(as.character(ins.1bp[,'ALT']), '', 2)[,2,drop=F], ']')
@@ -579,10 +641,10 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 		ins.1bp.context.end <- str_split_fixed(ins.1bp.context, '', 11)[,11,drop=F]
 		ins.1bp[,'TRIPLET'] <- paste(ins.1bp.context.start, ins.1bp.context.middle, ins.1bp.context.end, sep = '')
 		colnames(ins.1bp)[5] <- 'CONTEXT FW'
-		
+
 		## need the central base to be pyrimidine-centred, i.e. C or T, hence also run reverseComplements on full contexts
-		ins.1bp.context.rc <- as.character(reverseComplement(subseq(x = reference[as.character(ins.1bp[,'CHROM'])], 
-																																start = as.numeric(ins.1bp[,'POS']) - 9, 
+		ins.1bp.context.rc <- as.character(reverseComplement(subseq(x = reference[as.character(ins.1bp[,'CHROM'])],
+																																start = as.numeric(ins.1bp[,'POS']) - 9,
 																																end = as.numeric(ins.1bp[,'POS']) + 10)))
 		ins.1bp.context.rc.middle <- paste0('[', as.character(reverseComplement(DNAStringSet(str_split_fixed(as.character(ins.1bp[,'ALT']), '', 2)[,2,drop=F]))), ']')
 		ins.1bp.context.rc.start <- str_split_fixed(ins.1bp.context.rc, '', 11)[,1:10,drop=F]
@@ -593,7 +655,7 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 		ins.1bp.context.rc.end <- str_split_fixed(ins.1bp.context.rc, '', 11)[,11,drop=F]
 		ins.1bp <- cbind(ins.1bp[,1:5,drop=F], paste(ins.1bp.context.rc.start, ins.1bp.context.rc.middle, ins.1bp.context.rc.end, sep = ''))
 		colnames(ins.1bp)[6] <- 'CONTEXT RC'
-		
+
 		## summarise 1 bp insertions in matrix format
 		ins.1bp.summary <- matrix(0, ncol = 2, nrow = 6)
 		colnames(ins.1bp.summary) <- c('C', 'T') ## pyrimidine-centred inserted base
@@ -602,183 +664,183 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 		rc <- str_split_fixed(str_split_fixed(ins.1bp[,'CONTEXT RC'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		fw.if <- fw == 'C' | fw == 'T'
 		for (i in 1:nrow(ins.1bp)){
-			
+
 			if(fw.if[i] == T){
-				
+
 				## look at forward context
 				upstream.tmp <- str_split_fixed(str_split_fixed(as.character(ins.1bp[i,'CONTEXT FW']), '\\[', 2)[,1], '', 10)
 				upstream.tmp <- which(upstream.tmp == fw[i])
-				
+
 				### check all 6 categories for upstream bases
 				if(any(upstream.tmp %in% 10)){
-					
+
 					if(any(upstream.tmp %in% 9)){
-						
+
 						if(any(upstream.tmp %in% 8)){
-							
+
 							if(any(upstream.tmp %in% 7)){
-								
+
 								if(any(upstream.tmp %in% 6)){
-									
+
 									upstream.tmp <- 6
-									
+
 								}else{
 									upstream.tmp <- 5
 								}
-								
+
 							}else{
 								upstream.tmp <- 4
 							}
-							
+
 						}else{
 							upstream.tmp <- 3
 						}
-						
+
 					}else{
 						upstream.tmp <- 2
 					}
-					
+
 				}else{
 					upstream.tmp <- 1
 				}
-				
+
 				downstream.tmp <- str_split_fixed(str_split_fixed(as.character(ins.1bp[i,'CONTEXT FW']), '\\]', 2)[,2], '', 10)
 				downstream.tmp <- which(downstream.tmp == fw[i])
-				
+
 				### check all 6 categories for downstream bases
 				if(any(downstream.tmp %in% 1)){
-					
+
 					if(any(downstream.tmp %in% 2)){
-						
+
 						if(any(downstream.tmp %in% 3)){
-							
+
 							if(any(downstream.tmp %in% 4)){
-								
+
 								if(any(downstream.tmp %in% 5)){
-									
+
 									downstream.tmp <- 6
-									
+
 								}else{
 									downstream.tmp <- 5
 								}
-								
+
 							}else{
 								downstream.tmp <- 4
 							}
-							
+
 						}else{
 							downstream.tmp <- 3
 						}
-						
+
 					}else{
 						downstream.tmp <- 2
 					}
-					
+
 				}else{
 					downstream.tmp <- 1
 				}
-				
+
 				## summarise, which homopolymer is longer
 				ins.1bp.summary[max(c(upstream.tmp, downstream.tmp)),fw[i]] <- ins.1bp.summary[max(c(upstream.tmp, downstream.tmp)),fw[i]] + 1
-				
+
 			} else {
-				
+
 				## look at reverse complement context
 				upstream.tmp <- str_split_fixed(str_split_fixed(as.character(ins.1bp[i,'CONTEXT RC']), '\\[', 2)[,1], '', 10)
 				upstream.tmp <- which(upstream.tmp == rc[i])
-				
+
 				### check all 6 categories for upstream bases
 				if(any(upstream.tmp %in% 10)){
-					
+
 					if(any(upstream.tmp %in% 9)){
-						
+
 						if(any(upstream.tmp %in% 8)){
-							
+
 							if(any(upstream.tmp %in% 7)){
-								
+
 								if(any(upstream.tmp %in% 6)){
-									
+
 									upstream.tmp <- 6
-									
+
 								}else{
 									upstream.tmp <- 5
 								}
-								
+
 							}else{
 								upstream.tmp <- 4
 							}
-							
+
 						}else{
 							upstream.tmp <- 3
 						}
-						
+
 					}else{
 						upstream.tmp <- 2
 					}
-					
+
 				}else{
 					upstream.tmp <- 1
 				}
-				
+
 				downstream.tmp <- str_split_fixed(str_split_fixed(as.character(ins.1bp[i,'CONTEXT RC']), '\\]', 2)[,2], '', 10)
 				downstream.tmp <- which(downstream.tmp == rc[i])
-				
+
 				### check all 6 categories for downstream bases
 				if(any(downstream.tmp %in% 1)){
-					
+
 					if(any(downstream.tmp %in% 2)){
-						
+
 						if(any(downstream.tmp %in% 3)){
-							
+
 							if(any(downstream.tmp %in% 4)){
-								
+
 								if(any(downstream.tmp %in% 5)){
-									
+
 									downstream.tmp <- 6
-									
+
 								}else{
 									downstream.tmp <- 5
 								}
-								
+
 							}else{
 								downstream.tmp <- 4
 							}
-							
+
 						}else{
 							downstream.tmp <- 3
 						}
-						
+
 					}else{
 						downstream.tmp <- 2
 					}
-					
+
 				}else{
 					downstream.tmp <- 1
 				}
-				
+
 				## summarise, which homopolymer is longer
 				ins.1bp.summary[max(c(upstream.tmp, downstream.tmp)),rc[i]] <- ins.1bp.summary[max(c(upstream.tmp, downstream.tmp)),rc[i]] + 1
 			}
-			
-		} 
-		
+
+		}
+
 	}else{
-		
+
 		## summarise 1 bp insertions in matrix format
 		ins.1bp.summary <- matrix(0, ncol = 2, nrow = 6)
 		colnames(ins.1bp.summary) <- c('C', 'T') ## pyrimidine-centred inserted base
 		rownames(ins.1bp.summary) <- c('0 bp', '1 bp', '2 bp', '3 bp', '4 bp', '5+ bp') ## contextual homopolymer-length
-		
+
 	}
-	
+
 	## 3. classify >=2 bp deletions into:
-	
+
 	# (i) 2 bp deletions at simple repeats (length 1 == "no neighbouring simple repeat")
 	if(nrow(dels.2bp) > 0){
-		
+
 		## extract 5 x 2 bp upstream/downstream sequence context from reference
-		dels.2bp.context <- as.character(subseq(x = reference[as.character(dels.2bp[,'CHROM'])], 
-																						start = as.numeric(dels.2bp[,'POS']) - 9, 
+		dels.2bp.context <- as.character(subseq(x = reference[as.character(dels.2bp[,'CHROM'])],
+																						start = as.numeric(dels.2bp[,'POS']) - 9,
 																						end = as.numeric(dels.2bp[,'POS']) + 2 + 10))
 		dels.2bp.context.middle <- str_split_fixed(dels.2bp.context, '', 22)[,11:12,drop=F]
 		dels.2bp.context.middle <- paste0('[', dels.2bp.context.middle[,1], dels.2bp.context.middle[,2], ']')
@@ -789,16 +851,16 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 																		dels.2bp.context.start[,10], sep = '')
 		dels.2bp.context.end <- str_split_fixed(dels.2bp.context, '', 13)[,13,drop=F]
 		dels.2bp[,'TRIPLET'] <- paste(dels.2bp.context.start, dels.2bp.context.middle, dels.2bp.context.end, sep = '')
-		colnames(dels.2bp)[5] <- 'CONTEXT' 
-		
+		colnames(dels.2bp)[5] <- 'CONTEXT'
+
 	}
-	
+
 	# (ii) 3 bp deletions at simple repeats (length 1 == "no neighbouring simple repeat")
 	if(nrow(dels.3bp) > 0){
-		
+
 		## extract 5 x 3 bp upstream/downstream sequence context from reference
-		dels.3bp.context <- as.character(subseq(x = reference[as.character(dels.3bp[,'CHROM'])], 
-																						start = as.numeric(dels.3bp[,'POS']) - 14, 
+		dels.3bp.context <- as.character(subseq(x = reference[as.character(dels.3bp[,'CHROM'])],
+																						start = as.numeric(dels.3bp[,'POS']) - 14,
 																						end = as.numeric(dels.3bp[,'POS']) + 3 + 15))
 		dels.3bp.context.middle <- str_split_fixed(dels.3bp.context, '', 33)[,16:18,drop=F]
 		dels.3bp.context.middle <- paste0('[', dels.3bp.context.middle[,1], dels.3bp.context.middle[,2], dels.3bp.context.middle[,3], ']')
@@ -806,46 +868,46 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 		dels.3bp.context.start <- paste(dels.3bp.context.start[,1], dels.3bp.context.start[,2], dels.3bp.context.start[,3],
 																		dels.3bp.context.start[,4], dels.3bp.context.start[,5], dels.3bp.context.start[,6],
 																		dels.3bp.context.start[,7], dels.3bp.context.start[,8], dels.3bp.context.start[,9],
-																		dels.3bp.context.start[,10], dels.3bp.context.start[,11], dels.3bp.context.start[,12], 
+																		dels.3bp.context.start[,10], dels.3bp.context.start[,11], dels.3bp.context.start[,12],
 																		dels.3bp.context.start[,13], dels.3bp.context.start[,14], dels.3bp.context.start[,15], sep = '')
 		dels.3bp.context.end <- str_split_fixed(dels.3bp.context, '', 19)[,19,drop=F]
 		dels.3bp[,'TRIPLET'] <- paste(dels.3bp.context.start, dels.3bp.context.middle, dels.3bp.context.end, sep = '')
-		colnames(dels.3bp)[5] <- 'CONTEXT' 
-		
+		colnames(dels.3bp)[5] <- 'CONTEXT'
+
 	}
-	
+
 	# (iii) 4 bp deletions at simple repeats (length 1 == "no neighbouring simple repeat")
 	if(nrow(dels.4bp) > 0){
-		
+
 		## extract 5 x 4 bp upstream/downstream sequence context from reference
-		dels.4bp.context <- as.character(subseq(x = reference[as.character(dels.4bp[,'CHROM'])], 
-																						start = as.numeric(dels.4bp[,'POS']) - 19, 
+		dels.4bp.context <- as.character(subseq(x = reference[as.character(dels.4bp[,'CHROM'])],
+																						start = as.numeric(dels.4bp[,'POS']) - 19,
 																						end = as.numeric(dels.4bp[,'POS']) + 4 + 20))
 		dels.4bp.context.middle <- str_split_fixed(dels.4bp.context, '', 41)[,21:24,drop=F]
-		dels.4bp.context.middle <- paste0('[', dels.4bp.context.middle[,1], 
-																			dels.4bp.context.middle[,2], 
-																			dels.4bp.context.middle[,3], 
+		dels.4bp.context.middle <- paste0('[', dels.4bp.context.middle[,1],
+																			dels.4bp.context.middle[,2],
+																			dels.4bp.context.middle[,3],
 																			dels.4bp.context.middle[,4], ']')
 		dels.4bp.context.start <- str_split_fixed(dels.4bp.context, '', 21)[,1:20,drop=F]
 		dels.4bp.context.start <- paste(dels.4bp.context.start[,1], dels.4bp.context.start[,2], dels.4bp.context.start[,3],
 																		dels.4bp.context.start[,4], dels.4bp.context.start[,5], dels.4bp.context.start[,6],
 																		dels.4bp.context.start[,7], dels.4bp.context.start[,8], dels.4bp.context.start[,9],
-																		dels.4bp.context.start[,10], dels.4bp.context.start[,11], dels.4bp.context.start[,12], 
-																		dels.4bp.context.start[,13], dels.4bp.context.start[,14], dels.4bp.context.start[,15], 
-																		dels.4bp.context.start[,16], dels.4bp.context.start[,17], dels.4bp.context.start[,18], 
+																		dels.4bp.context.start[,10], dels.4bp.context.start[,11], dels.4bp.context.start[,12],
+																		dels.4bp.context.start[,13], dels.4bp.context.start[,14], dels.4bp.context.start[,15],
+																		dels.4bp.context.start[,16], dels.4bp.context.start[,17], dels.4bp.context.start[,18],
 																		dels.4bp.context.start[,19], dels.4bp.context.start[,20], sep = '')
 		dels.4bp.context.end <- str_split_fixed(dels.4bp.context, '', 25)[,25,drop=F]
 		dels.4bp[,'TRIPLET'] <- paste(dels.4bp.context.start, dels.4bp.context.middle, dels.4bp.context.end, sep = '')
-		colnames(dels.4bp)[5] <- 'CONTEXT' 
-		
+		colnames(dels.4bp)[5] <- 'CONTEXT'
+
 	}
-	
+
 	# (iv) 5+ bp deletions at simple repeats (length 1 == "no neighbouring simple repeat")
 	if(nrow(dels.5bp) > 0){
-		
+
 		# lengths of the deleted segments
 		dels.5bp.context.middle.lengths <- nchar(as.character(dels.5bp[,'REF'])) - 1
-		
+
 		# extract symmetric upstream/downstream flanks sized by context_bp and extend end by deletion length
 		dels.5bp.context <- as.character(
 			subseq(
@@ -854,12 +916,12 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 				end = as.numeric(dels.5bp[,'POS']) + dels.5bp.context.middle.lengths + .flank
 				)
 			)
-		
+
 		# build [deleted] middle
 		dels.5bp.context.middle <- as.character(dels.5bp[,'REF'])
 		dels.5bp.context.middle <- str_split_fixed(dels.5bp.context.middle, '', 2)[,2,drop=F]
 		dels.5bp.context.middle <- paste0('[', dels.5bp.context.middle, ']')
-		
+
 		#upstream
 		dels.5bp.context.start <- rep(NA, nrow(dels.5bp))
 		for (i in 1:length(dels.5bp.context.start)){
@@ -870,7 +932,7 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 			i2 <- .flank # end index (upstream flank end)
 			dels.5bp.context.start[i] <- paste(s[, i1:i2, drop=FALSE], collapse='')
 		}
-		
+
 		#downstream
 		dels.5bp.context.end <- rep(NA, nrow(dels.5bp))
 		for (i in 1:length(dels.5bp.context.end)){
@@ -881,306 +943,306 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 			i2 <- min(.flank + (6*l), nC) # clamp to available sequence
 			dels.5bp.context.end[i] <- paste(s[, i1:i2, drop=FALSE], collapse='')
 		}
-		
+
 		dels.5bp[,'TRIPLET'] <- paste(dels.5bp.context.start, dels.5bp.context.middle, dels.5bp.context.end, sep = '')
 		colnames(dels.5bp)[5] <- 'CONTEXT'
-		
+
 	}
-	
+
 	## summarise >=2 bp deletions at simple repeats in matrix format
 	## also create sub-tables for repeat length = 1 hits, to later assess these for microhomologies
 	dels.greater.2bp.summary <- matrix(0, ncol = 4, nrow = 6)
 	colnames(dels.greater.2bp.summary) <- c('2 bp', '3 bp', '4 bp', '5+ bp') ## deletion size
 	rownames(dels.greater.2bp.summary) <- c('1 or MH', '2', '3', '4', '5', '6+') ## number of repeats
-	
+
 	## 2 bp
 	if(nrow(dels.2bp) > 0){
-		
+
 		repeat.nts <- str_split_fixed(str_split_fixed(dels.2bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		downstream.context <- str_split_fixed(str_split_fixed(dels.2bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 		dels.2bp.pot.MH.ind <- c()
 		for (i in 1:nrow(dels.2bp)){
-			
+
 			## look at repeat
 			tmp.repeat.nts <- repeat.nts[i]
 			tmp.repeat.length <- nchar(tmp.repeat.nts)
-			
+
 			## how often does it match consecutively in the immediate downstream context?
 			tmp.downstream.context <- downstream.context[i]
 			tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]]
-			
+
 			## group
 			tmp.downstream.context <- c(paste(tmp.downstream.context[c(tmp.repeat.length-c(tmp.repeat.length - 1)):tmp.repeat.length], collapse = ''),
 																	paste(tmp.downstream.context[c(2*tmp.repeat.length-c(tmp.repeat.length - 1)):c(2*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(3*tmp.repeat.length-c(tmp.repeat.length - 1)):c(3*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(4*tmp.repeat.length-c(tmp.repeat.length - 1)):c(4*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(5*tmp.repeat.length-c(tmp.repeat.length - 1)):c(5*tmp.repeat.length)], collapse = ''))
-			
+
 			### check all 6 categories for upstream bases
 			if(tmp.downstream.context[1] %in% tmp.repeat.nts){
-				
+
 				if(tmp.downstream.context[2] %in% tmp.repeat.nts){
-					
+
 					if(tmp.downstream.context[3] %in% tmp.repeat.nts){
-						
+
 						if(tmp.downstream.context[4] %in% tmp.repeat.nts){
-							
+
 							if(tmp.downstream.context[5] %in% tmp.repeat.nts){
-								
+
 								dels.greater.2bp.summary['6+', '2 bp'] <- dels.greater.2bp.summary['6+', '2 bp'] + 1
-								
+
 							} else{
-								
+
 								dels.greater.2bp.summary['5', '2 bp'] <- dels.greater.2bp.summary['5', '2 bp'] + 1
-								
+
 							}
-							
+
 						}else{
-							
+
 							dels.greater.2bp.summary['4', '2 bp'] <- dels.greater.2bp.summary['4', '2 bp'] + 1
-							
+
 						}
-						
+
 					}else{
-						
+
 						dels.greater.2bp.summary['3', '2 bp'] <- dels.greater.2bp.summary['3', '2 bp'] + 1
-						
+
 					}
-					
+
 				}else{
-					
+
 					dels.greater.2bp.summary['2', '2 bp'] <- dels.greater.2bp.summary['2', '2 bp'] + 1
-					
+
 				}
-				
+
 			}else{
-				
+
 				dels.greater.2bp.summary['1 or MH', '2 bp'] <- dels.greater.2bp.summary['1 or MH', '2 bp'] + 1
 				dels.2bp.pot.MH.ind <- c(dels.2bp.pot.MH.ind, i)
-				
+
 			}
-			
+
 		}
-		dels.2bp.pot.MH <- dels.2bp[dels.2bp.pot.MH.ind,,drop=F] 
-		
+		dels.2bp.pot.MH <- dels.2bp[dels.2bp.pot.MH.ind,,drop=F]
+
 	}
-	
+
 	## 3 bp
 	if(nrow(dels.3bp) > 0){
-		
+
 		repeat.nts <- str_split_fixed(str_split_fixed(dels.3bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		downstream.context <- str_split_fixed(str_split_fixed(dels.3bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 		dels.3bp.pot.MH.ind <- c()
 		for (i in 1:nrow(dels.3bp)){
-			
+
 			## look at repeat
 			tmp.repeat.nts <- repeat.nts[i]
 			tmp.repeat.length <- nchar(tmp.repeat.nts)
-			
+
 			## how often does it match consecutively in the immediate downstream context?
 			tmp.downstream.context <- downstream.context[i]
 			tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]]
-			
+
 			## group
 			tmp.downstream.context <- c(paste(tmp.downstream.context[c(tmp.repeat.length-c(tmp.repeat.length - 1)):tmp.repeat.length], collapse = ''),
 																	paste(tmp.downstream.context[c(2*tmp.repeat.length-c(tmp.repeat.length - 1)):c(2*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(3*tmp.repeat.length-c(tmp.repeat.length - 1)):c(3*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(4*tmp.repeat.length-c(tmp.repeat.length - 1)):c(4*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(5*tmp.repeat.length-c(tmp.repeat.length - 1)):c(5*tmp.repeat.length)], collapse = ''))
-			
+
 			### check all 6 categories for upstream bases
 			if(tmp.downstream.context[1] %in% tmp.repeat.nts){
-				
+
 				if(tmp.downstream.context[2] %in% tmp.repeat.nts){
-					
+
 					if(tmp.downstream.context[3] %in% tmp.repeat.nts){
-						
+
 						if(tmp.downstream.context[4] %in% tmp.repeat.nts){
-							
+
 							if(tmp.downstream.context[5] %in% tmp.repeat.nts){
-								
+
 								dels.greater.2bp.summary['6+', '3 bp'] <- dels.greater.2bp.summary['6+', '3 bp'] + 1
-								
+
 							} else{
-								
+
 								dels.greater.2bp.summary['5', '3 bp'] <- dels.greater.2bp.summary['5', '3 bp'] + 1
-								
+
 							}
-							
+
 						}else{
-							
+
 							dels.greater.2bp.summary['4', '3 bp'] <- dels.greater.2bp.summary['4', '3 bp'] + 1
-							
+
 						}
-						
+
 					}else{
-						
+
 						dels.greater.2bp.summary['3', '3 bp'] <- dels.greater.2bp.summary['3', '3 bp'] + 1
-						
+
 					}
-					
+
 				}else{
-					
+
 					dels.greater.2bp.summary['2', '3 bp'] <- dels.greater.2bp.summary['2', '3 bp'] + 1
-					
+
 				}
-				
+
 			}else{
-				
+
 				dels.greater.2bp.summary['1 or MH', '3 bp'] <- dels.greater.2bp.summary['1 or MH', '3 bp'] + 1
 				dels.3bp.pot.MH.ind <- c(dels.3bp.pot.MH.ind, i)
-				
+
 			}
-			
+
 		}
-		dels.3bp.pot.MH <- dels.3bp[dels.3bp.pot.MH.ind,,drop=F] 
-		
+		dels.3bp.pot.MH <- dels.3bp[dels.3bp.pot.MH.ind,,drop=F]
+
 	}
-	
+
 	## 4 bp
 	if(nrow(dels.4bp) > 0){
-		
+
 		repeat.nts <- str_split_fixed(str_split_fixed(dels.4bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		downstream.context <- str_split_fixed(str_split_fixed(dels.4bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 		dels.4bp.pot.MH.ind <- c()
 		for (i in 1:nrow(dels.4bp)){
-			
+
 			## look at repeat
 			tmp.repeat.nts <- repeat.nts[i]
 			tmp.repeat.length <- nchar(tmp.repeat.nts)
-			
+
 			## how often does it match consecutively in the immediate downstream context?
 			tmp.downstream.context <- downstream.context[i]
 			tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]]
-			
+
 			## group
 			tmp.downstream.context <- c(paste(tmp.downstream.context[c(tmp.repeat.length-c(tmp.repeat.length - 1)):tmp.repeat.length], collapse = ''),
 																	paste(tmp.downstream.context[c(2*tmp.repeat.length-c(tmp.repeat.length - 1)):c(2*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(3*tmp.repeat.length-c(tmp.repeat.length - 1)):c(3*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(4*tmp.repeat.length-c(tmp.repeat.length - 1)):c(4*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(5*tmp.repeat.length-c(tmp.repeat.length - 1)):c(5*tmp.repeat.length)], collapse = ''))
-			
+
 			### check all 6 categories for upstream bases
 			if(tmp.downstream.context[1] %in% tmp.repeat.nts){
-				
+
 				if(tmp.downstream.context[2] %in% tmp.repeat.nts){
-					
+
 					if(tmp.downstream.context[3] %in% tmp.repeat.nts){
-						
+
 						if(tmp.downstream.context[4] %in% tmp.repeat.nts){
-							
+
 							if(tmp.downstream.context[5] %in% tmp.repeat.nts){
-								
+
 								dels.greater.2bp.summary['6+', '4 bp'] <- dels.greater.2bp.summary['6+', '4 bp'] + 1
-								
+
 							} else{
-								
+
 								dels.greater.2bp.summary['5', '4 bp'] <- dels.greater.2bp.summary['5', '4 bp'] + 1
-								
+
 							}
-							
+
 						}else{
-							
+
 							dels.greater.2bp.summary['4', '4 bp'] <- dels.greater.2bp.summary['4', '4 bp'] + 1
-							
+
 						}
-						
+
 					}else{
-						
+
 						dels.greater.2bp.summary['3', '4 bp'] <- dels.greater.2bp.summary['3', '4 bp'] + 1
-						
+
 					}
-					
+
 				}else{
-					
+
 					dels.greater.2bp.summary['2', '4 bp'] <- dels.greater.2bp.summary['2', '4 bp'] + 1
-					
+
 				}
-				
+
 			}else{
-				
+
 				dels.greater.2bp.summary['1 or MH', '4 bp'] <- dels.greater.2bp.summary['1 or MH', '4 bp'] + 1
 				dels.4bp.pot.MH.ind <- c(dels.4bp.pot.MH.ind, i)
-				
+
 			}
-			
+
 		}
 		dels.4bp.pot.MH <- dels.4bp[dels.4bp.pot.MH.ind,,drop=F]
-		
+
 	}
-	
+
 	## 5+ bp
 	if(nrow(dels.5bp) > 0){
-		
+
 		repeat.nts <- str_split_fixed(str_split_fixed(dels.5bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		downstream.context <- str_split_fixed(str_split_fixed(dels.5bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 		dels.5bp.pot.MH.ind <- c()
 		for (i in 1:nrow(dels.5bp)){
-			
+
 			## look at repeat
 			tmp.repeat.nts <- repeat.nts[i]
 			tmp.repeat.length <- nchar(tmp.repeat.nts)
-			
+
 			## how often does it match consecutively in the immediate downstream context?
 			tmp.downstream.context <- downstream.context[i]
 			tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]]
-			
+
 			## group
 			tmp.downstream.context <- c(paste(tmp.downstream.context[c(tmp.repeat.length-c(tmp.repeat.length - 1)):tmp.repeat.length], collapse = ''),
 																	paste(tmp.downstream.context[c(2*tmp.repeat.length-c(tmp.repeat.length - 1)):c(2*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(3*tmp.repeat.length-c(tmp.repeat.length - 1)):c(3*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(4*tmp.repeat.length-c(tmp.repeat.length - 1)):c(4*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(5*tmp.repeat.length-c(tmp.repeat.length - 1)):c(5*tmp.repeat.length)], collapse = ''))
-			
+
 			### check all 6 categories for upstream bases
 			if(tmp.downstream.context[1] %in% tmp.repeat.nts){
-				
+
 				if(tmp.downstream.context[2] %in% tmp.repeat.nts){
-					
+
 					if(tmp.downstream.context[3] %in% tmp.repeat.nts){
-						
+
 						if(tmp.downstream.context[4] %in% tmp.repeat.nts){
-							
+
 							if(tmp.downstream.context[5] %in% tmp.repeat.nts){
-								
+
 								dels.greater.2bp.summary['6+', '5+ bp'] <- dels.greater.2bp.summary['6+', '5+ bp'] + 1
-								
+
 							} else{
-								
+
 								dels.greater.2bp.summary['5', '5+ bp'] <- dels.greater.2bp.summary['5', '5+ bp'] + 1
-								
+
 							}
-							
+
 						}else{
-							
+
 							dels.greater.2bp.summary['4', '5+ bp'] <- dels.greater.2bp.summary['4', '5+ bp'] + 1
-							
+
 						}
-						
+
 					}else{
-						
+
 						dels.greater.2bp.summary['3', '5+ bp'] <- dels.greater.2bp.summary['3', '5+ bp'] + 1
-						
+
 					}
-					
+
 				}else{
-					
+
 					dels.greater.2bp.summary['2', '5+ bp'] <- dels.greater.2bp.summary['2', '5+ bp'] + 1
-					
+
 				}
-				
+
 			}else{
-				
+
 				dels.greater.2bp.summary['1 or MH', '5+ bp'] <- dels.greater.2bp.summary['1 or MH', '5+ bp'] + 1
 				dels.5bp.pot.MH.ind <- c(dels.5bp.pot.MH.ind, i)
-				
+
 			}
-			
+
 		}
-		dels.5bp.pot.MH <- dels.5bp[dels.5bp.pot.MH.ind,,drop=F] 
-		
+		dels.5bp.pot.MH <- dels.5bp[dels.5bp.pot.MH.ind,,drop=F]
+
 	}
-	
+
 	# (v) >=2 bp deletions at microhomologies
 	## go directly into in matrix format, thereby also re-classify repeat length = 1 deletions
 	dels.greater.2bp.MH.summary <- matrix(0, ncol = 4, nrow = 5)
@@ -1189,234 +1251,234 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 	dels.greater.2bp.MH.summary[2:5, '2 bp'] <- NA
 	dels.greater.2bp.MH.summary[3:5, '3 bp'] <- NA
 	dels.greater.2bp.MH.summary[4:5, '4 bp'] <- NA
-	
+
 	## 2 bp
 	if(nrow(dels.2bp) > 0){
-		
+
 		if(nrow(dels.2bp.pot.MH) > 0){
-			
+
 			repeat.nts <- str_split_fixed(str_split_fixed(dels.2bp.pot.MH[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 			upstream.context <- str_split_fixed(dels.2bp.pot.MH[,'CONTEXT'], '\\[', 2)[,1,drop=F]
 			downstream.context <- str_split_fixed(str_split_fixed(dels.2bp.pot.MH[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 			for (i in 1:nrow(dels.2bp.pot.MH)){
-				
+
 				## look at repeat
 				tmp.repeat.nts <- repeat.nts[i]
-				
+
 				## isolate first nucleotide in the immediate upstream context
 				tmp.upstream.context <- upstream.context[i]
 				tmp.upstream.context <- strsplit(tmp.upstream.context, '')[[1]][length(strsplit(tmp.upstream.context, '')[[1]])]
-				
+
 				## isolate first nucleotide in the immediate downstream context
 				tmp.downstream.context <- downstream.context[i]
 				tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]][1]
-				
+
 				if(strsplit(tmp.repeat.nts, '')[[1]][2] == tmp.upstream.context | strsplit(tmp.repeat.nts, '')[[1]][1] == tmp.downstream.context){
-					
+
 					dels.greater.2bp.MH.summary['1 bp MH', '2 bp'] <- dels.greater.2bp.MH.summary['1 bp MH', '2 bp'] + 1
 					dels.greater.2bp.summary['1 or MH', '2 bp'] <- dels.greater.2bp.summary['1 or MH', '2 bp'] - 1
-					
+
 				}
-			} 
-			
+			}
+
 		}
-		
+
 	}
-	
+
 	## 3 bp
 	if(nrow(dels.3bp) > 0){
-		
+
 		if(nrow(dels.3bp.pot.MH) > 0){
-			
+
 			repeat.nts <- str_split_fixed(str_split_fixed(dels.3bp.pot.MH[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 			upstream.context <- str_split_fixed(dels.3bp.pot.MH[,'CONTEXT'], '\\[', 2)[,1,drop=F]
 			downstream.context <- str_split_fixed(str_split_fixed(dels.3bp.pot.MH[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 			for (i in 1:nrow(dels.3bp.pot.MH)){
-				
+
 				## look at repeat
 				tmp.repeat.nts <- repeat.nts[i]
-				
+
 				## isolate first two nucleotides in the immediate upstream context
 				tmp.upstream.context <- upstream.context[i]
 				tmp.upstream.context <- strsplit(tmp.upstream.context, '')[[1]][c(length(strsplit(tmp.upstream.context, '')[[1]]) - 1):length(strsplit(tmp.upstream.context, '')[[1]])]
-				
+
 				## isolate first two nucleotides in the immediate downstream context
 				tmp.downstream.context <- downstream.context[i]
 				tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]][1:2]
-				
+
 				### MH length = 2 (important to start with the highest possible MH length)
-				
+
 				if(all(c(strsplit(tmp.repeat.nts, '')[[1]][2:3] == tmp.upstream.context) == T) | all(c(strsplit(tmp.repeat.nts, '')[[1]][1:2] == tmp.downstream.context) == T)){
-					
+
 					dels.greater.2bp.MH.summary['2 bp MH', '3 bp'] <- dels.greater.2bp.MH.summary['2 bp MH', '3 bp'] + 1
 					dels.greater.2bp.summary['1 or MH', '3 bp'] <- dels.greater.2bp.summary['1 or MH', '3 bp'] - 1
-					
+
 				}else{
-					
+
 					### MH length = 1
-					
+
 					if(strsplit(tmp.repeat.nts, '')[[1]][3] == tmp.upstream.context[2] | strsplit(tmp.repeat.nts, '')[[1]][1] == tmp.downstream.context[1]){
-						
+
 						dels.greater.2bp.MH.summary['1 bp MH', '3 bp'] <- dels.greater.2bp.MH.summary['1 bp MH', '3 bp'] + 1
 						dels.greater.2bp.summary['1 or MH', '3 bp'] <- dels.greater.2bp.summary['1 or MH', '3 bp'] - 1
-						
+
 					}
-					
+
 				}
-				
-			} 
-			
+
+			}
+
 		}
-		
+
 	}
-	
+
 	## 4 bp
 	if(nrow(dels.4bp) > 0){
-		
+
 		if(nrow(dels.4bp.pot.MH) > 0){
-			
+
 			repeat.nts <- str_split_fixed(str_split_fixed(dels.4bp.pot.MH[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 			upstream.context <- str_split_fixed(dels.4bp.pot.MH[,'CONTEXT'], '\\[', 2)[,1,drop=F]
 			downstream.context <- str_split_fixed(str_split_fixed(dels.4bp.pot.MH[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 			for (i in 1:nrow(dels.4bp.pot.MH)){
-				
+
 				## look at repeat
 				tmp.repeat.nts <- repeat.nts[i]
-				
+
 				## isolate first three nucleotides in the immediate upstream context
 				tmp.upstream.context <- upstream.context[i]
 				tmp.upstream.context <- strsplit(tmp.upstream.context, '')[[1]][c(length(strsplit(tmp.upstream.context, '')[[1]]) - 2):length(strsplit(tmp.upstream.context, '')[[1]])]
-				
+
 				## isolate first three nucleotides in the immediate downstream context
 				tmp.downstream.context <- downstream.context[i]
 				tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]][1:3]
-				
+
 				### MH length = 3 (important to start with the highest possible MH length)
-				
+
 				if(all(c(strsplit(tmp.repeat.nts, '')[[1]][2:4] == tmp.upstream.context) == T) | all(c(strsplit(tmp.repeat.nts, '')[[1]][1:3] == tmp.downstream.context) == T)){
-					
+
 					dels.greater.2bp.MH.summary['3 bp MH', '4 bp'] <- dels.greater.2bp.MH.summary['3 bp MH', '4 bp'] + 1
 					dels.greater.2bp.summary['1 or MH', '4 bp'] <- dels.greater.2bp.summary['1 or MH', '4 bp'] - 1
-					
+
 				}else{
-					
+
 					### MH length = 2
-					
+
 					if(all(c(strsplit(tmp.repeat.nts, '')[[1]][3:4] == tmp.upstream.context[2:3]) ==T) | all(c(strsplit(tmp.repeat.nts, '')[[1]][1:2] == tmp.downstream.context[1:2]) == T)){
-						
+
 						dels.greater.2bp.MH.summary['2 bp MH', '4 bp'] <- dels.greater.2bp.MH.summary['2 bp MH', '4 bp'] + 1
 						dels.greater.2bp.summary['1 or MH', '4 bp'] <- dels.greater.2bp.summary['1 or MH', '4 bp'] - 1
-						
+
 					}else{
-						
+
 						### MH length = 1
-						
+
 						if(strsplit(tmp.repeat.nts, '')[[1]][4] == tmp.upstream.context[3] | strsplit(tmp.repeat.nts, '')[[1]][1] == tmp.downstream.context[1]){
-							
+
 							dels.greater.2bp.MH.summary['1 bp MH', '4 bp'] <- dels.greater.2bp.MH.summary['1 bp MH', '4 bp'] + 1
 							dels.greater.2bp.summary['1 or MH', '4 bp'] <- dels.greater.2bp.summary['1 or MH', '4 bp'] - 1
-							
+
 						}
-						
+
 					}
-					
+
 				}
-				
-			} 
-			
+
+			}
+
 		}
-		
+
 	}
-	
+
 	## 5+ bp
 	if(nrow(dels.5bp) > 0){
-		
+
 		if(nrow(dels.5bp.pot.MH) > 0){
-			
+
 			repeat.nts <- str_split_fixed(str_split_fixed(dels.5bp.pot.MH[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 			upstream.context <- str_split_fixed(dels.5bp.pot.MH[,'CONTEXT'], '\\[', 2)[,1,drop=F]
 			downstream.context <- str_split_fixed(str_split_fixed(dels.5bp.pot.MH[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 			for (i in 1:nrow(dels.5bp.pot.MH)){
-				
+
 				## look at repeat
 				tmp.repeat.nts <- repeat.nts[i]
 				tmp.repeat.length <- nchar(tmp.repeat.nts)
-				
+
 				## isolate first X (= repeat length - 1) nucleotides in the immediate upstream context
 				tmp.upstream.context <- upstream.context[i]
 				tmp.upstream.context <- strsplit(tmp.upstream.context, '')[[1]][c(length(strsplit(tmp.upstream.context, '')[[1]]) - 4):length(strsplit(tmp.upstream.context, '')[[1]])]
-				
+
 				## isolate first X (= repeat length - 1) nucleotides in the immediate downstream context
 				tmp.downstream.context <- downstream.context[i]
 				tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]][1:5]
-				
+
 				### MH length = 5+ (important to start with the highest possible MH length); only need to look at first 5 up/downstream NTs
-				
+
 				if(all(c(strsplit(tmp.repeat.nts, '')[[1]][c(tmp.repeat.length-4):tmp.repeat.length] == tmp.upstream.context[c(length(tmp.upstream.context) - 4):length(tmp.upstream.context)]) == T) | all(c(strsplit(tmp.repeat.nts, '')[[1]][1:5] == tmp.downstream.context[1:5]) == T)){
-					
+
 					dels.greater.2bp.MH.summary['5+ bp MH', '5+ bp'] <- dels.greater.2bp.MH.summary['5+ bp MH', '5+ bp'] + 1
 					dels.greater.2bp.summary['1 or MH', '5+ bp'] <- dels.greater.2bp.summary['1 or MH', '5+ bp'] - 1
-					
+
 				}else{
-					
+
 					### MH length = 4
-					
+
 					if(all(c(strsplit(tmp.repeat.nts, '')[[1]][c(tmp.repeat.length-3):tmp.repeat.length] == tmp.upstream.context[c(length(tmp.upstream.context) - 3):length(tmp.upstream.context)]) == T) | all(c(strsplit(tmp.repeat.nts, '')[[1]][1:4] == tmp.downstream.context[1:4]) == T)){
-						
+
 						dels.greater.2bp.MH.summary['4 bp MH', '5+ bp'] <- dels.greater.2bp.MH.summary['4 bp MH', '5+ bp'] + 1
 						dels.greater.2bp.summary['1 or MH', '5+ bp'] <- dels.greater.2bp.summary['1 or MH', '5+ bp'] - 1
-						
+
 					}else{
-						
+
 						### MH length = 3
-						
+
 						if(all(c(strsplit(tmp.repeat.nts, '')[[1]][c(tmp.repeat.length-2):tmp.repeat.length] == tmp.upstream.context[c(length(tmp.upstream.context) - 2):length(tmp.upstream.context)]) == T) | all(c(strsplit(tmp.repeat.nts, '')[[1]][1:3] == tmp.downstream.context[1:3]) == T)){
-							
+
 							dels.greater.2bp.MH.summary['3 bp MH', '5+ bp'] <- dels.greater.2bp.MH.summary['3 bp MH', '5+ bp'] + 1
 							dels.greater.2bp.summary['1 or MH', '5+ bp'] <- dels.greater.2bp.summary['1 or MH', '5+ bp'] - 1
-							
+
 						}else{
-							
+
 							### MH length = 2
-							
+
 							if(all(c(strsplit(tmp.repeat.nts, '')[[1]][c(tmp.repeat.length-1):tmp.repeat.length] == tmp.upstream.context[c(length(tmp.upstream.context) - 1):length(tmp.upstream.context)]) == T) | all(c(strsplit(tmp.repeat.nts, '')[[1]][1:2] == tmp.downstream.context[1:2]) == T)){
-								
+
 								dels.greater.2bp.MH.summary['2 bp MH', '5+ bp'] <- dels.greater.2bp.MH.summary['2 bp MH', '5+ bp'] + 1
 								dels.greater.2bp.summary['1 or MH', '5+ bp'] <- dels.greater.2bp.summary['1 or MH', '5+ bp'] - 1
-								
+
 							}else{
-								
+
 								if(strsplit(tmp.repeat.nts, '')[[1]][tmp.repeat.length] == tmp.upstream.context[length(tmp.upstream.context)] | strsplit(tmp.repeat.nts, '')[[1]][1] == tmp.downstream.context[1]){
-									
+
 									dels.greater.2bp.MH.summary['1 bp MH', '5+ bp'] <- dels.greater.2bp.MH.summary['1 bp MH', '5+ bp'] + 1
 									dels.greater.2bp.summary['1 or MH', '5+ bp'] <- dels.greater.2bp.summary['1 or MH', '5+ bp'] - 1
-									
+
 								}
-								
+
 							}
-							
+
 						}
-						
+
 					}
-					
+
 				}
-				
-			} 
-			
+
+			}
+
 		}
-		
+
 	}
-	
+
 	## after MH cases have been taken out, rename row of deletions at 1-unit repeats in original table
 	rownames(dels.greater.2bp.summary)[1] <- '1'
-	
+
 	## 4. classify >=2 bp insertions into:
-	
+
 	# (i) 2 bp insertions at simple repeats (length 0 == "no neighbouring simple repeat")
 	if(nrow(ins.2bp) > 0){
-		
-		ins.2bp.context <- as.character(subseq(x = reference[as.character(ins.2bp[,'CHROM'])], 
-																					 start = as.numeric(ins.2bp[,'POS']) - 9, 
+
+		ins.2bp.context <- as.character(subseq(x = reference[as.character(ins.2bp[,'CHROM'])],
+																					 start = as.numeric(ins.2bp[,'POS']) - 9,
 																					 end = as.numeric(ins.2bp[,'POS']) + 10))
 		ins.2bp.context.middle <- as.character(ins.2bp[,'ALT'])
 		ins.2bp.context.middle <- paste0('[', str_split_fixed(ins.2bp.context.middle, '', 2)[,2,drop=F], ']')
@@ -1427,15 +1489,15 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 																	 ins.2bp.context.start[,10], sep = '')
 		ins.2bp.context.end <- str_split_fixed(ins.2bp.context, '', 11)[,11,drop=F]
 		ins.2bp[,'TRIPLET'] <- paste(ins.2bp.context.start, ins.2bp.context.middle, ins.2bp.context.end, sep = '')
-		colnames(ins.2bp)[5] <- 'CONTEXT' 
-		
+		colnames(ins.2bp)[5] <- 'CONTEXT'
+
 	}
-	
+
 	# (ii) 3 bp insertions at simple repeats (length 0 == "no neighbouring simple repeat")
 	if(nrow(ins.3bp) > 0){
-		
-		ins.3bp.context <- as.character(subseq(x = reference[as.character(ins.3bp[,'CHROM'])], 
-																					 start = as.numeric(ins.3bp[,'POS']) - 14, 
+
+		ins.3bp.context <- as.character(subseq(x = reference[as.character(ins.3bp[,'CHROM'])],
+																					 start = as.numeric(ins.3bp[,'POS']) - 14,
 																					 end = as.numeric(ins.3bp[,'POS']) + 15))
 		ins.3bp.context.middle <- as.character(ins.3bp[,'ALT'])
 		ins.3bp.context.middle <- paste0('[', str_split_fixed(ins.3bp.context.middle, '', 2)[,2,drop=F], ']')
@@ -1443,19 +1505,19 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 		ins.3bp.context.start <- paste(ins.3bp.context.start[,1], ins.3bp.context.start[,2], ins.3bp.context.start[,3],
 																	 ins.3bp.context.start[,4], ins.3bp.context.start[,5], ins.3bp.context.start[,6],
 																	 ins.3bp.context.start[,7], ins.3bp.context.start[,8], ins.3bp.context.start[,9],
-																	 ins.3bp.context.start[,10], ins.3bp.context.start[,11], ins.3bp.context.start[,12], 
+																	 ins.3bp.context.start[,10], ins.3bp.context.start[,11], ins.3bp.context.start[,12],
 																	 ins.3bp.context.start[,13], ins.3bp.context.start[,14], ins.3bp.context.start[,15], sep = '')
 		ins.3bp.context.end <- str_split_fixed(ins.3bp.context, '', 16)[,16,drop=F]
 		ins.3bp[,'TRIPLET'] <- paste(ins.3bp.context.start, ins.3bp.context.middle, ins.3bp.context.end, sep = '')
-		colnames(ins.3bp)[5] <- 'CONTEXT' 
-		
+		colnames(ins.3bp)[5] <- 'CONTEXT'
+
 	}
-	
+
 	# (iii) 4 bp insertions at simple repeats (length 0 == "no neighbouring simple repeat")
 	if(nrow(ins.4bp) > 0){
-		
-		ins.4bp.context <- as.character(subseq(x = reference[as.character(ins.4bp[,'CHROM'])], 
-																					 start = as.numeric(ins.4bp[,'POS']) - 19, 
+
+		ins.4bp.context <- as.character(subseq(x = reference[as.character(ins.4bp[,'CHROM'])],
+																					 start = as.numeric(ins.4bp[,'POS']) - 19,
 																					 end = as.numeric(ins.4bp[,'POS']) + 20))
 		ins.4bp.context.middle <- as.character(ins.4bp[,'ALT'])
 		ins.4bp.context.middle <- paste0('[', str_split_fixed(ins.4bp.context.middle, '', 2)[,2,drop=F], ']')
@@ -1463,19 +1525,19 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 		ins.4bp.context.start <- paste(ins.4bp.context.start[,1], ins.4bp.context.start[,2], ins.4bp.context.start[,3],
 																	 ins.4bp.context.start[,4], ins.4bp.context.start[,5], ins.4bp.context.start[,6],
 																	 ins.4bp.context.start[,7], ins.4bp.context.start[,8], ins.4bp.context.start[,9],
-																	 ins.4bp.context.start[,10], ins.4bp.context.start[,11], ins.4bp.context.start[,12], 
-																	 ins.4bp.context.start[,13], ins.4bp.context.start[,14], ins.4bp.context.start[,15], 
-																	 ins.4bp.context.start[,16], ins.4bp.context.start[,17], ins.4bp.context.start[,18], 
+																	 ins.4bp.context.start[,10], ins.4bp.context.start[,11], ins.4bp.context.start[,12],
+																	 ins.4bp.context.start[,13], ins.4bp.context.start[,14], ins.4bp.context.start[,15],
+																	 ins.4bp.context.start[,16], ins.4bp.context.start[,17], ins.4bp.context.start[,18],
 																	 ins.4bp.context.start[,19], ins.4bp.context.start[,20], sep = '')
 		ins.4bp.context.end <- str_split_fixed(ins.4bp.context, '', 21)[,21,drop=F]
 		ins.4bp[,'TRIPLET'] <- paste(ins.4bp.context.start, ins.4bp.context.middle, ins.4bp.context.end, sep = '')
-		colnames(ins.4bp)[5] <- 'CONTEXT' 
-		
+		colnames(ins.4bp)[5] <- 'CONTEXT'
+
 	}
-	
+
 	# (iv) 5+ bp insertions at simple repeats (length 0 == "no neighbouring simple repeat")
 	if(nrow(ins.5bp) > 0){
-		
+
 		ins.5bp.context <- as.character(
 			subseq(
 				x = reference[as.character(ins.5bp[,'CHROM'])],
@@ -1483,7 +1545,7 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 				end = as.numeric(ins.5bp[,'POS']) + .flank
 			)
 		)
-		
+
 		# inserted segment and its length
 		ins.5bp.context.middle <- as.character(ins.5bp[,'ALT'])
 		ins.5bp.context.middle <- str_split_fixed(ins.5bp.context.middle, '', 2)[,2,drop=F]
@@ -1499,7 +1561,7 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 			i2 <- .flank
 			ins.5bp.context.start[i] <- paste(s[, i1:i2, drop=FALSE], collapse='')
 		}
-		
+
 		# downstream: take up to 6×repeat-length starting immediately after POS
 		ins.5bp.context.end <- rep(NA, nrow(ins.5bp))
 		for (i in 1:length(ins.5bp.context.end)){
@@ -1509,293 +1571,293 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 			i2 <- min(.flank + (6 * l), 2*.flank) # clamp to available sequence
 			ins.5bp.context.end[i] <- paste(s[, i1:i2, drop=FALSE], collapse='')
 		}
-		
+
 		ins.5bp[,'TRIPLET'] <- paste(ins.5bp.context.start, ins.5bp.context.middle, ins.5bp.context.end, sep = '')
 		colnames(ins.5bp)[5] <- 'CONTEXT'
-		
+
 	}
-	
+
 	## summarise >=2 bp insertions at simple repeats in matrix format
 	ins.greater.2bp.summary <- matrix(0, ncol = 4, nrow = 6)
 	colnames(ins.greater.2bp.summary) <- c('2 bp', '3 bp', '4 bp', '5+ bp') ## insertion size
 	rownames(ins.greater.2bp.summary) <- c('0', '1', '2', '3', '4', '5+') ## number of repeats
-	
+
 	## 2 bp
 	if(nrow(ins.2bp) > 0){
-		
+
 		repeat.nts <- str_split_fixed(str_split_fixed(ins.2bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		downstream.context <- str_split_fixed(str_split_fixed(ins.2bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 		for (i in 1:nrow(ins.2bp)){
-			
+
 			## look at repeat
 			tmp.repeat.nts <- repeat.nts[i]
 			tmp.repeat.length <- nchar(tmp.repeat.nts)
-			
+
 			## how often does it match consecutively in the immediate downstream context?
 			tmp.downstream.context <- downstream.context[i]
 			tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]]
-			
+
 			## group
 			tmp.downstream.context <- c(paste(tmp.downstream.context[c(tmp.repeat.length-c(tmp.repeat.length - 1)):tmp.repeat.length], collapse = ''),
 																	paste(tmp.downstream.context[c(2*tmp.repeat.length-c(tmp.repeat.length - 1)):c(2*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(3*tmp.repeat.length-c(tmp.repeat.length - 1)):c(3*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(4*tmp.repeat.length-c(tmp.repeat.length - 1)):c(4*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(5*tmp.repeat.length-c(tmp.repeat.length - 1)):c(5*tmp.repeat.length)], collapse = ''))
-			
+
 			### check all 6 categories for upstream bases
 			if(tmp.downstream.context[1] %in% tmp.repeat.nts){
-				
+
 				if(tmp.downstream.context[2] %in% tmp.repeat.nts){
-					
+
 					if(tmp.downstream.context[3] %in% tmp.repeat.nts){
-						
+
 						if(tmp.downstream.context[4] %in% tmp.repeat.nts){
-							
+
 							if(tmp.downstream.context[5] %in% tmp.repeat.nts){
-								
+
 								ins.greater.2bp.summary['5+', '2 bp'] <- ins.greater.2bp.summary['5+', '2 bp'] + 1
-								
+
 							} else{
-								
+
 								ins.greater.2bp.summary['4', '2 bp'] <- ins.greater.2bp.summary['4', '2 bp'] + 1
-								
+
 							}
-							
+
 						}else{
-							
+
 							ins.greater.2bp.summary['3', '2 bp'] <- ins.greater.2bp.summary['3', '2 bp'] + 1
-							
+
 						}
-						
+
 					}else{
-						
+
 						ins.greater.2bp.summary['2', '2 bp'] <- ins.greater.2bp.summary['2', '2 bp'] + 1
-						
+
 					}
-					
+
 				}else{
-					
+
 					ins.greater.2bp.summary['1', '2 bp'] <- ins.greater.2bp.summary['1', '2 bp'] + 1
-					
+
 				}
-				
+
 			}else{
-				
+
 				ins.greater.2bp.summary['0', '2 bp'] <- ins.greater.2bp.summary['0', '2 bp'] + 1
-				
+
 			}
-			
+
 		}
-		
+
 	}
-	
+
 	## 3 bp
 	if(nrow(ins.3bp) > 0){
-		
+
 		repeat.nts <- str_split_fixed(str_split_fixed(ins.3bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		downstream.context <- str_split_fixed(str_split_fixed(ins.3bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 		for (i in 1:nrow(ins.3bp)){
-			
+
 			## look at repeat
 			tmp.repeat.nts <- repeat.nts[i]
 			tmp.repeat.length <- nchar(tmp.repeat.nts)
-			
+
 			## how often does it match consecutively in the immediate downstream context?
 			tmp.downstream.context <- downstream.context[i]
 			tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]]
-			
+
 			## group
 			tmp.downstream.context <- c(paste(tmp.downstream.context[c(tmp.repeat.length-c(tmp.repeat.length - 1)):tmp.repeat.length], collapse = ''),
 																	paste(tmp.downstream.context[c(2*tmp.repeat.length-c(tmp.repeat.length - 1)):c(2*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(3*tmp.repeat.length-c(tmp.repeat.length - 1)):c(3*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(4*tmp.repeat.length-c(tmp.repeat.length - 1)):c(4*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(5*tmp.repeat.length-c(tmp.repeat.length - 1)):c(5*tmp.repeat.length)], collapse = ''))
-			
+
 			### check all 6 categories for upstream bases
 			if(tmp.downstream.context[1] %in% tmp.repeat.nts){
-				
+
 				if(tmp.downstream.context[2] %in% tmp.repeat.nts){
-					
+
 					if(tmp.downstream.context[3] %in% tmp.repeat.nts){
-						
+
 						if(tmp.downstream.context[4] %in% tmp.repeat.nts){
-							
+
 							if(tmp.downstream.context[5] %in% tmp.repeat.nts){
-								
+
 								ins.greater.2bp.summary['5+', '3 bp'] <- ins.greater.2bp.summary['5+', '3 bp'] + 1
-								
+
 							} else{
-								
+
 								ins.greater.2bp.summary['4', '3 bp'] <- ins.greater.2bp.summary['4', '3 bp'] + 1
-								
+
 							}
-							
+
 						}else{
-							
+
 							ins.greater.2bp.summary['3', '3 bp'] <- ins.greater.2bp.summary['3', '3 bp'] + 1
-							
+
 						}
-						
+
 					}else{
-						
+
 						ins.greater.2bp.summary['2', '3 bp'] <- ins.greater.2bp.summary['2', '3 bp'] + 1
-						
+
 					}
-					
+
 				}else{
-					
+
 					ins.greater.2bp.summary['1', '3 bp'] <- ins.greater.2bp.summary['1', '3 bp'] + 1
-					
+
 				}
-				
+
 			}else{
-				
+
 				ins.greater.2bp.summary['0', '3 bp'] <- ins.greater.2bp.summary['0', '3 bp'] + 1
-				
+
 			}
-			
-		} 
-		
+
+		}
+
 	}
-	
+
 	## 4 bp
 	if(nrow(ins.4bp) > 0){
-		
+
 		repeat.nts <- str_split_fixed(str_split_fixed(ins.4bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		downstream.context <- str_split_fixed(str_split_fixed(ins.4bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 		for (i in 1:nrow(ins.4bp)){
-			
+
 			## look at repeat
 			tmp.repeat.nts <- repeat.nts[i]
 			tmp.repeat.length <- nchar(tmp.repeat.nts)
-			
+
 			## how often does it match consecutively in the immediate downstream context?
 			tmp.downstream.context <- downstream.context[i]
 			tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]]
-			
+
 			## group
 			tmp.downstream.context <- c(paste(tmp.downstream.context[c(tmp.repeat.length-c(tmp.repeat.length - 1)):tmp.repeat.length], collapse = ''),
 																	paste(tmp.downstream.context[c(2*tmp.repeat.length-c(tmp.repeat.length - 1)):c(2*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(3*tmp.repeat.length-c(tmp.repeat.length - 1)):c(3*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(4*tmp.repeat.length-c(tmp.repeat.length - 1)):c(4*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(5*tmp.repeat.length-c(tmp.repeat.length - 1)):c(5*tmp.repeat.length)], collapse = ''))
-			
+
 			### check all 6 categories for upstream bases
 			if(tmp.downstream.context[1] %in% tmp.repeat.nts){
-				
+
 				if(tmp.downstream.context[2] %in% tmp.repeat.nts){
-					
+
 					if(tmp.downstream.context[3] %in% tmp.repeat.nts){
-						
+
 						if(tmp.downstream.context[4] %in% tmp.repeat.nts){
-							
+
 							if(tmp.downstream.context[5] %in% tmp.repeat.nts){
-								
+
 								ins.greater.2bp.summary['5+', '4 bp'] <- ins.greater.2bp.summary['5+', '4 bp'] + 1
-								
+
 							} else{
-								
+
 								ins.greater.2bp.summary['4', '4 bp'] <- ins.greater.2bp.summary['4', '4 bp'] + 1
-								
+
 							}
-							
+
 						}else{
-							
+
 							ins.greater.2bp.summary['3', '4 bp'] <- ins.greater.2bp.summary['3', '4 bp'] + 1
-							
+
 						}
-						
+
 					}else{
-						
+
 						ins.greater.2bp.summary['2', '4 bp'] <- ins.greater.2bp.summary['2', '4 bp'] + 1
-						
+
 					}
-					
+
 				}else{
-					
+
 					ins.greater.2bp.summary['1', '4 bp'] <- ins.greater.2bp.summary['1', '4 bp'] + 1
-					
+
 				}
-				
+
 			}else{
-				
+
 				ins.greater.2bp.summary['0', '4 bp'] <- ins.greater.2bp.summary['0', '4 bp'] + 1
-				
+
 			}
-			
-		} 
-		
+
+		}
+
 	}
-	
+
 	## 5+ bp
 	if(nrow(ins.5bp) > 0){
-		
+
 		repeat.nts <- str_split_fixed(str_split_fixed(ins.5bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,1,drop=F]
 		downstream.context <- str_split_fixed(str_split_fixed(ins.5bp[,'CONTEXT'], '\\[', 2)[,2,drop=F], '\\]', 2)[,2,drop=F]
 		for (i in 1:nrow(ins.5bp)){
-			
+
 			## look at repeat
 			tmp.repeat.nts <- repeat.nts[i]
 			tmp.repeat.length <- nchar(tmp.repeat.nts)
-			
+
 			## how often does it match consecutively in the immediate downstream context?
 			tmp.downstream.context <- downstream.context[i]
 			tmp.downstream.context <- strsplit(tmp.downstream.context, '')[[1]]
-			
+
 			## group
 			tmp.downstream.context <- c(paste(tmp.downstream.context[c(tmp.repeat.length-c(tmp.repeat.length - 1)):tmp.repeat.length], collapse = ''),
 																	paste(tmp.downstream.context[c(2*tmp.repeat.length-c(tmp.repeat.length - 1)):c(2*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(3*tmp.repeat.length-c(tmp.repeat.length - 1)):c(3*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(4*tmp.repeat.length-c(tmp.repeat.length - 1)):c(4*tmp.repeat.length)], collapse = ''),
 																	paste(tmp.downstream.context[c(5*tmp.repeat.length-c(tmp.repeat.length - 1)):c(5*tmp.repeat.length)], collapse = ''))
-			
+
 			### check all 6 categories for upstream bases
 			if(tmp.downstream.context[1] %in% tmp.repeat.nts){
-				
+
 				if(tmp.downstream.context[2] %in% tmp.repeat.nts){
-					
+
 					if(tmp.downstream.context[3] %in% tmp.repeat.nts){
-						
+
 						if(tmp.downstream.context[4] %in% tmp.repeat.nts){
-							
+
 							if(tmp.downstream.context[5] %in% tmp.repeat.nts){
-								
+
 								ins.greater.2bp.summary['5+', '5+ bp'] <- ins.greater.2bp.summary['5+', '5+ bp'] + 1
-								
+
 							} else{
-								
+
 								ins.greater.2bp.summary['4', '5+ bp'] <- ins.greater.2bp.summary['4', '5+ bp'] + 1
-								
+
 							}
-							
+
 						}else{
-							
+
 							ins.greater.2bp.summary['3', '5+ bp'] <- ins.greater.2bp.summary['3', '5+ bp'] + 1
-							
+
 						}
-						
+
 					}else{
-						
+
 						ins.greater.2bp.summary['2', '5+ bp'] <- ins.greater.2bp.summary['2', '5+ bp'] + 1
-						
+
 					}
-					
+
 				}else{
-					
+
 					ins.greater.2bp.summary['1', '5+ bp'] <- ins.greater.2bp.summary['1', '5+ bp'] + 1
-					
+
 				}
-				
+
 			}else{
-				
+
 				ins.greater.2bp.summary['0', '5+ bp'] <- ins.greater.2bp.summary['0', '5+ bp'] + 1
-				
+
 			}
-			
-		} 
-		
+
+		}
+
 	}
-	
+
 	## 5. summarise outputs as five lists, each featuring one table per major ID category
 	out <- list('1bp del' = dels.1bp.summary,
 							'1bp ins' = ins.1bp.summary,
@@ -1803,33 +1865,33 @@ indel.spectrum <- function(x, reference, context_bp = 1000){
 							'>2bp ins' = ins.greater.2bp.summary,
 							'MH dels' = dels.greater.2bp.MH.summary)
 	return(out)
-	
+
 }
 
 #Function to convert indel spectrum produced by indel.spectrum() to sigfit format
 indelspectrum.to.sigfit <- function(indelspectrum){
-	
+
 	#Helpers to convert from indelwald to sigfit labels
 	map_1bp_rep  <- function(x){
 		case_match(x, "0 bp" ~ "0", "1 bp" ~ "1", "2 bp" ~ "2", "3 bp" ~ "3", "4 bp" ~ "4", "5+ bp" ~ "5")
 	}
-	
+
 	map_sz <- function(x){
 		case_match(x, "2 bp" ~ "2", "3 bp" ~ "3", "4 bp" ~ "4", "5+ bp" ~ "5")
 	}
-	
+
 	map_R_del <- function(x){
 		case_match(x, "1" ~ "0", "2" ~ "1", "3" ~ "2", "4" ~ "3", "5" ~ "4", "6+" ~ "5")
 	}
-	
+
 	map_R_ins <- function(x){
 		case_match(x,"0" ~ "0", "1" ~ "1", "2" ~ "2", "3" ~ "3", "4" ~ "4", "5+" ~ "5")
 	}
-	
+
 	map_MH_len <- function(x){
 		case_match(x,"1 bp MH" ~ "1", "2 bp MH" ~ "2", "3 bp MH" ~ "3", "4 bp MH" ~ "4", "5+ bp MH" ~ "5")
 	}
-	
+
 	indelspectrum %>%
 		imap_dfr(function(mat, grp){
 			mat %>%

--- a/config_templates/README.md
+++ b/config_templates/README.md
@@ -72,7 +72,7 @@ Barcode uniqueness rules within a run:
 | Key | Type | Required | Description |
 | --- | --- | --- | --- |
 | `analysis_output_dir` | path | yes | Root directory for final output folders. |
-| `cache_dir` | path | yes | Shared cache for reference-dependent intermediates (BSgenome installation, region filters, processed germline variant resources). Populate a shared cache with a single Nextflow run at a time (or point concurrent runs to distinct caches) so that parallel executions do not overwrite the same files while they are being written. |
+| `cache_dir` | path | yes | Shared cache for reference-dependent intermediates (forged BSgenome installation, region filters, processed germline variant resources). Populate a shared cache with a single Nextflow run at a time (or point concurrent runs to distinct caches) so that parallel executions do not overwrite the same files while they are being written. |
 
 ## Container and tool paths
 
@@ -109,10 +109,12 @@ Barcode uniqueness rules within a run:
 | `genome_fasta` | path | yes | Reference FASTA. |
 | `genome_fai` | path | yes | FASTA index produced by `samtools faidx`. |
 | `genome_mmi` | path | yes | pbmm2 index produced by `pbmm2 index`. |
-| `BSgenome.BSgenome_name` | string | yes | BSgenome package name (for example `BSgenome.Hsapiens.UCSC.hg38`) used by R scripts. Run `BSGenome::available.genomes()` in R to see all publicly available genomes. If the desired reference genome is not available, [create a custom BSgenome package](https://bioconductor.org/packages/devel/bioc/manuals/BSgenomeForge/man/BSgenomeForge.pdf) and set `BSgenome.BSgenome_name` to the custom package's name.<br /><u>Important:</u> The configured `BSgenome` must exactly match the configured `genome_fasta/fai/mmi` (i.e., same contigs, contig lengths, sequence). |
-| `BSgenome.BSgenome_file` | path | optional | Tarball (.tar.gz) file containing a custom BSgenome build. When supplied, `installBSgenome.R` installs it into `cache_dir`. |
+| `genome_organism` | string | yes | Organism token used when forging the BSgenome package from `genome_fasta`. For the hg38 template this is `Hsapiens`, producing a package named like `BSgenome.Hsapiens.user.hg38.fa`. |
 | `sex_chromosomes` | comma-separated string | yes | Names of sex chromosomes. Used to exclude them from sensitivity analysis. |
 | `mitochondrial_chromosome` | string | yes | Name of the mitochondrial chromosome. Used to exclude it from sensitivity analysis. |
+| `circular_chromosomes` | comma-separated string | optional | Names of circular chromosomes to pass as `circ_seqs` when forging the BSgenome package. Set to `chrM` when `mitochondrial_chromosome: chrM`; leave blank when there are no circular chromosomes. |
+
+HiDEF-seq does not search Bioconductor for prebuilt BSgenome packages and does not install a user-provided BSgenome tarball. The pipeline derives the BSgenome package name from `genome_organism` and the basename of `genome_fasta`, checks whether that package is already installed in `cache_dir`, and otherwise forges it locally from `genome_fasta` with BSgenomeForge before installing it into `cache_dir`. BSgenomeForge keeps dots in the FASTA basename and removes characters that are not letters, numbers, or dots when constructing the package name; for example, `hg38_SMaHT.fa` becomes package suffix `hg38SMaHT.fa`.
 
 ### Chromosome grouping
 | Key | Type | Required | Description |
@@ -182,7 +184,7 @@ Filter groups enable creation of different sets of thresholds for basic molecule
 
 ## Region filter configuration
 
-Processed region filter bigWig files are prepared by the `prepareFilters` workflow for analysis based on the below settings and saved in `cache_dir` for future analyses. 
+Processed region filter bigWig files are prepared by the `prepareFilters` workflow for analysis based on the below settings and saved in `cache_dir` for future analyses.
 
 ### Region-based molecule filters
 
@@ -198,7 +200,7 @@ Processed region filter bigWig files are prepared by the `prepareFilters` workfl
 | `region_filters[].read_filters[].applyto_filtergroups` | string | yes | `all` or a comma-separated list of filter groups to which the filter is applied. |
 | `region_filters[].read_filters[].is_germline_filter` | boolean, `true` or `false` | yes | Boolean indicating whether the filter targets germline variant contexts (for example, a filter based on gnomAD variants). If `true`, the filter is excluded from sensitivity calculations that rely on germline variant calls that pass non-germline filters. |
 
-### Genome region filters 
+### Genome region filters
 | Key | Type | Required | Description |
 | --- | --- | --- | --- |
 | `region_filters[].genome_filters[]` | list | optional | Filters based on genomic regions that filter calls. Deletions are filtered out even if they partially overlap filtered regions. |

--- a/config_templates/README.md
+++ b/config_templates/README.md
@@ -72,7 +72,7 @@ Barcode uniqueness rules within a run:
 | Key | Type | Required | Description |
 | --- | --- | --- | --- |
 | `analysis_output_dir` | path | yes | Root directory for final output folders. |
-| `cache_dir` | path | yes | Shared cache for reference-dependent intermediates (forged BSgenome installation, region filters, processed germline variant resources). Populate a shared cache with a single Nextflow run at a time (or point concurrent runs to distinct caches) so that parallel executions do not overwrite the same files while they are being written. |
+| `cache_dir` | path | yes | Shared cache for reference-dependent intermediates (BSgenome installation, region filters, processed germline variant resources). Populate a shared cache with a single Nextflow run at a time (or point concurrent runs to distinct caches) so that parallel executions do not overwrite the same files while they are being written. |
 
 ## Container and tool paths
 
@@ -109,12 +109,12 @@ Barcode uniqueness rules within a run:
 | `genome_fasta` | path | yes | Reference FASTA. |
 | `genome_fai` | path | yes | FASTA index produced by `samtools faidx`. |
 | `genome_mmi` | path | yes | pbmm2 index produced by `pbmm2 index`. |
-| `genome_organism` | string | yes | Organism token used when forging the BSgenome package from `genome_fasta`. For the hg38 template this is `Hsapiens`, producing a package named like `BSgenome.Hsapiens.user.hg38.fa`. |
+| `genome_organism` | string | yes | Single-word token used in the package name of the BSgenome package created from `genome_fasta`. |
 | `sex_chromosomes` | comma-separated string | yes | Names of sex chromosomes. Used to exclude them from sensitivity analysis. |
 | `mitochondrial_chromosome` | string | yes | Name of the mitochondrial chromosome. Used to exclude it from sensitivity analysis. |
-| `circular_chromosomes` | comma-separated string | optional | Names of circular chromosomes to pass as `circ_seqs` when forging the BSgenome package. Set to `chrM` when `mitochondrial_chromosome: chrM`; leave blank when there are no circular chromosomes. |
+| `circular_chromosomes` | comma-separated string | optional | Names of circular chromosomes used when creating the BSgenome package. |
 
-HiDEF-seq does not search Bioconductor for prebuilt BSgenome packages and does not install a user-provided BSgenome tarball. The pipeline derives the BSgenome package name from `genome_organism` and the basename of `genome_fasta`, checks whether that package is already installed in `cache_dir`, and otherwise forges it locally from `genome_fasta` with BSgenomeForge before installing it into `cache_dir`. BSgenomeForge keeps dots in the FASTA basename and removes characters that are not letters, numbers, or dots when constructing the package name; for example, `hg38_SMaHT.fa` becomes package suffix `hg38SMaHT.fa`.
+The pipeline creates a BSgenome package from `genome_fasta` and installs it in `cache_dir`.
 
 ### Chromosome grouping
 | Key | Type | Required | Description |
@@ -184,7 +184,7 @@ Filter groups enable creation of different sets of thresholds for basic molecule
 
 ## Region filter configuration
 
-Processed region filter bigWig files are prepared by the `prepareFilters` workflow for analysis based on the below settings and saved in `cache_dir` for future analyses.
+Processed region filter bigWig files are prepared by the `prepareFilters` workflow for analysis based on the below settings and saved in `cache_dir` for future analyses. 
 
 ### Region-based molecule filters
 
@@ -200,7 +200,7 @@ Processed region filter bigWig files are prepared by the `prepareFilters` workfl
 | `region_filters[].read_filters[].applyto_filtergroups` | string | yes | `all` or a comma-separated list of filter groups to which the filter is applied. |
 | `region_filters[].read_filters[].is_germline_filter` | boolean, `true` or `false` | yes | Boolean indicating whether the filter targets germline variant contexts (for example, a filter based on gnomAD variants). If `true`, the filter is excluded from sensitivity calculations that rely on germline variant calls that pass non-germline filters. |
 
-### Genome region filters
+### Genome region filters 
 | Key | Type | Required | Description |
 | --- | --- | --- | --- |
 | `region_filters[].genome_filters[]` | list | optional | Filters based on genomic regions that filter calls. Deletions are filtered out even if they partially overlap filtered regions. |

--- a/config_templates/hidef-seq_3.0.template.hg38.yaml
+++ b/config_templates/hidef-seq_3.0.template.hg38.yaml
@@ -6,7 +6,7 @@
 ###
 ### Analysis ID
 ###
-analysis_id: 
+analysis_id:
 
 ###
 ### Sequencing runs and samples
@@ -20,14 +20,14 @@ barcodes:
     barcode:
 
 runs: # can specify multiple run_id entries
-  - run_id: 
-    reads_file: 
+  - run_id:
+    reads_file:
     samples:
-      - sample_id: 
-        barcode_ids: 
+      - sample_id:
+        barcode_ids:
         barcode_ids_round2: # optional second demultiplexing round; if performed for a sample, barcode_ids_round2 must be configured for that sample across all runs that contain it
-      - sample_id: 
-        barcode_ids: 
+      - sample_id:
+        barcode_ids:
         barcode_ids_round2: # optional second demultiplexing round; if performed for a sample, barcode_ids_round2 must be configured for that sample across all runs that contain it
 
 samples:
@@ -42,29 +42,29 @@ samples:
 ### Individuals
 ###
 individuals:
-  - individual_id: 
+  - individual_id:
     sex:  # male or female
-    germline_bam_file: 
+    germline_bam_file:
     germline_bam_type: # Illumina or PacBio
     germline_vcf_files: # can define any number of germlien_vcf_files
-      - germline_vcf_file: 
+      - germline_vcf_file:
         germline_vcf_type:  # any value possible; each configured in the germline_vcf_types section
-      - germline_vcf_file: 
-        germline_vcf_type: 
-  - individual_id: 
-    sex: 
-    germline_bam_file: 
-    germline_bam_type: 
+      - germline_vcf_file:
+        germline_vcf_type:
+  - individual_id:
+    sex:
+    germline_bam_file:
+    germline_bam_type:
     germline_vcf_files:
-      - germline_vcf_file: 
-        germline_vcf_type: 
-      - germline_vcf_file: 
-        germline_vcf_type: 
+      - germline_vcf_file:
+        germline_vcf_type:
+      - germline_vcf_file:
+        germline_vcf_type:
 
 ###
 ### Output folders
 ###
-analysis_output_dir: 
+analysis_output_dir:
 cache_dir:  # cannot be under the /home folder to ensure mounting by container.
 
 ###
@@ -124,12 +124,11 @@ output_intermediate_files: true  # true or false
 genome_fasta: hg38.fa
 genome_fai: hg38.fa.fai
 genome_mmi: hg38.mmi
-BSgenome:
-  BSgenome_name: BSgenome.Hsapiens.UCSC.hg38 # run BSGenome available.genomes() function to see all available, or set to the BSgenome_name of below BSGenome_file
-  BSgenome_file:  # optional tar.gz of custom BSgenome that is not in available.genomes()
+genome_organism: Hsapiens
 sex_chromosomes: chrX,chrY # comma-delimited
 mitochondrial_chromosome: chrM
-chromgroups: 
+circular_chromosomes: chrM
+chromgroups:
   - chromgroup: 1-22X
     chroms: chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX #comma-delimited
   - chromgroup: mito
@@ -173,7 +172,7 @@ call_types:
         filtergroup: strict
       - SBSindel_call_type: mismatch-ds
         filtergroup: strict
-# - call_type: 
+# - call_type:
 #   call_class: MDB
 #   analyzein_chromgroups:
 #   MDB_bamtag: # only for MDB
@@ -182,34 +181,34 @@ call_types:
 #   MDB_base_opposite_strand:  # only for MDB; filter to require specific base on opposite strand or null if no filter
 #   SBSindel_call_types:
 #     - SBSindel_call_type: mutation
-#       filtergroup: 
+#       filtergroup:
 #     - SBSindel_call_type: mismatch-ss
-#       filtergroup: 
+#       filtergroup:
 #     - SBSindel_call_type: mismatch-ds
-#       filtergroup: 
+#       filtergroup:
 #     - SBSindel_call_type: mismatch-os
-#       filtergroup: 
+#       filtergroup:
 #     - SBSindel_call_type: match
-#       filtergroup: 
+#       filtergroup:
 
 ###
 ### Germline VCF filters
 ###
 # These filters, except for ins_pad/del_pad filters, are not applied to MDB calls.
 germline_vcf_types: #define one germline_vcf_type for each used for above germline_vcf_files
-  - germline_vcf_type: 
+  - germline_vcf_type:
     SBS_FILTERS: #Put filters in quotations to avoid bare '.' from being read as NA
-      - 
-    SBS_min_Depth: 
-    SBS_min_VAF: 
-    SBS_min_GQ: 
-    SBS_min_QUAL: 
-    indel_FILTERS: 
-      - 
-    indel_min_Depth: 
-    indel_min_VAF: 
-    indel_min_GQ: 
-    indel_min_QUAL: 
+      -
+    SBS_min_Depth:
+    SBS_min_VAF:
+    SBS_min_GQ:
+    SBS_min_QUAL:
+    indel_FILTERS:
+      -
+    indel_min_Depth:
+    indel_min_VAF:
+    indel_min_GQ:
+    indel_min_QUAL:
     indel_ins_pad: m2b15 # leave blank to disable this filter
     indel_del_pad: m2b15 # leave blank to disable this filter
 
@@ -387,7 +386,7 @@ region_filters:
 #Settings to select variants for sensitivity calculation for SBS and indels
 # Filters are applied separately for each germline_vcf_file and all filters
 # must pass in all germline VCF files. Note: MDB sensitivities are set in the
-# call_types section. 
+# call_types section.
 sensitivity_parameters:
   use_chromgroup: 1-22X # chromgroup to use for calculating sensitivity that is used for all chromgroups. If blank, sensitivity calculation is skipped and sensitivity for all SBS and indel call types is set to 1. Sex chromosomes and mitochondrial chromosome are always excluded from sensitivity analysis, due to complication of pseudo-autosomal regions.
   sensitivity_vcf: [gnomAD genomes SNVs and indels AF >= 0.001 vcf]

--- a/config_templates/hidef-seq_3.0.template.hg38.yaml
+++ b/config_templates/hidef-seq_3.0.template.hg38.yaml
@@ -6,7 +6,7 @@
 ###
 ### Analysis ID
 ###
-analysis_id:
+analysis_id: 
 
 ###
 ### Sequencing runs and samples
@@ -20,14 +20,14 @@ barcodes:
     barcode:
 
 runs: # can specify multiple run_id entries
-  - run_id:
-    reads_file:
+  - run_id: 
+    reads_file: 
     samples:
-      - sample_id:
-        barcode_ids:
+      - sample_id: 
+        barcode_ids: 
         barcode_ids_round2: # optional second demultiplexing round; if performed for a sample, barcode_ids_round2 must be configured for that sample across all runs that contain it
-      - sample_id:
-        barcode_ids:
+      - sample_id: 
+        barcode_ids: 
         barcode_ids_round2: # optional second demultiplexing round; if performed for a sample, barcode_ids_round2 must be configured for that sample across all runs that contain it
 
 samples:
@@ -42,29 +42,29 @@ samples:
 ### Individuals
 ###
 individuals:
-  - individual_id:
+  - individual_id: 
     sex:  # male or female
-    germline_bam_file:
+    germline_bam_file: 
     germline_bam_type: # Illumina or PacBio
     germline_vcf_files: # can define any number of germlien_vcf_files
-      - germline_vcf_file:
+      - germline_vcf_file: 
         germline_vcf_type:  # any value possible; each configured in the germline_vcf_types section
-      - germline_vcf_file:
-        germline_vcf_type:
-  - individual_id:
-    sex:
-    germline_bam_file:
-    germline_bam_type:
+      - germline_vcf_file: 
+        germline_vcf_type: 
+  - individual_id: 
+    sex: 
+    germline_bam_file: 
+    germline_bam_type: 
     germline_vcf_files:
-      - germline_vcf_file:
-        germline_vcf_type:
-      - germline_vcf_file:
-        germline_vcf_type:
+      - germline_vcf_file: 
+        germline_vcf_type: 
+      - germline_vcf_file: 
+        germline_vcf_type: 
 
 ###
 ### Output folders
 ###
-analysis_output_dir:
+analysis_output_dir: 
 cache_dir:  # cannot be under the /home folder to ensure mounting by container.
 
 ###
@@ -128,7 +128,7 @@ genome_organism: Hsapiens
 sex_chromosomes: chrX,chrY # comma-delimited
 mitochondrial_chromosome: chrM
 circular_chromosomes: chrM
-chromgroups:
+chromgroups: 
   - chromgroup: 1-22X
     chroms: chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX #comma-delimited
   - chromgroup: mito
@@ -172,7 +172,7 @@ call_types:
         filtergroup: strict
       - SBSindel_call_type: mismatch-ds
         filtergroup: strict
-# - call_type:
+# - call_type: 
 #   call_class: MDB
 #   analyzein_chromgroups:
 #   MDB_bamtag: # only for MDB
@@ -181,34 +181,34 @@ call_types:
 #   MDB_base_opposite_strand:  # only for MDB; filter to require specific base on opposite strand or null if no filter
 #   SBSindel_call_types:
 #     - SBSindel_call_type: mutation
-#       filtergroup:
+#       filtergroup: 
 #     - SBSindel_call_type: mismatch-ss
-#       filtergroup:
+#       filtergroup: 
 #     - SBSindel_call_type: mismatch-ds
-#       filtergroup:
+#       filtergroup: 
 #     - SBSindel_call_type: mismatch-os
-#       filtergroup:
+#       filtergroup: 
 #     - SBSindel_call_type: match
-#       filtergroup:
+#       filtergroup: 
 
 ###
 ### Germline VCF filters
 ###
 # These filters, except for ins_pad/del_pad filters, are not applied to MDB calls.
 germline_vcf_types: #define one germline_vcf_type for each used for above germline_vcf_files
-  - germline_vcf_type:
+  - germline_vcf_type: 
     SBS_FILTERS: #Put filters in quotations to avoid bare '.' from being read as NA
-      -
-    SBS_min_Depth:
-    SBS_min_VAF:
-    SBS_min_GQ:
-    SBS_min_QUAL:
-    indel_FILTERS:
-      -
-    indel_min_Depth:
-    indel_min_VAF:
-    indel_min_GQ:
-    indel_min_QUAL:
+      - 
+    SBS_min_Depth: 
+    SBS_min_VAF: 
+    SBS_min_GQ: 
+    SBS_min_QUAL: 
+    indel_FILTERS: 
+      - 
+    indel_min_Depth: 
+    indel_min_VAF: 
+    indel_min_GQ: 
+    indel_min_QUAL: 
     indel_ins_pad: m2b15 # leave blank to disable this filter
     indel_del_pad: m2b15 # leave blank to disable this filter
 
@@ -386,7 +386,7 @@ region_filters:
 #Settings to select variants for sensitivity calculation for SBS and indels
 # Filters are applied separately for each germline_vcf_file and all filters
 # must pass in all germline VCF files. Note: MDB sensitivities are set in the
-# call_types section.
+# call_types section. 
 sensitivity_parameters:
   use_chromgroup: 1-22X # chromgroup to use for calculating sensitivity that is used for all chromgroups. If blank, sensitivity calculation is skipped and sensitivity for all SBS and indel call types is set to 1. Sex chromosomes and mitochondrial chromosome are always excluded from sensitivity analysis, due to complication of pseudo-autosomal regions.
   sensitivity_vcf: [gnomAD genomes SNVs and indels AF >= 0.001 vcf]

--- a/config_templates/hidef-seq_3.0.template.yaml
+++ b/config_templates/hidef-seq_3.0.template.yaml
@@ -6,7 +6,7 @@
 ###
 ### Analysis ID
 ###
-analysis_id: 
+analysis_id:
 
 ###
 ### Sequencing runs and samples
@@ -20,14 +20,14 @@ barcodes:
     barcode:
 
 runs: # can specify multiple run_id entries
-  - run_id: 
-    reads_file: 
+  - run_id:
+    reads_file:
     samples:
-      - sample_id: 
-        barcode_ids: 
+      - sample_id:
+        barcode_ids:
         barcode_ids_round2: # optional second demultiplexing round; if performed for a sample, barcode_ids_round2 must be configured for that sample across all runs that contain it
-      - sample_id: 
-        barcode_ids: 
+      - sample_id:
+        barcode_ids:
         barcode_ids_round2: # optional second demultiplexing round; if performed for a sample, barcode_ids_round2 must be configured for that sample across all runs that contain it
 
 samples:
@@ -42,29 +42,29 @@ samples:
 ### Individuals
 ###
 individuals:
-  - individual_id: 
+  - individual_id:
     sex:  # male or female
-    germline_bam_file: 
+    germline_bam_file:
     germline_bam_type: # Illumina or PacBio
     germline_vcf_files: # can define any number of germlien_vcf_files
-      - germline_vcf_file: 
+      - germline_vcf_file:
         germline_vcf_type:  # any value possible; each configured in the germline_vcf_types section
-      - germline_vcf_file: 
-        germline_vcf_type: 
-  - individual_id: 
-    sex: 
-    germline_bam_file: 
-    germline_bam_type: 
+      - germline_vcf_file:
+        germline_vcf_type:
+  - individual_id:
+    sex:
+    germline_bam_file:
+    germline_bam_type:
     germline_vcf_files:
-      - germline_vcf_file: 
-        germline_vcf_type: 
-      - germline_vcf_file: 
-        germline_vcf_type: 
+      - germline_vcf_file:
+        germline_vcf_type:
+      - germline_vcf_file:
+        germline_vcf_type:
 
 ###
 ### Output folders
 ###
-analysis_output_dir: 
+analysis_output_dir:
 cache_dir:  # cannot be under the /home folder to ensure mounting by container.
 
 ###
@@ -121,19 +121,18 @@ output_intermediate_files: true  # true or false
 ###
 ### Genome reference
 ###
-genome_fasta: 
-genome_fai: 
-genome_mmi: 
-BSgenome:
-  BSgenome_name: # run BSGenome available.genomes() function to see all available, or set to the BSgenome_name of below BSGenome_file
-  BSgenome_file:  # optional tar.gz of custom BSgenome that is not in available.genomes()
+genome_fasta:
+genome_fai:
+genome_mmi:
+genome_organism: # used to derive the forged BSgenome package name
 sex_chromosomes: # comma-delimited
-mitochondrial_chromosome: 
-chromgroups: 
-  - chromgroup: 
+mitochondrial_chromosome:
+circular_chromosomes: # comma-delimited; use chrM when mitochondrial_chromosome is chrM
+chromgroups:
+  - chromgroup:
     chroms:  #comma-delimited
-  - chromgroup: 
-    chroms: 
+  - chromgroup:
+    chroms:
 
 ###
 ### extractCalls workflow
@@ -173,7 +172,7 @@ call_types:
         filtergroup: strict
       - SBSindel_call_type: mismatch-ds
         filtergroup: strict
-# - call_type: 
+# - call_type:
 #   call_class: MDB
 #   analyzein_chromgroups:
 #   MDB_bamtag: # only for MDB
@@ -182,34 +181,34 @@ call_types:
 #   MDB_base_opposite_strand:  # only for MDB; filter to require specific base on opposite strand or null if no filter
 #   SBSindel_call_types:
 #     - SBSindel_call_type: mutation
-#       filtergroup: 
+#       filtergroup:
 #     - SBSindel_call_type: mismatch-ss
-#       filtergroup: 
+#       filtergroup:
 #     - SBSindel_call_type: mismatch-ds
-#       filtergroup: 
+#       filtergroup:
 #     - SBSindel_call_type: mismatch-os
-#       filtergroup: 
+#       filtergroup:
 #     - SBSindel_call_type: match
-#       filtergroup: 
+#       filtergroup:
 
 ###
 ### Germline VCF filters
 ###
 # These filters, except for ins_pad/del_pad filters, are not applied to MDB calls.
 germline_vcf_types: #define one germline_vcf_type for each used for above germline_vcf_files
-  - germline_vcf_type: 
+  - germline_vcf_type:
     SBS_FILTERS: #Put filters in quotations to avoid bare '.' from being read as NA
-      - 
-    SBS_min_Depth: 
-    SBS_min_VAF: 
-    SBS_min_GQ: 
-    SBS_min_QUAL: 
-    indel_FILTERS: 
-      - 
-    indel_min_Depth: 
-    indel_min_VAF: 
-    indel_min_GQ: 
-    indel_min_QUAL: 
+      -
+    SBS_min_Depth:
+    SBS_min_VAF:
+    SBS_min_GQ:
+    SBS_min_QUAL:
+    indel_FILTERS:
+      -
+    indel_min_Depth:
+    indel_min_VAF:
+    indel_min_GQ:
+    indel_min_QUAL:
     indel_ins_pad: m2b15 # leave blank to disable this filter
     indel_del_pad: m2b15 # leave blank to disable this filter
 
@@ -290,21 +289,21 @@ filtergroups:
 region_filters:
   - read_filters: # define any number of read filters
     - region_filter_file: # bigWig file
-      binsize: 
+      binsize:
       threshold: # lt (<), lte (<=), gt (>), gte (>=) followed by a number (no space between)
-      padding: 
-      read_threshold: 
+      padding:
+      read_threshold:
       applyto_chromgroups:  # comma-separated list, or 'all'
       applyto_filtergroups:  # comma-separated list, or 'all'
       is_germline_filter:  # true/false if this filter specifically removes germline variants, such as a gnomAD variant filter. This prevents this filter from being applied in sensitivity calculations that analyze germline variants.
   - genome_filters: # define any number of genome filters
-    - region_filter_file: 
-      binsize: 
-      threshold: 
-      padding: 
-      applyto_chromgroups: 
-      applyto_filtergroups: 
-      is_germline_filter: 
+    - region_filter_file:
+      binsize:
+      threshold:
+      padding:
+      applyto_chromgroups:
+      applyto_filtergroups:
+      is_germline_filter:
 
 ###
 ### Sensitivity calculation
@@ -312,10 +311,10 @@ region_filters:
 #Settings to select variants for sensitivity calculation for SBS and indels
 # Filters are applied separately for each germline_vcf_file and all filters
 # must pass in all germline VCF files. Note: MDB sensitivities are set in the
-# call_types section. 
+# call_types section.
 sensitivity_parameters:
   use_chromgroup: # chromgroup to use for calculating sensitivity that is used for all chromgroups. If blank, sensitivity calculation is skipped and sensitivity for all SBS and indel call types is set to 1. Sex chromosomes and mitochondrial chromosome are always excluded from sensitivity analysis, due to complication of pseudo-autosomal regions.
-  sensitivity_vcf: 
+  sensitivity_vcf:
   genotype: heterozygous #heterozygous or homozygous
   SBS_min_Depth_quantile: 0.5
   SBS_min_VAF: 0.3

--- a/config_templates/hidef-seq_3.0.template.yaml
+++ b/config_templates/hidef-seq_3.0.template.yaml
@@ -6,7 +6,7 @@
 ###
 ### Analysis ID
 ###
-analysis_id:
+analysis_id: 
 
 ###
 ### Sequencing runs and samples
@@ -20,14 +20,14 @@ barcodes:
     barcode:
 
 runs: # can specify multiple run_id entries
-  - run_id:
-    reads_file:
+  - run_id: 
+    reads_file: 
     samples:
-      - sample_id:
-        barcode_ids:
+      - sample_id: 
+        barcode_ids: 
         barcode_ids_round2: # optional second demultiplexing round; if performed for a sample, barcode_ids_round2 must be configured for that sample across all runs that contain it
-      - sample_id:
-        barcode_ids:
+      - sample_id: 
+        barcode_ids: 
         barcode_ids_round2: # optional second demultiplexing round; if performed for a sample, barcode_ids_round2 must be configured for that sample across all runs that contain it
 
 samples:
@@ -42,29 +42,29 @@ samples:
 ### Individuals
 ###
 individuals:
-  - individual_id:
+  - individual_id: 
     sex:  # male or female
-    germline_bam_file:
+    germline_bam_file: 
     germline_bam_type: # Illumina or PacBio
     germline_vcf_files: # can define any number of germlien_vcf_files
-      - germline_vcf_file:
+      - germline_vcf_file: 
         germline_vcf_type:  # any value possible; each configured in the germline_vcf_types section
-      - germline_vcf_file:
-        germline_vcf_type:
-  - individual_id:
-    sex:
-    germline_bam_file:
-    germline_bam_type:
+      - germline_vcf_file: 
+        germline_vcf_type: 
+  - individual_id: 
+    sex: 
+    germline_bam_file: 
+    germline_bam_type: 
     germline_vcf_files:
-      - germline_vcf_file:
-        germline_vcf_type:
-      - germline_vcf_file:
-        germline_vcf_type:
+      - germline_vcf_file: 
+        germline_vcf_type: 
+      - germline_vcf_file: 
+        germline_vcf_type: 
 
 ###
 ### Output folders
 ###
-analysis_output_dir:
+analysis_output_dir: 
 cache_dir:  # cannot be under the /home folder to ensure mounting by container.
 
 ###
@@ -121,18 +121,18 @@ output_intermediate_files: true  # true or false
 ###
 ### Genome reference
 ###
-genome_fasta:
-genome_fai:
-genome_mmi:
-genome_organism: # used to derive the forged BSgenome package name
+genome_fasta: 
+genome_fai: 
+genome_mmi: 
+genome_organism: # single-word token used in the package name of the created BSgenome package
 sex_chromosomes: # comma-delimited
-mitochondrial_chromosome:
-circular_chromosomes: # comma-delimited; use chrM when mitochondrial_chromosome is chrM
-chromgroups:
-  - chromgroup:
+mitochondrial_chromosome: 
+circular_chromosomes: # comma-delimited
+chromgroups: 
+  - chromgroup: 
     chroms:  #comma-delimited
-  - chromgroup:
-    chroms:
+  - chromgroup: 
+    chroms: 
 
 ###
 ### extractCalls workflow
@@ -172,7 +172,7 @@ call_types:
         filtergroup: strict
       - SBSindel_call_type: mismatch-ds
         filtergroup: strict
-# - call_type:
+# - call_type: 
 #   call_class: MDB
 #   analyzein_chromgroups:
 #   MDB_bamtag: # only for MDB
@@ -181,34 +181,34 @@ call_types:
 #   MDB_base_opposite_strand:  # only for MDB; filter to require specific base on opposite strand or null if no filter
 #   SBSindel_call_types:
 #     - SBSindel_call_type: mutation
-#       filtergroup:
+#       filtergroup: 
 #     - SBSindel_call_type: mismatch-ss
-#       filtergroup:
+#       filtergroup: 
 #     - SBSindel_call_type: mismatch-ds
-#       filtergroup:
+#       filtergroup: 
 #     - SBSindel_call_type: mismatch-os
-#       filtergroup:
+#       filtergroup: 
 #     - SBSindel_call_type: match
-#       filtergroup:
+#       filtergroup: 
 
 ###
 ### Germline VCF filters
 ###
 # These filters, except for ins_pad/del_pad filters, are not applied to MDB calls.
 germline_vcf_types: #define one germline_vcf_type for each used for above germline_vcf_files
-  - germline_vcf_type:
+  - germline_vcf_type: 
     SBS_FILTERS: #Put filters in quotations to avoid bare '.' from being read as NA
-      -
-    SBS_min_Depth:
-    SBS_min_VAF:
-    SBS_min_GQ:
-    SBS_min_QUAL:
-    indel_FILTERS:
-      -
-    indel_min_Depth:
-    indel_min_VAF:
-    indel_min_GQ:
-    indel_min_QUAL:
+      - 
+    SBS_min_Depth: 
+    SBS_min_VAF: 
+    SBS_min_GQ: 
+    SBS_min_QUAL: 
+    indel_FILTERS: 
+      - 
+    indel_min_Depth: 
+    indel_min_VAF: 
+    indel_min_GQ: 
+    indel_min_QUAL: 
     indel_ins_pad: m2b15 # leave blank to disable this filter
     indel_del_pad: m2b15 # leave blank to disable this filter
 
@@ -289,21 +289,21 @@ filtergroups:
 region_filters:
   - read_filters: # define any number of read filters
     - region_filter_file: # bigWig file
-      binsize:
+      binsize: 
       threshold: # lt (<), lte (<=), gt (>), gte (>=) followed by a number (no space between)
-      padding:
-      read_threshold:
+      padding: 
+      read_threshold: 
       applyto_chromgroups:  # comma-separated list, or 'all'
       applyto_filtergroups:  # comma-separated list, or 'all'
       is_germline_filter:  # true/false if this filter specifically removes germline variants, such as a gnomAD variant filter. This prevents this filter from being applied in sensitivity calculations that analyze germline variants.
   - genome_filters: # define any number of genome filters
-    - region_filter_file:
-      binsize:
-      threshold:
-      padding:
-      applyto_chromgroups:
-      applyto_filtergroups:
-      is_germline_filter:
+    - region_filter_file: 
+      binsize: 
+      threshold: 
+      padding: 
+      applyto_chromgroups: 
+      applyto_filtergroups: 
+      is_germline_filter: 
 
 ###
 ### Sensitivity calculation
@@ -311,10 +311,10 @@ region_filters:
 #Settings to select variants for sensitivity calculation for SBS and indels
 # Filters are applied separately for each germline_vcf_file and all filters
 # must pass in all germline VCF files. Note: MDB sensitivities are set in the
-# call_types section.
+# call_types section. 
 sensitivity_parameters:
   use_chromgroup: # chromgroup to use for calculating sensitivity that is used for all chromgroups. If blank, sensitivity calculation is skipped and sensitivity for all SBS and indel call types is set to 1. Sex chromosomes and mitochondrial chromosome are always excluded from sensitivity analysis, due to complication of pseudo-autosomal regions.
-  sensitivity_vcf:
+  sensitivity_vcf: 
   genotype: heterozygous #heterozygous or homozygous
   SBS_min_Depth_quantile: 0.5
   SBS_min_VAF: 0.3

--- a/main.nf
+++ b/main.nf
@@ -2,11 +2,6 @@
  * Global variables and functions
  *****************************************************************/
 
-//Library imports
-import org.yaml.snakeyaml.Yaml
-import org.yaml.snakeyaml.DumperOptions
-import java.security.MessageDigest
-
 //Define output directories and related helper functions
 sharedLogsDir = "${params.analysis_output_dir}/${params.analysis_id}.sharedLogs"
 
@@ -33,12 +28,12 @@ def generateAfterScript(logDir, logName) {
   """
 }
 
-signatureYamlOptions = new DumperOptions()
-signatureYamlOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK)
+signatureYamlOptions = new org.yaml.snakeyaml.DumperOptions()
+signatureYamlOptions.setDefaultFlowStyle(org.yaml.snakeyaml.DumperOptions.FlowStyle.BLOCK)
 signatureYamlOptions.setPrettyFlow(false)
 signatureYamlOptions.setIndent(2)
 
-signatureYaml = new Yaml(signatureYamlOptions)
+signatureYaml = new org.yaml.snakeyaml.Yaml(signatureYamlOptions)
 
 // Function to calculate a hash for a subset of keys from a parameters file
 def configHash(params_input, keys) {
@@ -50,7 +45,7 @@ def configHash(params_input, keys) {
   }
 
   def serialized = signatureYaml.dump(subset ?: [:])
-  def digest = MessageDigest.getInstance('SHA-256')
+  def digest = java.security.MessageDigest.getInstance('SHA-256')
   digest.update(serialized.getBytes('UTF-8'))
   digest.digest().encodeHex().toString()
 }
@@ -100,11 +95,11 @@ workflow {
   logsDir = file("${sharedLogsDir}")
   logsDir.mkdirs()
 
-  options = new DumperOptions()
-  options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK)
+  options = new org.yaml.snakeyaml.DumperOptions()
+  options.setDefaultFlowStyle(org.yaml.snakeyaml.DumperOptions.FlowStyle.BLOCK)
   options.setIndent(2)
 
-  yaml = new Yaml(options)
+  yaml = new org.yaml.snakeyaml.Yaml(options)
   timestamp = new Date().format('yyyy_MMdd_HHmm')
   file("${logsDir}/runParams.${timestamp}.yaml").text = yaml.dump(params)
 
@@ -128,7 +123,7 @@ workflow {
   params.paramsFileName = commandLineTokens[commandLineTokens.indexOf('-params-file') + 1]
 
   // Define parameters file components that are checked for changes to determine if a process is rerun upon resume
-  sharedFunctionsHash = MessageDigest.getInstance('SHA-256')
+  sharedFunctionsHash = java.security.MessageDigest.getInstance('SHA-256')
     .digest(file("${workflow.projectDir}/bin/sharedFunctions.R").bytes)
     .encodeHex()
     .toString()

--- a/main.nf
+++ b/main.nf
@@ -445,7 +445,7 @@ workflow {
     .map { run_id, individual_id, sample_id, barcode_ids, barcode_ids_round2, barcode_pair_key_round2, barcode_pair_key, bamFile ->
       tuple(run_id, individual_id, sample_id, "${barcode_ids}.${barcode_ids_round2}", bamFile)
     }
-
+  
   mergeDemuxBams_round2_input_ch = limaDemux_round2_map_ch
     .groupTuple(by: [0,1,2,3])
 
@@ -543,7 +543,7 @@ workflow {
   // installBSgenome
   //******************
   installBSgenome(Channel.value(config_signatures.installBSgenome))
-  BSgenome_name_ch = installBSgenome.out.bsgenome_name_file.map { it.text.trim() }
+  BSgenome_name_ch = installBSgenome.out.map { it.text.trim() }
 
   //******************
   // extractGenomeTrinucleotides
@@ -745,7 +745,7 @@ process ccsChunk {
     time '24h'
     tag { "ccsChunk: chunk ${chunkID}" }
     container "${params.hidefseq_container}"
-
+    
     input:
       tuple val(run_id), path(bamFile), path(pbiFile), val(chunkID)
 
@@ -791,7 +791,7 @@ process mergeCCSchunks {
     time '6h'
     tag "mergeCCSchunks"
     container "${params.hidefseq_container}"
-
+    
     input:
       tuple val(run_id), path(bamChunks), path(pbiChunks)
 
@@ -822,10 +822,10 @@ process filterAdapter {
     time '4h'
     tag "filterAdapter"
     container "${params.hidefseq_container}"
-
+    
     input:
       tuple val(run_id), path(bamFile), path(pbiFile)
-
+    
     output:
       tuple val(run_id), path("${run_id}.ccs.filtered.bam"), path("${run_id}.ccs.filtered.bam.pbi")
 
@@ -835,7 +835,7 @@ process filterAdapter {
         "${task.process}.${params.analysis_id}.${run_id}.command.log"
       )
     }
-
+    
     script:
     """
     ${params.samtools_bin} view -b -@ ${task.cpus} -e "[ma]==0" ${bamFile} > ${run_id}.ccs.filtered.bam
@@ -979,10 +979,10 @@ process pbmm2Align {
     time '6h'
     tag { "pbmm2Align: ${run_id} ${sample_id} ${barcode_id}" }
     container "${params.hidefseq_container}"
-
+    
     input:
       tuple val(run_id), val(individual_id), val(sample_id), val(barcode_id), path(bamFile)
-
+    
     output:
       tuple val(run_id), val(individual_id), val(sample_id), val(barcode_id), path("${run_id}.${individual_id}.${sample_id}.${barcode_id}.ccs.filtered.aligned.bam"), path("${run_id}.${individual_id}.${sample_id}.${barcode_id}.ccs.filtered.aligned.bam.pbi")
 
@@ -1045,7 +1045,7 @@ process mergeAlignedSampleBAMs {
     time '4h'
     tag { "mergeAlignedSampleBAMs: ${sample_id}" }
     container "${params.hidefseq_container}"
-
+    
     input:
       tuple val(individual_id), val(sample_id), path(bamFiles), path(pbiFiles)
 
@@ -1074,7 +1074,7 @@ process mergeAlignedSampleBAMs {
     conda activate ${params.conda_pbbioconda_env}
     pbmerge -o \${sample_basename}.unsorted.bam ${bamFiles.join(' ')}
     conda deactivate
-
+    
     ${params.samtools_bin} sort -@ ${task.cpus} -m 4G \${sample_basename}.unsorted.bam > \${sample_basename}.sorted.bam
     ${params.samtools_bin} index -@ ${task.cpus} \${sample_basename}.sorted.bam
 
@@ -1092,15 +1092,15 @@ process countZMWs {
     time '10m'
     tag { "countZMWs: ${bamFile}" }
     container "${params.hidefseq_container}"
-
+    
     input:
       tuple path(bamFile), path(pbiFile), val(outFileSuffix)
-
+    
     output:
       path "*.${outFileSuffix}"
-
+    
     publishDir "${sharedLogsDir}", mode: "copy"
-
+    
     script:
     """
     set -euo pipefail
@@ -1120,10 +1120,10 @@ process splitBAM {
     time '1h'
     tag { "splitBAM: ${sample_id}" }
     container "${params.hidefseq_container}"
-
+    
     input:
       tuple val(individual_id), val(sample_id), path(bamFile), path(pbiFile), path(baiFile), val(chunkID)
-
+    
     output:
       tuple val(individual_id), val(sample_id),
       path("${params.analysis_id}.${individual_id}.${sample_id}.ccs.filtered.aligned.sorted.chunk${chunkID}.bam"),
@@ -1153,7 +1153,7 @@ process splitBAM {
     ids_file=\${sample_basename}.zmwIDs.txt
     chunk_ids=\${sample_basename}.chunk${chunkID}.zmwIDs.txt
     chunk_bam=\${sample_basename}.chunk${chunkID}.bam
-
+    
     zmwfilter --show-all ${bamFile} > \$ids_file
 
     total_zmws=\$(wc -l < \$ids_file)
@@ -1192,7 +1192,7 @@ process splitBAM {
 process installBSgenome {
     cpus 1
     memory '16 GB'
-    time '12h'
+    time '8h'
     tag { "installBSgenome" }
     container "${params.hidefseq_container}"
     cache false //Always run this process because the BSgenome could have been deleted outside nextflow and because the script itself checks if the BSgenome is already installed.
@@ -1201,7 +1201,7 @@ process installBSgenome {
       val(config_sig)
 
     output:
-      path("BSgenome_name.txt"), emit: bsgenome_name_file
+      path("BSgenome_name.txt")
 
     afterScript{
       generateAfterScript(
@@ -1266,7 +1266,7 @@ process processGermlineVCFs {
     time '4h'
     tag { "processGermlineVCFs: ${individual_id}" }
     container "${params.hidefseq_container}"
-
+      
     input:
       tuple val(individual_id), path(germline_bam_file), val(config_sig)
 
@@ -1297,7 +1297,7 @@ process processGermlineBAMs {
     time '24h'
     tag { "processGermlineBAMs: ${germline_bam_file}" }
     container "${params.hidefseq_container}"
-
+    
     input:
       tuple path(germline_bam_file), val(germline_bam_type)
 
@@ -1327,7 +1327,7 @@ process processGermlineBAMs {
 
     #Slightly different parameters are used for Illumina vs PacBio germline BAM to match how bcftools mpileup is run later
     #in the call filtering analysis.
-
+    
     set -euo pipefail
 
     if [[ ${germline_bam_type} == Illumina ]]; then
@@ -1358,7 +1358,7 @@ process prepareRegionFilters {
     time '24h'
     tag { "prepareRegionFilters: ${region_filter_file}, bin ${binsize}, threshold ${threshold}" }
     container "${params.hidefseq_container}"
-
+    
     input:
       tuple path(region_filter_file), val(binsize), val(threshold)
 
@@ -1395,7 +1395,7 @@ process prepareRegionFilters {
     fi
 
     echo "threshold command: \$threshold_command"
-
+    
     ${params.wiggletools_bin} \$threshold_command trim chromsizes.bed fillIn chromsizes.bed \$scale_command ${region_filter_file} \
       | ${params.wigToBigWig_bin} stdin <(cut -f 1,2 ${params.genome_fai}) ${region_filter_file}.bin${binsize}.${threshold}.bw
     """
@@ -1417,10 +1417,10 @@ process extractCallsChunk {
     maxRetries params.maxRetries_extractCallsChunk
     tag { "extractCallsChunk: ${sample_id} -> chunk ${chunkID}" }
     container "${params.hidefseq_container}"
-
+    
     input:
       tuple val(individual_id), val(sample_id), path(bamFile), path(pbiFile), path(baiFile), val(chunkID), val(config_sig)
-
+    
     output:
       tuple val(individual_id), val(sample_id), path("${params.analysis_id}.${individual_id}.${sample_id}.extractCalls.chunk${chunkID}.qs2"), val(chunkID)
 
@@ -1461,7 +1461,7 @@ process filterCallsChunkChromgroupFiltergroup {
 
     input:
       tuple val(individual_id), val(sample_id), path(extractCallsFile), val(chunkID), val(chromgroup), val(filtergroup), val(config_sig)
-
+    
     output:
       tuple val(individual_id), val(sample_id), val(chromgroup), val(filtergroup), val(chunkID), path("${params.analysis_id}.${individual_id}.${sample_id}.${chromgroup}.${filtergroup}.filterCalls.chunk${chunkID}.qs2")
 
@@ -1499,10 +1499,10 @@ process calculateBurdensChromgroupFiltergroup {
     maxRetries params.maxRetries_calculateBurdensChromgroupFiltergroup
     tag { "calculateBurdensChromgroupFiltergroup: ${sample_id} -> ${chromgroup} x ${filtergroup}" }
     container "${params.hidefseq_container}"
-
+    
     input:
       tuple val(individual_id), val(sample_id), val(chromgroup), val(filtergroup), path(filterCallsFiles), val(config_sig)
-
+    
     output:
       tuple val(individual_id), val(sample_id), val(chromgroup), val(filtergroup), path("${params.analysis_id}.${individual_id}.${sample_id}.${chromgroup}.${filtergroup}.calculateBurdens.qs2"), emit: tuple_qs2
       tuple val(individual_id), val(sample_id), val(chromgroup), val(filtergroup), path("*.bed.gz"), path("*.bed.gz.tbi"), emit: coverage_reftnc
@@ -1547,17 +1547,17 @@ process outputResultsSample {
     maxRetries params.maxRetries_outputResultsSample
     tag { "outputResultsSample: ${sample_id}" }
     container "${params.hidefseq_container}"
-
+    
     input:
       tuple val(individual_id), val(sample_id), path(calculateBurdensFiles), val(config_sig)
-
+    
     output:
       tuple val(individual_id), val(sample_id), emit: out_ch
       path("${params.analysis_id}.${individual_id}.${sample_id}.outputResults.qs2")
       path("${params.analysis_id}.${individual_id}.${sample_id}.yaml_config.tsv")
       path("${params.analysis_id}.${individual_id}.${sample_id}.run_metadata.tsv")
       path("*/**/*.{tsv,vcf.bgz,vcf.bgz.tbi,pdf}")
-
+        
     publishDir path: "${params.analysis_output_dir}",
       mode: 'move',
       saveAs: { filename -> "${sampleBaseDir(individual_id, sample_id)}/${filename}" }

--- a/main.nf
+++ b/main.nf
@@ -573,7 +573,7 @@ workflow {
   //******************
   // extractGenomeTrinucleotides
   //******************
-  extractGenomeTrinucleotides(BSgenome_name_ch)
+  extractGenomeTrinucleotides()
 
   //******************
   // processGermlineVCFs
@@ -1260,12 +1260,9 @@ process extractGenomeTrinucleotides {
       )
     }
 
-    input:
-      val(BSgenome_name)
-
     output:
-      path("${BSgenome_name}.bed.gz")
-      path("${BSgenome_name}.bed.gz.tbi")
+      path("${file(params.genome_fasta).name}.bed.gz")
+      path("${file(params.genome_fasta).name}.bed.gz.tbi")
 
     script:
     """
@@ -1276,9 +1273,9 @@ process extractGenomeTrinucleotides {
       ${params.seqkit_bin} seq -u | \
       ${params.seqkit_bin} fx2tab -Q | \
       awk -F '[:\\-\\t]' 'BEGIN {OFS="\\t"}{print \$1, \$2, \$2+1, \$4}' | \
-      ${params.bgzip_bin} -c > ${BSgenome_name}.bed.gz
+      ${params.bgzip_bin} -c > ${file(params.genome_fasta).name}.bed.gz
 
-    ${params.tabix_bin} -@ ${task.cpus} -s 1 -b 2 -e 3 ${BSgenome_name}.bed.gz
+    ${params.tabix_bin} -@ ${task.cpus} -s 1 -b 2 -e 3 ${file(params.genome_fasta).name}.bed.gz
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -134,12 +134,12 @@ workflow {
     .toString()
   paramsWithSharedFunctionsHash = params + [sharedFunctionsHash: sharedFunctionsHash]
   config_signatures = [
-    installBSgenome: configHash(params, ['cache_dir', 'BSgenome']),
-    processGermlineVCFs: configHash(paramsWithSharedFunctionsHash, ['cache_dir', 'BSgenome', 'individuals', 'genome_fasta', 'bcftools_bin', 'sharedFunctionsHash']),
-    extractCallsChunk: configHash(paramsWithSharedFunctionsHash, ['cache_dir', 'BSgenome', 'call_types', 'chromgroups', 'runs', 'min_strand_overlap', 'sharedFunctionsHash']),
-    filterCallsChunkChromgroupFiltergroup: configHash(paramsWithSharedFunctionsHash, ['BSgenome', 'bcftools_bin', 'cache_dir', 'call_types', 'chromgroups', 'filtergroups', 'genome_fai', 'genome_fasta', 'germline_vcf_types', 'individuals', 'region_filters', 'samples', 'wigToBigWig_bin', 'wiggletools_bin', 'sharedFunctionsHash']),
-    calculateBurdensChromgroupFiltergroup: configHash(paramsWithSharedFunctionsHash, ['BSgenome', 'analysis_id', 'bcftools_bin', 'bedtools_bin', 'bgzip_bin', 'cache_dir', 'call_types', 'chromgroups', 'genome_fai', 'genome_fasta', 'individuals', 'mitochondrial_chromosome', 'samples', 'sensitivity_parameters', 'sex_chromosomes', 'tabix_bin', 'sharedFunctionsHash']),
-    outputResultsSample: configHash(paramsWithSharedFunctionsHash, ['BSgenome', 'analysis_id', 'cache_dir', 'call_types', 'chromgroups', 'filtergroups', 'region_filters', 'samples', 'sharedFunctionsHash'])
+    installBSgenome: configHash(params, ['cache_dir', 'genome_fasta', 'genome_organism', 'circular_chromosomes']),
+    processGermlineVCFs: configHash(paramsWithSharedFunctionsHash, ['cache_dir', 'circular_chromosomes', 'individuals', 'genome_fasta', 'genome_organism', 'bcftools_bin', 'sharedFunctionsHash']),
+    extractCallsChunk: configHash(paramsWithSharedFunctionsHash, ['cache_dir', 'circular_chromosomes', 'genome_fasta', 'genome_organism', 'call_types', 'chromgroups', 'runs', 'min_strand_overlap', 'sharedFunctionsHash']),
+    filterCallsChunkChromgroupFiltergroup: configHash(paramsWithSharedFunctionsHash, ['bcftools_bin', 'cache_dir', 'call_types', 'chromgroups', 'circular_chromosomes', 'filtergroups', 'genome_fai', 'genome_fasta', 'genome_organism', 'germline_vcf_types', 'individuals', 'region_filters', 'samples', 'wigToBigWig_bin', 'wiggletools_bin', 'sharedFunctionsHash']),
+    calculateBurdensChromgroupFiltergroup: configHash(paramsWithSharedFunctionsHash, ['analysis_id', 'bcftools_bin', 'bedtools_bin', 'bgzip_bin', 'cache_dir', 'call_types', 'chromgroups', 'circular_chromosomes', 'genome_fai', 'genome_fasta', 'genome_organism', 'individuals', 'mitochondrial_chromosome', 'samples', 'sensitivity_parameters', 'sex_chromosomes', 'tabix_bin', 'sharedFunctionsHash']),
+    outputResultsSample: configHash(paramsWithSharedFunctionsHash, ['analysis_id', 'cache_dir', 'call_types', 'chromgroups', 'circular_chromosomes', 'filtergroups', 'genome_fasta', 'genome_organism', 'region_filters', 'samples', 'sharedFunctionsHash'])
   ]
 
   // Validate barcodes section and build barcode map
@@ -445,7 +445,7 @@ workflow {
     .map { run_id, individual_id, sample_id, barcode_ids, barcode_ids_round2, barcode_pair_key_round2, barcode_pair_key, bamFile ->
       tuple(run_id, individual_id, sample_id, "${barcode_ids}.${barcode_ids_round2}", bamFile)
     }
-  
+
   mergeDemuxBams_round2_input_ch = limaDemux_round2_map_ch
     .groupTuple(by: [0,1,2,3])
 
@@ -543,11 +543,12 @@ workflow {
   // installBSgenome
   //******************
   installBSgenome(Channel.value(config_signatures.installBSgenome))
+  BSgenome_name_ch = installBSgenome.out.bsgenome_name_file.map { it.text.trim() }
 
   //******************
   // extractGenomeTrinucleotides
   //******************
-  extractGenomeTrinucleotides()
+  extractGenomeTrinucleotides(BSgenome_name_ch)
 
   //******************
   // processGermlineVCFs
@@ -557,8 +558,8 @@ workflow {
   processGermlineVCFs_input_ch = Channel
     .from(params.individuals)
     .map { individual -> tuple(individual.individual_id, file(individual.germline_bam_file)) }
-    .combine(installBSgenome.out)
-    .map { individual_id, germline_bam_file, bsgenome_done -> 
+    .combine(BSgenome_name_ch)
+    .map { individual_id, germline_bam_file, BSgenome_name ->
       tuple(individual_id, germline_bam_file, config_signatures.processGermlineVCFs)
     }
 
@@ -607,7 +608,7 @@ workflow {
   //******************
 
   // Create a completion signal for all filter-related processes by collecting all outputs
-  prepareFilters_done = installBSgenome.out
+  prepareFilters_done = BSgenome_name_ch
     .mix(
       extractGenomeTrinucleotides.out,
       processGermlineVCFs.out,
@@ -744,7 +745,7 @@ process ccsChunk {
     time '24h'
     tag { "ccsChunk: chunk ${chunkID}" }
     container "${params.hidefseq_container}"
-    
+
     input:
       tuple val(run_id), path(bamFile), path(pbiFile), val(chunkID)
 
@@ -790,7 +791,7 @@ process mergeCCSchunks {
     time '6h'
     tag "mergeCCSchunks"
     container "${params.hidefseq_container}"
-    
+
     input:
       tuple val(run_id), path(bamChunks), path(pbiChunks)
 
@@ -821,10 +822,10 @@ process filterAdapter {
     time '4h'
     tag "filterAdapter"
     container "${params.hidefseq_container}"
-    
+
     input:
       tuple val(run_id), path(bamFile), path(pbiFile)
-    
+
     output:
       tuple val(run_id), path("${run_id}.ccs.filtered.bam"), path("${run_id}.ccs.filtered.bam.pbi")
 
@@ -834,7 +835,7 @@ process filterAdapter {
         "${task.process}.${params.analysis_id}.${run_id}.command.log"
       )
     }
-    
+
     script:
     """
     ${params.samtools_bin} view -b -@ ${task.cpus} -e "[ma]==0" ${bamFile} > ${run_id}.ccs.filtered.bam
@@ -978,10 +979,10 @@ process pbmm2Align {
     time '6h'
     tag { "pbmm2Align: ${run_id} ${sample_id} ${barcode_id}" }
     container "${params.hidefseq_container}"
-    
+
     input:
       tuple val(run_id), val(individual_id), val(sample_id), val(barcode_id), path(bamFile)
-    
+
     output:
       tuple val(run_id), val(individual_id), val(sample_id), val(barcode_id), path("${run_id}.${individual_id}.${sample_id}.${barcode_id}.ccs.filtered.aligned.bam"), path("${run_id}.${individual_id}.${sample_id}.${barcode_id}.ccs.filtered.aligned.bam.pbi")
 
@@ -1044,7 +1045,7 @@ process mergeAlignedSampleBAMs {
     time '4h'
     tag { "mergeAlignedSampleBAMs: ${sample_id}" }
     container "${params.hidefseq_container}"
-    
+
     input:
       tuple val(individual_id), val(sample_id), path(bamFiles), path(pbiFiles)
 
@@ -1073,7 +1074,7 @@ process mergeAlignedSampleBAMs {
     conda activate ${params.conda_pbbioconda_env}
     pbmerge -o \${sample_basename}.unsorted.bam ${bamFiles.join(' ')}
     conda deactivate
-    
+
     ${params.samtools_bin} sort -@ ${task.cpus} -m 4G \${sample_basename}.unsorted.bam > \${sample_basename}.sorted.bam
     ${params.samtools_bin} index -@ ${task.cpus} \${sample_basename}.sorted.bam
 
@@ -1091,15 +1092,15 @@ process countZMWs {
     time '10m'
     tag { "countZMWs: ${bamFile}" }
     container "${params.hidefseq_container}"
-    
+
     input:
       tuple path(bamFile), path(pbiFile), val(outFileSuffix)
-    
+
     output:
       path "*.${outFileSuffix}"
-    
+
     publishDir "${sharedLogsDir}", mode: "copy"
-    
+
     script:
     """
     set -euo pipefail
@@ -1119,10 +1120,10 @@ process splitBAM {
     time '1h'
     tag { "splitBAM: ${sample_id}" }
     container "${params.hidefseq_container}"
-    
+
     input:
       tuple val(individual_id), val(sample_id), path(bamFile), path(pbiFile), path(baiFile), val(chunkID)
-    
+
     output:
       tuple val(individual_id), val(sample_id),
       path("${params.analysis_id}.${individual_id}.${sample_id}.ccs.filtered.aligned.sorted.chunk${chunkID}.bam"),
@@ -1152,7 +1153,7 @@ process splitBAM {
     ids_file=\${sample_basename}.zmwIDs.txt
     chunk_ids=\${sample_basename}.chunk${chunkID}.zmwIDs.txt
     chunk_bam=\${sample_basename}.chunk${chunkID}.bam
-    
+
     zmwfilter --show-all ${bamFile} > \$ids_file
 
     total_zmws=\$(wc -l < \$ids_file)
@@ -1190,8 +1191,8 @@ process splitBAM {
 */
 process installBSgenome {
     cpus 1
-    memory '4 GB'
-    time '2h'
+    memory '16 GB'
+    time '12h'
     tag { "installBSgenome" }
     container "${params.hidefseq_container}"
     cache false //Always run this process because the BSgenome could have been deleted outside nextflow and because the script itself checks if the BSgenome is already installed.
@@ -1200,7 +1201,7 @@ process installBSgenome {
       val(config_sig)
 
     output:
-      val(true)
+      path("BSgenome_name.txt"), emit: bsgenome_name_file
 
     afterScript{
       generateAfterScript(
@@ -1225,9 +1226,12 @@ process extractGenomeTrinucleotides {
     tag { "extractGenomeTrinucleotides" }
     container "${params.hidefseq_container}"
 
+    input:
+      val(BSgenome_name)
+
     output:
-      path("${params.BSgenome.BSgenome_name}.bed.gz")
-      path("${params.BSgenome.BSgenome_name}.bed.gz.tbi")
+      path("${BSgenome_name}.bed.gz")
+      path("${BSgenome_name}.bed.gz.tbi")
 
     storeDir "${params.cache_dir}"
 
@@ -1247,9 +1251,9 @@ process extractGenomeTrinucleotides {
       ${params.seqkit_bin} seq -u | \
       ${params.seqkit_bin} fx2tab -Q | \
       awk -F '[:\\-\\t]' 'BEGIN {OFS="\\t"}{print \$1, \$2, \$2+1, \$4}' | \
-      ${params.bgzip_bin} -c > ${params.BSgenome.BSgenome_name}.bed.gz
+      ${params.bgzip_bin} -c > ${BSgenome_name}.bed.gz
 
-    ${params.tabix_bin} -@ ${task.cpus} -s 1 -b 2 -e 3 ${params.BSgenome.BSgenome_name}.bed.gz
+    ${params.tabix_bin} -@ ${task.cpus} -s 1 -b 2 -e 3 ${BSgenome_name}.bed.gz
     """
 }
 
@@ -1262,7 +1266,7 @@ process processGermlineVCFs {
     time '4h'
     tag { "processGermlineVCFs: ${individual_id}" }
     container "${params.hidefseq_container}"
-      
+
     input:
       tuple val(individual_id), path(germline_bam_file), val(config_sig)
 
@@ -1293,7 +1297,7 @@ process processGermlineBAMs {
     time '24h'
     tag { "processGermlineBAMs: ${germline_bam_file}" }
     container "${params.hidefseq_container}"
-    
+
     input:
       tuple path(germline_bam_file), val(germline_bam_type)
 
@@ -1323,7 +1327,7 @@ process processGermlineBAMs {
 
     #Slightly different parameters are used for Illumina vs PacBio germline BAM to match how bcftools mpileup is run later
     #in the call filtering analysis.
-    
+
     set -euo pipefail
 
     if [[ ${germline_bam_type} == Illumina ]]; then
@@ -1354,7 +1358,7 @@ process prepareRegionFilters {
     time '24h'
     tag { "prepareRegionFilters: ${region_filter_file}, bin ${binsize}, threshold ${threshold}" }
     container "${params.hidefseq_container}"
-    
+
     input:
       tuple path(region_filter_file), val(binsize), val(threshold)
 
@@ -1391,7 +1395,7 @@ process prepareRegionFilters {
     fi
 
     echo "threshold command: \$threshold_command"
-    
+
     ${params.wiggletools_bin} \$threshold_command trim chromsizes.bed fillIn chromsizes.bed \$scale_command ${region_filter_file} \
       | ${params.wigToBigWig_bin} stdin <(cut -f 1,2 ${params.genome_fai}) ${region_filter_file}.bin${binsize}.${threshold}.bw
     """
@@ -1413,10 +1417,10 @@ process extractCallsChunk {
     maxRetries params.maxRetries_extractCallsChunk
     tag { "extractCallsChunk: ${sample_id} -> chunk ${chunkID}" }
     container "${params.hidefseq_container}"
-    
+
     input:
       tuple val(individual_id), val(sample_id), path(bamFile), path(pbiFile), path(baiFile), val(chunkID), val(config_sig)
-    
+
     output:
       tuple val(individual_id), val(sample_id), path("${params.analysis_id}.${individual_id}.${sample_id}.extractCalls.chunk${chunkID}.qs2"), val(chunkID)
 
@@ -1457,7 +1461,7 @@ process filterCallsChunkChromgroupFiltergroup {
 
     input:
       tuple val(individual_id), val(sample_id), path(extractCallsFile), val(chunkID), val(chromgroup), val(filtergroup), val(config_sig)
-    
+
     output:
       tuple val(individual_id), val(sample_id), val(chromgroup), val(filtergroup), val(chunkID), path("${params.analysis_id}.${individual_id}.${sample_id}.${chromgroup}.${filtergroup}.filterCalls.chunk${chunkID}.qs2")
 
@@ -1495,10 +1499,10 @@ process calculateBurdensChromgroupFiltergroup {
     maxRetries params.maxRetries_calculateBurdensChromgroupFiltergroup
     tag { "calculateBurdensChromgroupFiltergroup: ${sample_id} -> ${chromgroup} x ${filtergroup}" }
     container "${params.hidefseq_container}"
-    
+
     input:
       tuple val(individual_id), val(sample_id), val(chromgroup), val(filtergroup), path(filterCallsFiles), val(config_sig)
-    
+
     output:
       tuple val(individual_id), val(sample_id), val(chromgroup), val(filtergroup), path("${params.analysis_id}.${individual_id}.${sample_id}.${chromgroup}.${filtergroup}.calculateBurdens.qs2"), emit: tuple_qs2
       tuple val(individual_id), val(sample_id), val(chromgroup), val(filtergroup), path("*.bed.gz"), path("*.bed.gz.tbi"), emit: coverage_reftnc
@@ -1543,17 +1547,17 @@ process outputResultsSample {
     maxRetries params.maxRetries_outputResultsSample
     tag { "outputResultsSample: ${sample_id}" }
     container "${params.hidefseq_container}"
-    
+
     input:
       tuple val(individual_id), val(sample_id), path(calculateBurdensFiles), val(config_sig)
-    
+
     output:
       tuple val(individual_id), val(sample_id), emit: out_ch
       path("${params.analysis_id}.${individual_id}.${sample_id}.outputResults.qs2")
       path("${params.analysis_id}.${individual_id}.${sample_id}.yaml_config.tsv")
       path("${params.analysis_id}.${individual_id}.${sample_id}.run_metadata.tsv")
       path("*/**/*.{tsv,vcf.bgz,vcf.bgz.tbi,pdf}")
-        
+
     publishDir path: "${params.analysis_output_dir}",
       mode: 'move',
       saveAs: { filename -> "${sampleBaseDir(individual_id, sample_id)}/${filename}" }

--- a/main.nf
+++ b/main.nf
@@ -1266,11 +1266,12 @@ process extractGenomeTrinucleotides {
 
     script:
     """
-    #Extract sequences for all bases (except contig edges) from genome with seqkit,
-    #convert to upper case, convert to BED format (column 2 of trinucleotides is start position of trinucleotide position),
+    #Convert to upper case, replace unsupported bases with N's, extract sequences for all bases
+    #(except contig edges), convert to BED format (column 2 is start position of trinucleotide position),
     #and bgzip + tabix index
-    ${params.seqkit_bin} sliding -S '' -s1 -W3 ${params.genome_fasta} | \
-      ${params.seqkit_bin} seq -u | \
+    ${params.seqkit_bin} seq -u ${params.genome_fasta} | \
+      ${params.seqkit_bin} replace -s -p '[^ACGTN]' -r N | \
+      ${params.seqkit_bin} sliding -S '' -s1 -W3 | \
       ${params.seqkit_bin} fx2tab -Q | \
       awk -F '[:\\-\\t]' 'BEGIN {OFS="\\t"}{print \$1, \$2, \$2+1, \$4}' | \
       ${params.bgzip_bin} -c > ${file(params.genome_fasta).name}.bed.gz


### PR DESCRIPTION
## Summary

- Forge and install a BSgenome package from the configured genome FASTA instead of relying on a preconfigured BSgenome package name.
- Derive the BSgenome name from `genome_fasta` and `genome_organism`, pass it through the Nextflow workflow, and use it consistently in downstream R scripts.
- Merge current `main` and preserve the Nextflow 26.04 strict-syntax updates from `71fdb80` while resolving conflicts.

## Validation

- `Rscript -e "invisible(parse(file='bin/calculateBurdens.R'))"`
- `nextflow run main.nf -stub-run -ansi-log false` with Nextflow 26.04.0 compiled past the previous syntax issue and stopped at expected missing `barcodes` configuration validation.
- strict-syntax scan for old imports, uppercase `Channel`, unqualified SnakeYAML/MessageDigest references, top-level helper closures, and process directives after `input`/`output`.
- `git diff --check`
- `git merge-tree --write-tree origin/main HEAD`

Nextflow-generated `.nextflow*`, `work`, and `null` artifacts were removed after validation.