### PR TITLE
[codex] Annotate extracted calls with barcode IDs

### DIFF
--- a/bin/extractCalls.R
+++ b/bin/extractCalls.R
@@ -36,13 +36,15 @@ option_list = list(
               help="path to YAML configuration file"),
   make_option(c("-b", "--bam"), type = "character", default=NULL,
               help="path to BAM file"),
+  make_option(c("-s", "--sample_id"), type = "character", default=NULL,
+              help="sample_id being processed"),
   make_option(c("-o", "--output"), type = "character", default=NULL,
   						help="output qs2 file")
 )
 
 opt <- parse_args(OptionParser(option_list=option_list))
 
-if(is.null(opt$config) | is.null(opt$bam) | is.null(opt$output)){
+if(is.null(opt$config) | is.null(opt$bam) | is.null(opt$sample_id) | is.null(opt$output)){
   stop("Missing input parameter(s)!")
 }
 
@@ -55,6 +57,42 @@ suppressPackageStartupMessages(library(yaml.config$BSgenome$BSgenome_name,charac
 
 #General parameters
 strand_levels <- c("+","-")
+
+sample_uses_round2 <- yaml.config$runs %>%
+  map_lgl(function(run){
+    run$samples %>%
+      map_lgl(function(sample){
+        sample$sample_id == opt$sample_id && !is.null(sample$barcode_ids_round2)
+      }) %>%
+      any
+  }) %>%
+  any
+
+#Map 0-based BAM bc tag indices to barcode_id values from the run-specific lima barcode FASTA.
+barcode_ids_by_run <- yaml.config$runs %>%
+  map_df(function(run){
+    run$samples %>%
+      map_df(function(sample){
+        tibble(
+          run_id = run$run_id,
+          sample_id = sample$sample_id,
+          barcode_ids = sample$barcode_ids,
+          barcode_ids_round2 = if(is.null(sample$barcode_ids_round2)) NA_character_ else sample$barcode_ids_round2
+        )
+      })
+  }) %>%
+  mutate(
+    barcode_id = if(sample_uses_round2) barcode_ids_round2 else barcode_ids
+  ) %>%
+  filter(!is.na(barcode_id)) %>%
+  separate_rows(barcode_id, sep = "-") %>%
+  group_by(run_id) %>%
+  # Match makeBarcodesFasta: barcode IDs keep first YAML/sample occurrence, with duplicates removed.
+  summarize(
+    barcode_ids = list(unique(barcode_id)),
+    .groups = "drop"
+  ) %>%
+  deframe
 
 #Load call types, and filter to make a table only for MDB call types
 call_types <- yaml.config$call_types %>%
@@ -198,9 +236,10 @@ invisible(gc())
 bam.df <- bam.df %>%
 	cbind(run_metadata[match(bam.df$RG, run_metadata$rg_id),c("movie_id","run_id")])
 
-#Convert bc tag from uint16[2] list to comma-separated string (factor) (forward,reverse barcode FASTA indices)
-bam.df$bc <- bam.df$bc %>%
-	map_chr(function(x){str_c(x, collapse = ",")}) %>%
+#Convert bc tag from uint16[2] list to hyphen-separated barcode_id string (factor) (forward-reverse)
+bam.df$bc <- map2_chr(bam.df$bc, bam.df$run_id, function(bc_tag, run_id){
+    str_c(barcode_ids_by_run[[run_id]][bc_tag + 1L], collapse = "-")
+  }) %>%
 	factor
 
 #Extract ccs strand

--- a/bin/extractCalls.R
+++ b/bin/extractCalls.R
@@ -977,6 +977,7 @@ extract_calls <- function(bam.gr.input, call_class.input, call_type.input, cigar
     left_join(
       bam.gr.input %>%
         as_tibble %>%
+        mutate(strand = fct_drop(strand)) %>%
         distinct(zm, strand, bc),
       by = join_by(zm, strand)
     ) %>%

--- a/bin/outputResults.R
+++ b/bin/outputResults.R
@@ -601,6 +601,8 @@ cat("DONE\n")
 
 cat("## Outputting germline variant calls...")
 
+germlineVariantCalls_for_tsv <- list()
+
 #Define columns that are identical between strands to either '_keep' or '_discard' in the subsequent pivot_wider.
 strand_identical_cols_keep <- c(
 	"analysis_id", "individual_id", "sample_id", "chromgroup", "filtergroup",
@@ -703,6 +705,8 @@ for(i in chromgroups){
 	      names_expand = TRUE
 			)
 		
+		germlineVariantCalls_for_tsv[[length(germlineVariantCalls_for_tsv) + 1]] <- germlineVariantCalls.out
+
 		#tsv
 		germlineVariantCalls.out %>%
 			write_tsv(str_c(output_basename_full,".germlineVariantCalls.tsv"))
@@ -729,6 +733,8 @@ for(i in chromgroups){
 		
 	}
 }
+
+germlineVariantCalls_for_tsv <- germlineVariantCalls_for_tsv %>% bind_rows
 
 cat("DONE\n")
 
@@ -1217,6 +1223,7 @@ qs_save(
 		finalCalls,
 		finalCalls.bytype,
 		germlineVariantCalls,
+		germlineVariantCalls_for_tsv,
 		finalCalls.reftnc_spectra,
 		bam.gr.filtertrack.bytype.coverage_tnc,
 		genome.reftnc,

--- a/bin/processGermlineVCFs.R
+++ b/bin/processGermlineVCFs.R
@@ -87,11 +87,11 @@ for(i in 1:nrow(vcf_files_individual)){
   cat(">> Processing VCF file:",germline_vcf_file,"...")
   
   germline_vcf_variants[[i]] <- load_vcf(
-	  	vcf_file = germline_vcf_file,
-	  	genome_fasta = yaml.config$genome_fasta,
-		  BSgenome_name = BSgenome_name,
-	  	bcftools_bin = yaml.config$bcftools_bin
-  	) %>%
+    vcf_file = germline_vcf_file,
+    genome_fasta = yaml.config$genome_fasta,
+    BSgenome_name = BSgenome_name,
+    bcftools_bin = yaml.config$bcftools_bin
+  ) %>%
   	mutate(
   		germline_vcf_file = factor(!!germline_vcf_file),
   		germline_vcf_type = factor(!!germline_vcf_type)

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -108,7 +108,7 @@ The table below summarises tags present in the aligned CCS BAM. See references f
 | `ma` | Barcode/adapter | Adapter detection status (`0` both sides detected, `1` missing left, `2` missing right). |
 | `qs` | Barcode/adapter | Query start position after barcode trimming. |
 | `qe` | Barcode/adapter | Query end position before barcode trimming. |
-| `bc` | Barcode/adapter | Comma-separated barcode pair indices (`forward,reverse`) stored from the `uint16[2]` barcode call; values are 0-based offsets within the barcode FASTA. |
+| `bc` | Barcode/adapter | Comma-separated barcode pair indices (`forward,reverse`) stored from the `uint16[2]` barcode call; values are 0-based offsets within the barcode FASTA. Downstream extracted call tables translate these indices to hyphen-separated configured `barcode_id` values. |
 | `bq` | Barcode/adapter | Quality of the barcode call. |
 | `cx` | Barcode/adapter | Sum of subread local context flags (adapter/barcode presence, pass orientation, etc.); CCS BAMs downstream of pbmm2 set `cx=12`. |
 | `bl` | Barcode/adapter | Barcode sequence clipped from the leading end. |
@@ -185,7 +185,7 @@ The pipeline emits four artefacts per call subtype:
   - Shared identifiers: `analysis_id`, `individual_id`, `sample_id`, `chromgroup`, `filtergroup`, `call_class`, `call_type`, `SBSindel_call_type`, `analysis_chunk`.
   - Molecule identifiers and coordinates in reference space: `run_id`, `zm`, `seqnames`, `start_refspace`, `end_refspace`.
   - Alleles: `ref_plus_strand`, `alt_plus_strand`
-  - Strand-specific coordinates in query space (i.e., read coordinates), quality metrics, and additional sequence information: `bc` (comma-separated `forward,reverse` barcode indices), `start_queryspace`, `end_queryspace`, `qual`, `sa`, `sm`, `sx`, `ref_synthesized_strand`, `ref_template_strand`, `alt_synthesized_strand`, `alt_template_strand`. Measurements for multi-base calls, such as `qual` are stored as comma-delimited values for every base. SBS and indel mutation call tables are pivoted to one row per mutation with these strand-specific columns suffixed with `_refstrand_plus_read` and `_refstrand_minus_read`. Non-mutation (i.e., single-strand) call types remain one row per call with a `refstrand` column annotating to which reference strand the call's read aligned.
+  - Strand-specific coordinates in query space (i.e., read coordinates), quality metrics, and additional sequence information: `bc` (hyphen-separated `forward-reverse` barcode IDs), `start_queryspace`, `end_queryspace`, `qual`, `sa`, `sm`, `sx`, `ref_synthesized_strand`, `ref_template_strand`, `alt_synthesized_strand`, `alt_template_strand`. Measurements for multi-base calls, such as `qual` are stored as comma-delimited values for every base. SBS and indel mutation call tables are pivoted to one row per mutation with these strand-specific columns suffixed with `_refstrand_plus_read` and `_refstrand_minus_read`. Non-mutation (i.e., single-strand) call types remain one row per call with a `refstrand` column annotating to which reference strand the call's read aligned.
   - Trinucleotide context (SBS and MDB tables only):
     - `reftnc_plus_strand` and `alttnc_plus_strand` — reference and call trinucleotide sequence at the call position on the reference genome plus strand.
     - `reftnc_pyr` and `alttnc_pyr`— reference and call trinucleotide sequences collapsed to central pyrimidine trinucleotide sequences.
@@ -330,7 +330,7 @@ Unified table of all call types across all chromgroups and filtergroups, with on
 | --- | --- |
 | `analysis_id`, `individual_id`, `sample_id`, `chromgroup`, `filtergroup`, `call_class`, `call_type`, `SBSindel_call_type` | Call metadata. |
 | `analysis_chunk`, `run_id`, `zm` | Chunk identifier, sequencing run ID, and ZMW hole number. |
-| `bc`, `seqnames`, `refstrand` | Barcode pair indices from the last round of demultplexing (encoded as a comma-separated `forward,reverse` index pair), reference contig, and reference genome strand that the read aligned to which supplied the call (`+` or `-`). |
+| `bc`, `seqnames`, `refstrand` | Barcode pair IDs from the last round of demultiplexing (encoded as a hyphen-separated `forward-reverse` `barcode_id` pair), reference contig, and reference genome strand that the read aligned to which supplied the call (`+` or `-`). |
 | `start_refspace`, `end_refspace` | Reference space 1-based coordinates. |
 | `ref_plus_strand`, `alt_plus_strand` | Reference genome forward strand reference and alternate allele sequences. |
 | `start_queryspace`, `end_queryspace` | Query-space 1-based coordinates. |

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -357,6 +357,10 @@ Contains final calls split into one row for each combination of `call_class`, `c
 
 Germline variant calls with the same schema as the unified finalCalls table.
 
+#### germlineVariantCalls_for_tsv
+
+Same format as `germlineVariantCalls.tsv` described above.
+
 #### finalCalls.reftnc_spectra
 
 Table containing trinucleotide distributions and spectra of final calls, split into one row for each combination of `call_class`, `call_type`, and `SBSindel_call_type`. Additionally, there is one additional row for each `analysis_id`, `individual_id`, `sample_id`, `chromgroup` combination that contains the combined spectra of insertion and deletion mutations, and analogous additional rows for combined insertion and deletion template-strand indel spectra; for these rows, `call_class` = `indel`, and `filtergroup` and `call_type` = `NA`.

--- a/main.nf
+++ b/main.nf
@@ -2,11 +2,6 @@
  * Global variables and functions
  *****************************************************************/
 
-//Library imports
-import org.yaml.snakeyaml.Yaml
-import org.yaml.snakeyaml.DumperOptions
-import java.security.MessageDigest
-
 //Define output directories and related helper functions
 sharedLogsDir = "${params.analysis_output_dir}/${params.analysis_id}.sharedLogs"
 
@@ -33,12 +28,12 @@ def generateAfterScript(logDir, logName) {
   """
 }
 
-signatureYamlOptions = new DumperOptions()
-signatureYamlOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK)
+signatureYamlOptions = new org.yaml.snakeyaml.DumperOptions()
+signatureYamlOptions.setDefaultFlowStyle(org.yaml.snakeyaml.DumperOptions.FlowStyle.BLOCK)
 signatureYamlOptions.setPrettyFlow(false)
 signatureYamlOptions.setIndent(2)
 
-signatureYaml = new Yaml(signatureYamlOptions)
+signatureYaml = new org.yaml.snakeyaml.Yaml(signatureYamlOptions)
 
 // Function to calculate a hash for a subset of keys from a parameters file
 def configHash(params_input, keys) {
@@ -50,7 +45,7 @@ def configHash(params_input, keys) {
   }
 
   def serialized = signatureYaml.dump(subset ?: [:])
-  def digest = MessageDigest.getInstance('SHA-256')
+  def digest = java.security.MessageDigest.getInstance('SHA-256')
   digest.update(serialized.getBytes('UTF-8'))
   digest.digest().encodeHex().toString()
 }
@@ -100,11 +95,11 @@ workflow {
   logsDir = file("${sharedLogsDir}")
   logsDir.mkdirs()
 
-  options = new DumperOptions()
-  options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK)
+  options = new org.yaml.snakeyaml.DumperOptions()
+  options.setDefaultFlowStyle(org.yaml.snakeyaml.DumperOptions.FlowStyle.BLOCK)
   options.setIndent(2)
 
-  yaml = new Yaml(options)
+  yaml = new org.yaml.snakeyaml.Yaml(options)
   timestamp = new Date().format('yyyy_MMdd_HHmm')
   file("${logsDir}/runParams.${timestamp}.yaml").text = yaml.dump(params)
 
@@ -128,7 +123,7 @@ workflow {
   params.paramsFileName = commandLineTokens[commandLineTokens.indexOf('-params-file') + 1]
 
   // Define parameters file components that are checked for changes to determine if a process is rerun upon resume
-  sharedFunctionsHash = MessageDigest.getInstance('SHA-256')
+  sharedFunctionsHash = java.security.MessageDigest.getInstance('SHA-256')
     .digest(file("${workflow.projectDir}/bin/sharedFunctions.R").bytes)
     .encodeHex()
     .toString()

--- a/main.nf
+++ b/main.nf
@@ -136,7 +136,7 @@ workflow {
   config_signatures = [
     installBSgenome: configHash(params, ['cache_dir', 'BSgenome']),
     processGermlineVCFs: configHash(paramsWithSharedFunctionsHash, ['cache_dir', 'BSgenome', 'individuals', 'genome_fasta', 'bcftools_bin', 'sharedFunctionsHash']),
-    extractCallsChunk: configHash(paramsWithSharedFunctionsHash, ['cache_dir', 'BSgenome', 'call_types', 'chromgroups', 'runs', 'min_strand_overlap', 'sharedFunctionsHash']),
+    extractCallsChunk: configHash(paramsWithSharedFunctionsHash, ['cache_dir', 'BSgenome', 'call_types', 'chromgroups', 'runs', 'barcodes', 'min_strand_overlap', 'sharedFunctionsHash']),
     filterCallsChunkChromgroupFiltergroup: configHash(paramsWithSharedFunctionsHash, ['BSgenome', 'bcftools_bin', 'cache_dir', 'call_types', 'chromgroups', 'filtergroups', 'genome_fai', 'genome_fasta', 'germline_vcf_types', 'individuals', 'region_filters', 'samples', 'wigToBigWig_bin', 'wiggletools_bin', 'sharedFunctionsHash']),
     calculateBurdensChromgroupFiltergroup: configHash(paramsWithSharedFunctionsHash, ['BSgenome', 'analysis_id', 'bcftools_bin', 'bedtools_bin', 'bgzip_bin', 'cache_dir', 'call_types', 'chromgroups', 'genome_fai', 'genome_fasta', 'individuals', 'mitochondrial_chromosome', 'samples', 'sensitivity_parameters', 'sex_chromosomes', 'tabix_bin', 'sharedFunctionsHash']),
     outputResultsSample: configHash(paramsWithSharedFunctionsHash, ['BSgenome', 'analysis_id', 'cache_dir', 'call_types', 'chromgroups', 'filtergroups', 'region_filters', 'samples', 'sharedFunctionsHash'])
@@ -284,9 +284,7 @@ workflow {
     def barcodeIdsInRun = run_sample_configs
       .findAll { it.run_id == run.run_id }
       .collectMany { cfg -> cfg.barcode_ids_parsed.ids }
-      .toSet()
-      .toList()
-      .sort()
+      .unique()
 
     def runBarcodeFasta = barcodeIdsInRun.collect { barcodeId ->
       ">${barcodeId}\n${barcode_seq_by_id[barcodeId]}"
@@ -298,9 +296,7 @@ workflow {
       def barcodeIdsInRun = run_sample_configs
         .findAll { cfg -> cfg.run_id == run_id && cfg.barcode_ids_round2_parsed != null }
         .collectMany { cfg -> cfg.barcode_ids_round2_parsed.ids }
-        .toSet()
-        .toList()
-        .sort()
+        .unique()
 
       def runBarcodeFasta = barcodeIdsInRun.collect { barcodeId ->
         ">${barcodeId}\n${barcode_seq_by_id[barcodeId]}"
@@ -1434,7 +1430,7 @@ process extractCallsChunk {
 
     script:
     """
-    extractCalls.R -c ${params.paramsFileName} -b ${bamFile} -o ${params.analysis_id}.${individual_id}.${sample_id}.extractCalls.chunk${chunkID}.qs2
+    extractCalls.R -c ${params.paramsFileName} -b ${bamFile} -s ${sample_id} -o ${params.analysis_id}.${individual_id}.${sample_id}.extractCalls.chunk${chunkID}.qs2
     """
 }
 


### PR DESCRIPTION
## Summary

This PR updates extracted call barcode annotations to report configured barcode IDs instead of raw BAM barcode index pairs.

It also merges the current `main` branch so the barcode annotation work is compatible with the BSgenome-from-FASTA changes and the Nextflow 26 SnakeYAML qualification fix.

## Impact

- `extractCalls.R` now receives `sample_id` and maps BAM `bc` tag indices back to run-specific configured `barcode_id` values.
- Barcode FASTA generation preserves configured barcode order while removing duplicates.
- Output documentation describes the extracted call `bc` field as hyphen-separated barcode IDs.
- The branch is up to date with `main`, resolving the auto-merge conflict in `main.nf`.

## Validation

- Parsed changed R scripts with `Rscript`.
- Ran `git diff --check --cached` before committing.
- Ran `nextflow 26.04.0` preview with temporary filled params.
- Removed temporary Nextflow files and verified no `__pycache__` or preview scratch files remained.